### PR TITLE
fix(harbor): allow renovate → harbor-nginx:8443 (digest lookup)

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -55,6 +55,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | Workflow pods (image-build) | Harbor nginx (harbor) | 8443 | Internal image push |
 | Kyverno (kyverno) | Harbor nginx (harbor) | 8443 | Image signature verification |
 | scan-jobs (trivy-system) | Harbor nginx (harbor) | 8443 | Image scan from Harbor registry |
+| Renovate (argo) | Harbor nginx (harbor) | 8443 | Self-hosted Renovate digest lookup (tools/*) |
 | SeaweedFS filer (seaweedfs) | shared-pg (database) | 5432 | Filer metadata (postgres2) |
 | Harbor core (harbor) | shared-pg (database) | 5432 | Harbor database |
 | Harbor jobservice (harbor) | shared-pg (database) | 5432 | Job metadata |
@@ -255,7 +256,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **nginx** | ingress, cloudflared (argocd), image-build (image-build), host/remote-node, kyverno (admission/background/reports-controller), scan-jobs (trivy-system) → 8443; prometheus (monitoring) → 8001 | core:8080, portal:8080 |
+| **nginx** | ingress, cloudflared (argocd), image-build (image-build), host/remote-node, kyverno (admission/background/reports-controller), scan-jobs (trivy-system), renovate (argo) → 8443; prometheus (monitoring) → 8001 | core:8080, portal:8080 |
 | **core** | nginx, jobservice, exporter, trivy → 8080; prometheus (monitoring) → 8001 | shared-pg (database):5432, redis:6379, registry:5000/8080, portal:8080, jobservice:8080, trivy:8080, kanidm (kanidm):8443, kube-apiserver |
 | **portal** | nginx, core → 8080 | (none) |
 | **registry** | core, jobservice → 5000/8080; prometheus (monitoring) → 8001 | seaweedfs-filer (seaweedfs):8333, redis:6379 |

--- a/manifests/harbor/netpol-nginx.yaml
+++ b/manifests/harbor/netpol-nginx.yaml
@@ -41,6 +41,9 @@ spec:
         - matchLabels:
             app.kubernetes.io/managed-by: trivy-operator
             io.kubernetes.pod.namespace: trivy-system
+        - matchLabels:
+            renovate: "true"
+            io.kubernetes.pod.namespace: argo
       toPorts:
         - ports:
             - port: "8443"


### PR DESCRIPTION
自前 Renovate の初回実行で horenso の digest lookup が `ETIMEDOUT`(60s) で失敗。DNS は解決するが接続が drop されていた。

原因: renovate の egress CNP は harbor-nginx:8443 を許可済みだが、**harbor-nginx 側の ingress CNP に renovate が無く** Cilium が drop（default deny）。

修正: harbor-nginx ingress の 8443 許可リストに `renovate=true` (argo ns) を追加。docs/network-policies.md も更新。

その他は検証済み: GitHub App 認証(3リポ)、ESO Secret 同期、uid 65532 動作、renovate CLI 起動。これで horenso の Harbor 認証も通る想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYYmMhieNeQ5Kjaw2NrfFk