### PR TITLE
feat: change default StorageClass from ext4 to xfs

### DIFF
--- a/manifests/database/shared-pg.yaml
+++ b/manifests/database/shared-pg.yaml
@@ -15,7 +15,7 @@ spec:
     limits:
       memory: 512Mi
   storage:
-    storageClass: qnap-iscsi-xfs
+    storageClass: qnap-iscsi
     size: 10Gi
   bootstrap:
     initdb:

--- a/manifests/storage/storageclass.yaml
+++ b/manifests/storage/storageclass.yaml
@@ -7,20 +7,6 @@ metadata:
 provisioner: csi.trident.qnap.io
 parameters:
   selector: "performance=default"
-  fsType: "ext4"
-mountOptions:
-  - discard
-allowVolumeExpansion: true
-reclaimPolicy: Delete
-volumeBindingMode: Immediate
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: qnap-iscsi-xfs
-provisioner: csi.trident.qnap.io
-parameters:
-  selector: "performance=default"
   fsType: "xfs"
 mountOptions:
   - discard


### PR DESCRIPTION
## Summary
- デフォルト StorageClass `qnap-iscsi` の fsType を ext4 → xfs に変更
- `qnap-iscsi-xfs` を削除して統合（shared-pg は `qnap-iscsi` に戻す）
- 既存 ext4 PVC は影響なし。PVC 再作成時に自動的に xfs になる

## Why
iSCSI I/O 瞬断時に ext4 がジャーナルエラーで read-only リマウント → Pod 削除しても fsck なしでは RW に戻らない。shared-pg, Loki, Nextcloud が 6日以上ダウンした。xfs は I/O 復旧後に自動回復する。

## Test plan
- [ ] StorageClass の fsType が xfs になること
- [ ] qnap-iscsi-xfs が削除されること
- [ ] 既存 PVC は影響を受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)