### PR TITLE
fix(argocd): permit ValidatingAdmissionPolicy in the networking project

### DIFF
--- a/docs/argocd-projects.md
+++ b/docs/argocd-projects.md
@@ -42,6 +42,8 @@ ArgoCD AppProject でアプリケーションをドメインごとに分離し�
 | platform | TracingPolicy | cilium.io | Tetragon セキュリティポリシー |
 | networking | ValidatingWebhookConfiguration | `*` | cert-manager |
 | networking | MutatingWebhookConfiguration | `*` | cert-manager |
+| networking | ValidatingAdmissionPolicy | admissionregistration.k8s.io | Gateway API safe-upgrades (v1.5+) |
+| networking | ValidatingAdmissionPolicyBinding | admissionregistration.k8s.io | Gateway API safe-upgrades (v1.5+) |
 | networking | Namespace | `*` | cert-manager, external-dns |
 | networking | ClusterIssuer | `*` | cert-manager |
 | networking | CiliumClusterwideNetworkPolicy | `*` | DNS 共通ポリシー等 |

--- a/manifests/argocd/appproject-networking.yaml
+++ b/manifests/argocd/appproject-networking.yaml
@@ -24,6 +24,10 @@ spec:
       kind: ValidatingWebhookConfiguration
     - group: '*'
       kind: MutatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: ValidatingAdmissionPolicy
+    - group: admissionregistration.k8s.io
+      kind: ValidatingAdmissionPolicyBinding
     - group: '*'
       kind: Namespace
     - group: '*'


### PR DESCRIPTION
Prep for bumping the Gateway API CRD bundle past v1.5.

From v1.5.0 the experimental channel ships `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` named `safe-upgrades.gateway.networking.k8s.io` next to the CRDs. The `networking` AppProject does not whitelist those cluster-scoped kinds, so the `gateway-api-crds` sync would be rejected exactly like the `cilium` one was in #472.

Landing this first keeps the CRD bump itself a clean one-line change. On its own this commit is a no-op — nothing yet creates those objects.

Follow-ups:
1. bump `apps/gateway-api-crds.yaml` to v1.6.1 and drop the renovate `<1.5.0` pin
2. move the TLSRoute manifests from `v1alpha2` to `v1`

## Why the bundle has to move

Cilium 1.20 requires `TLSRoute v1` and `ReferenceGrant v1`, neither of which exists before Gateway API v1.5.0. The operator currently refuses to start its Gateway API controller:

```
level=error msg="Required GatewayAPI resources are not found"
  error="CRD \"tlsroutes.gateway.networking.k8s.io\" does not have version \"v1\"
         CRD \"referencegrants.gateway.networking.k8s.io\" does not have version \"v1\""
```

Existing traffic still flows on the Envoy config already programmed, but no Gateway, HTTPRoute or TLSRoute change is being reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpXBfyiVYij1VyQyQgCzE4