### PR TITLE
feat(gateway-api): move the CRD bundle to v1.6.1

### DIFF
--- a/apps/gateway-api-crds.yaml
+++ b/apps/gateway-api-crds.yaml
@@ -7,7 +7,7 @@ spec:
   project: networking
   source:
     repoURL: https://github.com/kubernetes-sigs/gateway-api.git
-    targetRevision: v1.4.1
+    targetRevision: v1.6.1
     path: config/crd/experimental
   destination:
     server: https://kubernetes.default.svc

--- a/renovate.json
+++ b/renovate.json
@@ -127,11 +127,6 @@
       ]
     },
     {
-      "description": "Pin Gateway API to <1.5.0 until Cilium 1.20 ships v1.5 conformance (Cilium 1.19 supports v1.4.1 only)",
-      "matchPackageNames": ["https://github.com/kubernetes-sigs/gateway-api.git"],
-      "allowedVersions": "<1.5.0"
-    },
-    {
       "description": "Pin claude-code-action until anthropics/claude-code-action#1260 lands (Issue #1242)",
       "matchManagers": ["github-actions"],
       "matchDepNames": ["anthropics/claude-code-action"],


### PR DESCRIPTION
## Why

Cilium 1.20 lists `TLSRoute v1` and `ReferenceGrant v1` in its required Gateway API resource set. Neither version exists before Gateway API v1.5.0, so since the 1.20 rollout the operator has been refusing to start its Gateway API controller:

```
level=error msg="Required GatewayAPI resources are not found"
  error="CRD \"tlsroutes.gateway.networking.k8s.io\" does not have version \"v1\"
         CRD \"referencegrants.gateway.networking.k8s.io\" does not have version \"v1\""
```

Traffic still flows on the Envoy config that was already programmed, and every HTTPRoute still reports a stale `Accepted: True`, but no Gateway, HTTPRoute or TLSRoute change is being reconciled. v1.6.1 is the bundle Cilium 1.20 documents and passes core conformance against.

## Migration check (v1.4.1 -> v1.6.1, experimental channel)

Diffed the actual CRDs from both tags:

| CRD | v1.4.1 | v1.6.1 | Objects | Note |
|-----|--------|--------|---------|------|
| TLSRoute | `v1alpha2`, `v1alpha3*` | `v1*`, `v1alpha2`, `v1alpha3` | 2 | all versions still served, `conversion: None`, spec schemas identical |
| ReferenceGrant | `v1beta1*` | `v1`, `v1beta1*` | 0 | storage unchanged |
| TCPRoute / UDPRoute | `v1alpha2*` | `v1*`, `v1alpha2` | 0 | graduated to Standard in v1.6 |
| BackendTLSPolicy | `v1*`, `v1alpha3` | unchanged | 0 | |
| XListenerSet (`x-k8s.io`) | `v1alpha1*` | removed | 0 | replaced by `ListenerSet` (`gateway.networking.k8s.io/v1`) |
| XBackend (`x-k8s.io`) | absent | `v1alpha1*` | n/a | new |

`*` = storage version.

The two stored TLSRoutes (`argocd/argocd-server`, `kanidm/kanidm`) are persisted as `v1alpha3`, which v1.6.1 still serves with a byte-identical spec schema and no conversion webhook, so they carry over untouched. Migrating those manifests to `v1` is a separate follow-up.

## Note on rollback

From v1.5.0 the bundle ships a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy with `failurePolicy: Fail` that denies applying any `gateway.networking.k8s.io` CRD whose bundle-version matches `v1.[0-4]`. Once this merges, rolling back to v1.4.1 requires deleting that policy first. #473 whitelisted the kind so the sync can create it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpXBfyiVYij1VyQyQgCzE4