### PR TITLE
ci: stop persisting the checkout credential in the claude-code-action jobs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -431,11 +431,17 @@ jobs:
       issues: write
       id-token: write
     steps:
-      # Claude drives `gh pr review` / `gh pr merge` from this checkout and the
-      # job uploads no artifacts, so the persisted credential never leaves the
-      # runner. Dropping it is probably still correct — it needs one live run to
-      # confirm `gh` keeps authenticating — so it stays for now.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
+      # No credential is left behind, and claude-code-action does not want one.
+      # Passing a prompt selects its agent mode, where configureGitAuth() runs
+      # first and explicitly unsets the http.<server>/.extraheader that
+      # actions/checkout installs, then puts its own token in the remote URL.
+      #
+      # Restore this if the job is ever switched to tag mode (the @claude
+      # mention flow): there setupBranch() runs `git fetch` at modes/tag/index.ts
+      # before the auth is configured, so it would fetch with no credential.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -501,12 +507,15 @@ jobs:
       issues: write
       id-token: write
     steps:
-      # This job's whole purpose is to commit and push the fix, so the
-      # credential has to persist. No artifacts are uploaded from it.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
+      # This job pushes, but not through anything actions/checkout leaves in
+      # .git/config — the push goes through the remote URL claude-code-action
+      # rewrites in agent mode. See the note on ai-review's checkout above.
+      # `token:` is still needed for the clone itself.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Add ai-fix label
         run: gh pr edit ${{ github.event.pull_request.number }} --add-label "ai-fix"


### PR DESCRIPTION
Removes the last `zizmor: ignore[artipacked]` suppressions. Reading the action settled what the earlier comments left as "needs a live run to confirm".

## Why it is safe

Passing `prompt` / `direct_prompt` selects claude-code-action's **agent mode** (`src/modes/detector.ts` branches on `context.inputs.prompt`). In that mode `prepareAgentMode()` calls `configureGitAuth()` before anything else touches git, and that function:

```ts
// src/github/operations/git-config.ts:48
await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
// :78-79
const remoteUrl = `https://x-access-token:${githubToken}@${serverUrl.host}/...`;
await $`git remote set-url origin ${remoteUrl}`;
```

It strips the header `actions/checkout` installs and supplies its own token. `use_commit_signing` defaults to `"false"`, so the branch that calls it is the one taken. Agent mode also never calls `setupBranch()`, so no `git fetch` happens during preparation.

`ai-fix-ci` still pushes — through that rewritten remote, not through anything checkout left in `.git/config`. Its `token:` input stays, since the clone itself needs it.

## The case where this would break

**Tag mode** (the `@claude` mention flow) calls `setupBranch()` at `src/modes/tag/index.ts:66`, which runs `git fetch origin --depth=N <branch>`, *before* `configureGitAuth()` at :83/:96. With no persisted credential that fetch is unauthenticated — fine on a public repo, broken on a private one. There is a comment next to each checkout saying to restore the setting if the mode ever changes.

## Verification

`actionlint` and `zizmor` clean across the repo, with no `artipacked` suppressions left.

Note that these PRs do not exercise the change: `ai-review` and `ai-fix-ci` are gated on bot authorship, so they skip here. The first real exercise is the next Renovate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoQkgisfTG4AUatvnHNVxB