### PR TITLE
fix(argo): allow renovate-webhook sensor → NATS eventbus

### DIFF
--- a/manifests/argo/netpol-eventbus.yaml
+++ b/manifests/argo/netpol-eventbus.yaml
@@ -39,6 +39,8 @@ spec:
             eventsource-name: argocd-deployed
         - matchLabels:
             sensor-name: talos-extension-bump
+        - matchLabels:
+            sensor-name: renovate-webhook
       toPorts:
         - ports:
             - port: "4222"


### PR DESCRIPTION
renovate-webhook Sensor が (:4222) で CrashLoop。netpol-sensor(egress) は許可済みだが **eventbus(NATS) ingress CNP に sensor-name renovate-webhook が無く** drop されていた（両側 CNP の片手落ち）。:4222 ingress に追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYYmMhieNeQ5Kjaw2NrfFk