### PR TITLE
fix(renovate): invoke renovate binary (v43 path fix)

### DIFF
--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -75,7 +75,7 @@ spec:
             set -e
             export RENOVATE_TOKEN=$(cat /github-token/token)
             export RENOVATE_HOST_RULES=$(node -e "console.log(JSON.stringify([{matchHost:'registry.infra.tgy.io',username:process.env.HARBOR_USER,password:process.env.HARBOR_PASS,hostType:'docker'}]))")
-            node /usr/src/app/dist/renovate.js
+            exec renovate
         env:
           - name: HARBOR_USER
             valueFrom:


### PR DESCRIPTION
初回実行で main が `Cannot find module '/usr/src/app/dist/renovate.js'` で失敗。v43 イメージは CLI を `/usr/local/sbin/renovate`（PATH 上）で提供するため、`exec renovate` に変更。

- probe で `renovate 43.251.3` が uid 65532 + HOME=/tmp で動作することを確認済み
- init container (github-auth) と ESO Secret 同期は正常動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYYmMhieNeQ5Kjaw2NrfFk