### PR TITLE
temp: remove seaweedfs volume nodeSelector for xfs migration

### DIFF
--- a/helm-values/seaweedfs/values.yaml
+++ b/helm-values/seaweedfs/values.yaml
@@ -64,8 +64,6 @@ volume:
       memory: 128Mi
     limits:
       memory: 1Gi
-  nodeSelector: |
-    kubernetes.io/hostname: wn-02
   tolerations: |
     - key: memory-constrained
       operator: Exists


### PR DESCRIPTION
## Summary
- volume server の nodeSelector を一時削除（anti-affinity で volume-1 がスケジュールできないため）
- 移行完了後に nodeSelector を復帰する

🤖 Generated with [Claude Code](https://claude.com/claude-code)