### PR TITLE
ci: gate ai-review on PR author instead of github.actor

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -223,7 +223,7 @@ jobs:
     needs: [kubeconform, helm-template, image-existence]
     if: >-
       github.event_name == 'pull_request' &&
-      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.user.login == 'renovate[bot]' &&
       !contains(github.event.pull_request.body, '**Automerge**: Enabled') &&
       !contains(github.event.pull_request.title, 'gateway-api')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 問題

`ai-review` ジョブが Renovate PR の **初回 `opened` run でのみ実行**され、その後の `synchronize` run（同じ PR を新バージョンに更新したとき）ではすべて skip されていた。

実例: PR #294 (kube-prometheus-stack)
- `26695446578` (86.0.0 で opened) → ai-review=**success**
- 以降 86.0.1→86.0.2→86.1.0 の更新 run はすべて ai-review=**skipped**

skip 時も actor=renovate[bot]・body に Automerge:Enabled 無し・title に gateway-api 無し・needs 全 success と、`if` 条件は満たされているように見えるのに skip されていた。

## 原因

`github.actor` は **個々の run をトリガーした主体**を指し、`synchronize` / re-run / Renovate のプラットフォーム更新では値が揺れる。そのため PR 更新時に `renovate[bot]` ゲートが外れていた。

## 修正

ゲートを `github.event.pull_request.user.login`（PR 作成者 = 常に `renovate[bot]`）に変更。これで PR の全更新 run で ai-review が走る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)