### PR TITLE
temp: scale seaweedfs volume to 2 for xfs migration

### DIFF
--- a/helm-values/seaweedfs/values.yaml
+++ b/helm-values/seaweedfs/values.yaml
@@ -48,7 +48,7 @@ master:
       mountPath: /tmp
 
 volume:
-  replicas: 1
+  replicas: 2
   dataDirs:
     - name: data
       type: "persistentVolumeClaim"


### PR DESCRIPTION
## Summary
- SeaweedFS volume server を一時的に 2 に拡張（ext4 → xfs 移行のため）
- volume.move で全データを新 volume server に移動後、1 に戻す

🤖 Generated with [Claude Code](https://claude.com/claude-code)