### PR TITLE
refactor(gateway): declare the TLSRoutes as v1

### DIFF
--- a/manifests/argocd/tlsroute.yaml
+++ b/manifests/argocd/tlsroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: argocd-server

--- a/manifests/kanidm/tlsroute.yaml
+++ b/manifests/kanidm/tlsroute.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: kanidm


### PR DESCRIPTION
Follow-up to #474.

TLSRoute reached `v1` in Gateway API v1.5 and the bundle now runs v1.6.1, where `v1alpha2` and `v1alpha3` are both flagged `deprecated: true`. Both manifests still name `v1alpha2`.

The CRD serves all three versions with a byte-identical spec schema (`hostnames`, `parentRefs`, `rules`, `useDefaultGateways`) and `conversion: None`, so this only changes the version the manifests ask for — the stored objects are untouched.

Verified with `kubectl apply --dry-run=server` against the live cluster: both routes come back `configured`, no schema complaints.

Files:
- `manifests/argocd/tlsroute.yaml` (`argocd/argocd-server`, argocd.infra.tgy.io)
- `manifests/kanidm/tlsroute.yaml` (`kanidm/kanidm`, idm.tgy.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpXBfyiVYij1VyQyQgCzE4