### PR TITLE
feat: restore seaweedfs volume after xfs migration

### DIFF
--- a/helm-values/seaweedfs/values.yaml
+++ b/helm-values/seaweedfs/values.yaml
@@ -48,7 +48,7 @@ master:
       mountPath: /tmp
 
 volume:
-  replicas: 2
+  replicas: 1
   dataDirs:
     - name: data
       type: "persistentVolumeClaim"
@@ -64,6 +64,8 @@ volume:
       memory: 128Mi
     limits:
       memory: 1Gi
+  nodeSelector: |
+    kubernetes.io/hostname: wn-02
   tolerations: |
     - key: memory-constrained
       operator: Exists


### PR DESCRIPTION
## Summary
- SeaweedFS volume replicas: 2 → 1 に復帰
- nodeSelector: wn-02 を復帰
- 全49 volume を ext4 → xfs PVC に移動済み（volume.move でデータロスなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)