### PR TITLE
fix(renovate): pin talos-build extension digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/manifests/talos-build/workflowtemplate\\.yaml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*\\S+:(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*-\\s*[^\\s:]+:(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ]
     }
   ],


### PR DESCRIPTION
## 背景
Dependency Dashboard (#2) に2つのエラーが出ていた:

- **Repository Problems**: `⚠️ WARN: Error updating branch: update failure`
- **Errored**: `pin ghcr.io/siderolabs/iscsi-tools docker tag to 5b13f10` (branch: `renovate/talos-extensions`)

## 原因
`manifests/talos-build/workflowtemplate.yaml` は renovate.json の custom regex manager で管理されているが、matchStrings に `currentDigest` キャプチャグループが無かった。一方 packageRules は `manifests/talos-build/**` に `pinDigests: true` を要求しているため、Renovate が digest の挿入位置を特定できず update failure になっていた。

- spin / kata はバージョン更新があるためブランチは作成される
- iscsi-tools は v0.2.0 据え置きで **digest ピンだけ** が pending → それが失敗して Errored に残る

## 修正
custom manager の regex に optional な `currentDigest` を追加し、`currentValue` が `@sha256:...` を飲み込まないようにした。これで iscsi-tools / spin / kata の3つとも `tag@sha256:...` 形式でピンできる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYYmMhieNeQ5Kjaw2NrfFk