### PR TITLE
feat: add xfs StorageClass for PostgreSQL resilience

### DIFF
--- a/manifests/database/shared-pg.yaml
+++ b/manifests/database/shared-pg.yaml
@@ -15,7 +15,7 @@ spec:
     limits:
       memory: 512Mi
   storage:
-    storageClass: qnap-iscsi
+    storageClass: qnap-iscsi-xfs
     size: 10Gi
   bootstrap:
     initdb:

--- a/manifests/storage/storageclass.yaml
+++ b/manifests/storage/storageclass.yaml
@@ -13,3 +13,17 @@ mountOptions:
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: qnap-iscsi-xfs
+provisioner: csi.trident.qnap.io
+parameters:
+  selector: "performance=default"
+  fsType: "xfs"
+mountOptions:
+  - discard
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary
- iSCSI I/O エラー時に ext4 が read-only リマウントして PostgreSQL が全滅する問題への対策
- `qnap-iscsi-xfs` StorageClass を追加（xfs は I/O 復旧後に自動回復）
- shared-pg の storageClass を `qnap-iscsi-xfs` に変更

## Migration plan (post-merge)
1. ArgoCD sync で StorageClass 作成 + CNPG Cluster spec 更新
2. replica (shared-pg-4) の PVC 削除 → xfs で再作成、pg_basebackup で同期
3. switchover で xfs replica を primary に昇格
4. 旧 primary (shared-pg-2, ext4) の PVC 削除 → xfs で再作成

各ステップで片方が生きているためデータロスなし。

## Test plan
- [ ] StorageClass が作成されること
- [ ] 新 PVC が xfs でフォーマットされること (`lsblk -f` で確認)
- [ ] CNPG クラスタが 2/2 healthy になること
- [ ] horenso create_task が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)