### PR TITLE
temp: scale rss-pg to 2 for xfs migration

### DIFF
--- a/manifests/rss/rss-pg.yaml
+++ b/manifests/rss/rss-pg.yaml
@@ -4,16 +4,13 @@ metadata:
   name: rss-pg
   namespace: rss
 spec:
-  instances: 1
+  instances: 2
   resources:
     requests:
       cpu: 10m
       memory: 128Mi
     limits:
       memory: 512Mi
-  affinity:
-    nodeSelector:
-      kubernetes.io/hostname: wn-01
   storage:
     storageClass: qnap-iscsi
     size: 5Gi


### PR DESCRIPTION
## Summary
- rss-pg を一時的に 2 インスタンスに拡張（ext4 → xfs ローリング移行のため）
- nodeSelector を一時的に削除
- 移行完了後に instances: 1 + nodeSelector を戻す別 PR を出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)