### PR TITLE
feat(renovate): Mend cloud から Argo self-host に移行

### DIFF
--- a/manifests/argo/netpol-renovate.yaml
+++ b/manifests/argo/netpol-renovate.yaml
@@ -1,0 +1,19 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: renovate
+  namespace: argo
+spec:
+  endpointSelector:
+    matchLabels:
+      renovate: "true"
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: harbor
+            component: nginx
+            io.kubernetes.pod.namespace: harbor
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP

--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: renovate-executor
+  namespace: argo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: renovate-executor
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-edit
+subjects:
+  - kind: ServiceAccount
+    name: renovate-executor
+    namespace: argo
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: renovate
+  namespace: argo
+spec:
+  activeDeadlineSeconds: 3600
+  serviceAccountName: renovate-executor
+  entrypoint: main
+  podMetadata:
+    labels:
+      renovate: "true"
+  templates:
+    - name: main
+      volumes:
+        - name: github-token
+          emptyDir: {}
+        - name: github-app-secret
+          secret:
+            secretName: github-app-private-key
+      initContainers:
+        - name: github-auth
+          image: registry.infra.tgy.io/tools/argo-tools:latest
+          command: [github-auth.sh]
+          env:
+            - name: GITHUB_APP_ID
+              value: "2998228"
+            - name: GITHUB_APP_INSTALLATION_ID
+              value: "113765957"
+          securityContext:
+            runAsUser: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: github-app-secret
+              mountPath: /github-app
+              readOnly: true
+            - name: github-token
+              mountPath: /github-token
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      container:
+        image: ghcr.io/renovatebot/renovate:latest
+        command: [sh, -c]
+        args:
+          - |
+            set -e
+            export RENOVATE_TOKEN=$(cat /github-token/token)
+            export RENOVATE_HOST_RULES=$(node -e "console.log(JSON.stringify([{matchHost:'registry.infra.tgy.io',username:process.env.HARBOR_USER,password:process.env.HARBOR_PASS,hostType:'docker'}]))")
+            node /usr/src/app/dist/renovate.js
+        env:
+          - name: HARBOR_USER
+            valueFrom:
+              secretKeyRef:
+                name: renovate-harbor-robot
+                key: username
+          - name: HARBOR_PASS
+            valueFrom:
+              secretKeyRef:
+                name: renovate-harbor-robot
+                key: password
+          - name: RENOVATE_PLATFORM
+            value: github
+          - name: RENOVATE_REPOSITORIES
+            value: '["Tsuguya/home-cluster","Tsuguya/home-infra","Tsuguya/home-cloudflare"]'
+          - name: RENOVATE_AUTODISCOVER
+            value: "false"
+          - name: RENOVATE_ONBOARDING
+            value: "false"
+          - name: LOG_LEVEL
+            value: info
+        volumeMounts:
+          - name: github-token
+            mountPath: /github-token
+            readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: renovate-periodic
+  namespace: argo
+spec:
+  schedules:
+    - "0 */4 * * *"
+  timezone: Asia/Tokyo
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  workflowSpec:
+    workflowTemplateRef:
+      name: renovate

--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -38,6 +38,8 @@ spec:
         - name: github-app-secret
           secret:
             secretName: github-app-private-key
+        - name: workdir
+          emptyDir: {}
       initContainers:
         - name: github-auth
           image: registry.infra.tgy.io/tools/argo-tools:latest
@@ -66,7 +68,7 @@ spec:
             limits:
               memory: 64Mi
       container:
-        image: ghcr.io/renovatebot/renovate:latest
+        image: ghcr.io/renovatebot/renovate:43.251.3@sha256:e5c59392e4fc8279e2034773f356c06e0a5ffc0c5ad97ab9c2edc1d9944fb9af
         command: [sh, -c]
         args:
           - |
@@ -95,10 +97,18 @@ spec:
             value: "false"
           - name: LOG_LEVEL
             value: info
+          # renovate image runs under the argo restricted-PSA uid (65532);
+          # give it a writable HOME and base dir so git/cache work
+          - name: HOME
+            value: /tmp
+          - name: RENOVATE_BASE_DIR
+            value: /tmp/renovate
         volumeMounts:
           - name: github-token
             mountPath: /github-token
             readOnly: true
+          - name: workdir
+            mountPath: /tmp
         resources:
           requests:
             cpu: 100m

--- a/manifests/horenso/deployment.yaml
+++ b/manifests/horenso/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: horenso
-          image: registry.infra.tgy.io/tools/horenso@sha256:cfe3202c91a79f6aebd0d10f7f452c4e855f1458074cdba1d5a031653d3b8ad7
+          image: registry.infra.tgy.io/tools/horenso:latest@sha256:cfe3202c91a79f6aebd0d10f7f452c4e855f1458074cdba1d5a031653d3b8ad7
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/manifests/secrets/argo-renovate-harbor-robot.yaml
+++ b/manifests/secrets/argo-renovate-harbor-robot.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: renovate-harbor-robot
+  namespace: argo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: renovate-harbor-robot
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: harbor-robot-renovate
+        metadataPolicy: None
+        nullBytePolicy: Ignore


### PR DESCRIPTION
Horenso タスク #295。Renovate を Mend cloud から **クラスタ内 Argo self-host** に移行し、内部 Harbor イメージ (horenso) の digest 更新も in-cluster 認証で自動化する。外部 SaaS に認証情報を一切渡さない。

## 構成
- `manifests/argo/renovate.yaml` — WorkflowTemplate `renovate` + CronWorkflow `renovate-periodic`(4h)
  - init: `github-auth.sh` (tgy-cluster-bot App) → installation token → `RENOVATE_TOKEN`
  - Harbor 認証は `RENOVATE_HOST_RULES`(robot creds を env→JSON、CLI 露出なし)
  - image は `renovate:43.251.3` を digest ピン（`:latest` から変更）
  - restricted-PSA(uid 65532) 用に `HOME=/tmp` + `RENOVATE_BASE_DIR` + 書込可 emptyDir
- `manifests/secrets/argo-renovate-harbor-robot.yaml` — ESO で `renovate-harbor-robot` Secret 生成
- `manifests/argo/netpol-renovate.yaml` — Harbor nginx(:8443) への egress 許可
- `manifests/horenso/deployment.yaml` — `horenso:latest@sha256:…` にタグ付与（digest 不変、Harbor の :latest と一致確認済み）→ Renovate が digest 追跡可能に

## マージ前の必須作業（この順で）
- [ ] **Harbor robot account 作成**：`tools` プロジェクトの **pull 権限**（⚠️ library/global ではなく tools。horenso が tools プロジェクトのため）
- [ ] **1Password `harbor-robot-renovate`** に `username` / `password` フィールド追加
- [ ] ESO が `renovate-harbor-robot` Secret を同期することを確認
- [ ] このPRを ready にしてマージ（ArgoCD が即 apply）
- [ ] 初回 CronWorkflow を手動実行し、Dependency Dashboard 生成 + horenso digest 追跡を確認
  - PSA uid 65532 で renovate のキャッシュ/clone が動くかここで検証
- [ ] 動作確認後、**Mend GitHub App を3リポから削除**（二重 PR 防止）
- [ ] `fix/renovate-disable-internal-registry` ブランチ破棄

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYYmMhieNeQ5Kjaw2NrfFk