### PR TITLE
fix(argocd): permit ValidatingAdmissionPolicy in the platform project

### DIFF
--- a/docs/argocd-projects.md
+++ b/docs/argocd-projects.md
@@ -33,6 +33,8 @@ ArgoCD AppProject でアプリケーションをドメインごとに分離し�
 |---------|------|-------|------|
 | platform | ValidatingWebhookConfiguration | `*` | Cilium, ArgoCD |
 | platform | MutatingWebhookConfiguration | `*` | Cilium |
+| platform | ValidatingAdmissionPolicy | admissionregistration.k8s.io | Cilium Gateway API (1.20+) |
+| platform | ValidatingAdmissionPolicyBinding | admissionregistration.k8s.io | Cilium Gateway API (1.20+) |
 | platform | APIService | `*` | metrics-server |
 | platform | GatewayClass | `*` | Cilium Gateway API |
 | platform | Namespace | `*` | kube-system config |

--- a/manifests/argocd/appproject-platform.yaml
+++ b/manifests/argocd/appproject-platform.yaml
@@ -32,6 +32,10 @@ spec:
       kind: ValidatingWebhookConfiguration
     - group: '*'
       kind: MutatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: ValidatingAdmissionPolicy
+    - group: admissionregistration.k8s.io
+      kind: ValidatingAdmissionPolicyBinding
     - group: '*'
       kind: APIService
     - group: '*'


### PR DESCRIPTION
## Problem

The `cilium` Application has been stuck `OutOfSync` since #447 bumped the chart to 1.20.0:

```
resource admissionregistration.k8s.io:ValidatingAdmissionPolicy is not permitted in project platform
resource admissionregistration.k8s.io:ValidatingAdmissionPolicyBinding is not permitted in project platform
```

Cilium 1.20 renders a `ValidatingAdmissionPolicy` + `Binding` named `gateway.cilium.io` whenever `gatewayAPI.enabled` is true and a GatewayClass is created. Those kinds were missing from the `platform` AppProject's `clusterResourceWhitelist`, so ArgoCD rejected the whole sync and the cluster stayed on 1.19.5.

## Change

- Whitelist `admissionregistration.k8s.io/ValidatingAdmissionPolicy` and `.../ValidatingAdmissionPolicyBinding` in `appproject-platform.yaml`
- Record both in the `docs/argocd-projects.md` table

## Verification

- `helm template cilium/cilium --version 1.20.0 -f helm-values/cilium/values.yaml` renders clean
- Gateway API CRDs are already at v1.4.1, which 1.20 supports

Merging rolls Cilium 1.19.5 -> 1.20.0 across all six nodes via selfHeal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpXBfyiVYij1VyQyQgCzE4