### PR TITLE
ci: pin and checksum the workflow CLIs with aqua

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,10 +19,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install kubeconform
-        run: |
-          curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
-            | tar xz -C /usr/local/bin
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
 
       - name: Validate manifests
         run: |
@@ -47,12 +46,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install tools
-        run: |
-          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          chmod +x /usr/local/bin/yq
-          curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
-            | tar xz -C /usr/local/bin
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
 
       - name: Validate Helm templates
         run: |
@@ -126,12 +122,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install tools
-        run: |
-          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          chmod +x /usr/local/bin/yq
-          curl -fsSL https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz \
-            | tar xz -C /usr/local/bin crane
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
@@ -244,10 +237,9 @@ jobs:
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
-      - name: Install yq
-        run: |
-          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          chmod +x /usr/local/bin/yq
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
 
       - name: Install argo CLI matching the deployed controller
         run: |
@@ -325,9 +317,7 @@ jobs:
   # Most of this file is bash inside `run:` blocks, and none of it is exercised
   # until a push runs it. actionlint checks the expressions and the job graph,
   # and shells out to shellcheck for every script — which is where the real
-  # findings are. Pinned and checksummed for the same reason the argo CLI is:
-  # an unverified `latest` install has no business in the job that exists to
-  # keep the supply chain honest.
+  # findings are.
   actionlint:
     runs-on: ubuntu-latest
     steps:
@@ -335,21 +325,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install actionlint
-        env:
-          # renovate: datasource=github-releases depName=rhysd/actionlint
-          ACTIONLINT_VERSION: "1.7.12"
-        run: |
-          set -euo pipefail
-          base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
-          # `sha256sum -c` resolves the file name from the checksum line, so the
-          # tarball has to stay under the name the release published it as.
-          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          curl -fsSL "$base/${tarball}" -o "${tarball}"
-          curl -fsSL "$base/actionlint_${ACTIONLINT_VERSION}_checksums.txt" -o checksums.txt
-          grep " ${tarball}\$" checksums.txt | sha256sum -c -
-          sudo tar xzf "${tarball}" -C /usr/local/bin actionlint
-          actionlint --version
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
 
       - name: Lint workflows
         run: |
@@ -524,15 +502,9 @@ jobs:
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
-      - name: Install kubeconform
-        run: |
-          curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
-            | tar xz -C /usr/local/bin
-
-      - name: Install yq
-        run: |
-          wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          chmod +x /usr/local/bin/yq
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
 
       # Pinned to v1.0.99 — v1.0.100+ has a regression where install.sh
       # silently fails and the SDK can't fall back to its bundled binary.

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -1,0 +1,29 @@
+{
+  "checksums": [
+    {
+      "id": "github_release/github.com/google/go-containerregistry/v0.21.9/go-containerregistry_Linux_x86_64.tar.gz",
+      "checksum": "5C16D8DDB971CB1D5E6ED8B1E743DA8224414EEBA2C2762D8F1A61B2F095699E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mikefarah/yq/v4.53.3/yq_linux_amd64",
+      "checksum": "2148F058B3D9BE6348C7F261F504E53C52FFC4ADDCCC9659A82866E73BCA0AC62F9443D146932C547EFE54748700AC5A1633D9AFF01BA5605EEDDBF58FF880B5",
+      "algorithm": "sha512"
+    },
+    {
+      "id": "github_release/github.com/rhysd/actionlint/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz",
+      "checksum": "8ACA8DB96F1B94770F1B0D72B6DDDCB1EBB8123CB3712530B08CC387B349A3D8",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/yannh/kubeconform/v0.8.0/kubeconform-linux-amd64.tar.gz",
+      "checksum": "9BC2BFFBF71F261128533EDAF912153948B7FF238F9A531AE6D34466EC287883",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.552.0/registry.yaml",
+      "checksum": "24EE3C66CE9DD9C2A5F790268252399A3614A746F50DB24158096974B98C8618",
+      "algorithm": "sha256"
+    }
+  ]
+}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+#
+# CLI versions for the lint workflow. These used to be fetched from
+# `releases/latest/download/...` with nothing pinning or verifying them — the
+# one unpinned surface left in a repo that SHA-pins every action and
+# digest-pins every image. aqua records a SHA256 for each binary in
+# aqua-checksums.json and refuses to install anything that does not match.
+#
+# The argo CLI is deliberately not here: its version is resolved at run time
+# from the argo-workflows chart's appVersion so it matches the deployed
+# controller, and it verifies itself against the release's checksums.txt.
+checksum:
+  enabled: true
+  # Fail rather than fall back to "just download it" when a checksum is missing.
+  require_checksum: true
+  # CI and the workstation are both linux/amd64; recording other platforms
+  # would only pad the lock file.
+  supported_envs:
+    - linux/amd64
+
+registries:
+  - type: standard
+    ref: v4.552.0 # renovate: depName=aquaproj/aqua-registry
+
+packages:
+  - name: yannh/kubeconform@v0.8.0
+  - name: mikefarah/yq@v4.53.3
+  # provides `crane`
+  - name: google/go-containerregistry@v0.21.9
+  - name: rhysd/actionlint@v1.7.12

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "github>aquaproj/aqua-renovate-config#2.13.0"
   ],
   "platformAutomerge": true,
   "automergeStrategy": "squash",
@@ -64,7 +65,7 @@
       ]
     },
     {
-      "description": "Tool versions pinned as a workflow env var or action input. actionlint and zizmor install a specific version rather than the release page's `latest`, so the pin has to be something Renovate can see. extractVersionTemplate drops the tag's leading v to match how the version is written in the file.",
+      "description": "zizmor's version input, pinned so the action resolves a digest-pinned container instead of `latest`. Every other CLI in the workflows comes from aqua.yaml now, which the aqua preset handles. extractVersionTemplate drops the tag's leading v to match how the version is written in the file.",
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [


### PR DESCRIPTION
Moves the CLIs the workflows install onto [aqua](https://aquaproj.github.io/), so every binary CI runs is version-pinned and checksum-verified.

## Why

Actions are SHA-pinned, images are digest-pinned and gated by digest-cooldown — but the tools that *do* the validating were fetched like this:

```
curl -fsSL https://github.com/yannh/kubeconform/releases/latest/download/... | tar xz -C /usr/local/bin
wget  -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
```

No version, no checksum. `aqua.yaml` pins each version and `aqua-checksums.json` records a SHA256 per binary; `require_checksum: true` makes a missing entry an error rather than a silent fallback.

## What moved

Each bespoke install block becomes:

```yaml
      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
        with:
          aqua_version: v2.62.3
```

## What deliberately did not

- **The argo CLI** (home-cluster) stays as-is: its version is resolved at run time from the argo-workflows chart's appVersion so it matches the deployed controller, which a static pin cannot express. It already verifies itself against the release's `checksums.txt`.
- **helm** (`azure/setup-helm`) and **tofu** (`opentofu/setup-opentofu`) are still on their actions' default `version: latest`. Both exist in the aqua registry; moving them pins what templates the charts / validates the config, so it is worth doing as a separate change rather than bundling it here.

## Renovate

`github>aquaproj/aqua-renovate-config#2.13.0` handles `aqua.yaml` package versions, the registry `ref`, and the `aqua_version` input. The hand-rolled customManager stays for zizmor's `version` input, which is not an aqua package.

## Verification

`aqua i` resolves and every binary runs at the pinned version locally; `actionlint` and `zizmor` clean; no `releases/latest/download` or `i.jpillora.com` left in any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoQkgisfTG4AUatvnHNVxB