### PR TITLE
feat: restore rss-pg to 1 instance after xfs migration

### DIFF
--- a/manifests/rss/rss-pg.yaml
+++ b/manifests/rss/rss-pg.yaml
@@ -4,13 +4,16 @@ metadata:
   name: rss-pg
   namespace: rss
 spec:
-  instances: 2
+  instances: 1
   resources:
     requests:
       cpu: 10m
       memory: 128Mi
     limits:
       memory: 512Mi
+  affinity:
+    nodeSelector:
+      kubernetes.io/hostname: wn-01
   storage:
     storageClass: qnap-iscsi
     size: 5Gi


### PR DESCRIPTION
## Summary
- rss-pg を instances: 1 + nodeSelector: wn-01 に復帰
- ext4 → xfs のローリング移行完了後の後始末

🤖 Generated with [Claude Code](https://claude.com/claude-code)