### PR TITLE
fix(talos-build): seed digests for iscsi-tools & kata-containers

### DIFF
--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -203,14 +203,14 @@ spec:
             - amd64
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/iscsi-tools
-            - ghcr.io/siderolabs/iscsi-tools:v0.2.0
+            - ghcr.io/siderolabs/iscsi-tools:v0.2.0@sha256:5b13f10660fb0491d9df0a3f710028c1177f1ce869d30643ae53a6dd01440068
             - --system-extension-image
             # self-built mirror until siderolabs publishes spin v0.25.x
             # (build: talos-custom-build/extensions/spin)
             - ghcr.io/tsuguya/spin:v0.25.1@sha256:013755d0cfb72578ac199358e1e3bb4e74584c7bcb80dc464cd0c3539496d751
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
-            - ghcr.io/siderolabs/kata-containers:3.30.0
+            - ghcr.io/siderolabs/kata-containers:3.30.0@sha256:92e878e4d301eb48680952b90ab6ca362ce943736641274518e78090928210c1
             - --base-installer-image
             - "ghcr.io/tsuguya/installer-base:{{inputs.parameters.version}}"
             - --extra-kernel-arg
@@ -327,14 +327,14 @@ spec:
             - amd64
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/iscsi-tools
-            - ghcr.io/siderolabs/iscsi-tools:v0.2.0
+            - ghcr.io/siderolabs/iscsi-tools:v0.2.0@sha256:5b13f10660fb0491d9df0a3f710028c1177f1ce869d30643ae53a6dd01440068
             - --system-extension-image
             # self-built mirror until siderolabs publishes spin v0.25.x
             # (build: talos-custom-build/extensions/spin)
             - ghcr.io/tsuguya/spin:v0.25.1@sha256:013755d0cfb72578ac199358e1e3bb4e74584c7bcb80dc464cd0c3539496d751
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
-            - ghcr.io/siderolabs/kata-containers:3.30.0
+            - ghcr.io/siderolabs/kata-containers:3.30.0@sha256:92e878e4d301eb48680952b90ab6ca362ce943736641274518e78090928210c1
             - --base-installer-image
             - "ghcr.io/tsuguya/installer-base:{{inputs.parameters.version}}"
             - --extra-kernel-arg
@@ -370,14 +370,14 @@ spec:
             - amd64
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/iscsi-tools
-            - ghcr.io/siderolabs/iscsi-tools:v0.2.0
+            - ghcr.io/siderolabs/iscsi-tools:v0.2.0@sha256:5b13f10660fb0491d9df0a3f710028c1177f1ce869d30643ae53a6dd01440068
             - --system-extension-image
             # self-built mirror until siderolabs publishes spin v0.25.x
             # (build: talos-custom-build/extensions/spin)
             - ghcr.io/tsuguya/spin:v0.25.1@sha256:013755d0cfb72578ac199358e1e3bb4e74584c7bcb80dc464cd0c3539496d751
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
-            - ghcr.io/siderolabs/kata-containers:3.30.0
+            - ghcr.io/siderolabs/kata-containers:3.30.0@sha256:92e878e4d301eb48680952b90ab6ca362ce943736641274518e78090928210c1
             - --base-installer-image
             - "ghcr.io/tsuguya/installer-base:{{inputs.parameters.version}}"
             - --extra-kernel-arg


### PR DESCRIPTION
## 背景
Dependency Dashboard (#2) の `renovate/talos-extensions` が更新失敗し続けていた。Renovate ログの真因:

\`\`\`
DEBUG: Digest is not updated  depName: ghcr.io/siderolabs/iscsi-tools  expectedValue: sha256:5b13f10...
WARN: Error updating branch: update failure (branch="renovate/talos-extensions")
\`\`\`

## 原因
Renovate の **regex (custom) manager は既存の部分文字列を置換するだけで、digest が無い行に digest を新規挿入できない**。`manifests/talos-build/**` に `pinDigests: true` を設定しているが、`iscsi-tools` と `kata-containers` は digest 無しだったため、3か所すべてで `Digest is not updated` → update failure。

同ファイルの自前ビルド spin 行は既に digest 付き (`ghcr.io/tsuguya/spin:v0.25.1@sha256:...`) で正常。これが seed 方式が正しい裏付け。

## 修正
`iscsi-tools:v0.2.0` と `kata-containers:3.30.0` に現行 digest を手動 seed（`crane digest` で解決）:

- iscsi-tools → `@sha256:5b13f10660fb0491d9df0a3f710028c1177f1ce869d30643ae53a6dd01440068`
- kata-containers → `@sha256:92e878e4d301eb48680952b90ab6ca362ce943736641274518e78090928210c1`

以降 Renovate は in-place で digest / tag を更新でき、`Digest is not updated` と「バージョン保留 vs 単独ピン」の collision も解消。マージは既存の digest-cooldown workflow が引き続きゲート。

## 検証
- digest は `crane digest` で解決、iscsi-tools はログの expectedValue と一致
- 3ブロック × 2イメージ = 6行すべてに付与済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYYmMhieNeQ5Kjaw2NrfFk