### PR TITLE
feat(argo): plan home-unifi tofu changes on every PR

### DIFF
--- a/manifests/argo/netpol-eventbus.yaml
+++ b/manifests/argo/netpol-eventbus.yaml
@@ -16,6 +16,8 @@ spec:
         - matchLabels:
             sensor-name: tofu-cloudflare
         - matchLabels:
+            sensor-name: tofu-unifi
+        - matchLabels:
             sensor-name: upgrade-k8s
         - matchLabels:
             sensor-name: pxe-sync

--- a/manifests/argo/netpol-sensor.yaml
+++ b/manifests/argo/netpol-sensor.yaml
@@ -10,6 +10,7 @@ spec:
         operator: In
         values:
           - tofu-cloudflare
+          - tofu-unifi
           - upgrade-k8s
           - pxe-sync
           - talos-build

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -162,6 +162,20 @@ spec:
         key: credential
       active: false
       contentType: json
+    unifi:
+      owner: Tsuguya
+      repository: home-unifi
+      webhook:
+        endpoint: /unifi
+        port: "12000"
+        method: POST
+      events:
+        - pull_request
+      webhookSecret:
+        name: home-unifi-github-webhook
+        key: credential
+      active: false
+      contentType: json
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
@@ -275,3 +289,88 @@ spec:
                 dependencyName: pull-request
                 dataKey: body.pull_request.user.login
               dest: spec.arguments.parameters.2.value
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: tofu-unifi
+  namespace: argo
+spec:
+  template:
+    serviceAccountName: workflow-executor
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    container:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 64Mi
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+  dependencies:
+    # No push trigger: home-unifi is applied by hand from the workstation
+    # (`make apply`), because a bad apply takes the whole house off the
+    # network. This sensor only ever plans.
+    - name: pull-request
+      eventSourceName: github-webhook
+      eventName: unifi
+      filters:
+        script: |-
+          if event.body == nil or event.body.pull_request == nil or event.body.action == nil then
+            return false
+          end
+          local action = event.body.action
+          return action == "opened" or action == "synchronize" or action == "reopened"
+  triggers:
+    - template:
+        name: tofu-plan
+        conditions: "pull-request"
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: tofu-unifi-plan-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: tofu-unifi-plan
+                arguments:
+                  parameters:
+                    - name: pr-number
+                      value: ""
+                    - name: branch
+                      value: ""
+                    - name: sha
+                      value: ""
+                    - name: author
+                      value: ""
+          parameters:
+            - src:
+                dependencyName: pull-request
+                dataKey: body.number
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: pull-request
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: pull-request
+                dataKey: body.pull_request.head.sha
+              dest: spec.arguments.parameters.2.value
+            - src:
+                dependencyName: pull-request
+                dataKey: body.pull_request.user.login
+              dest: spec.arguments.parameters.3.value

--- a/manifests/argo/tofu-unifi.yaml
+++ b/manifests/argo/tofu-unifi.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tofu-unifi-plan
+  namespace: argo
+spec:
+  activeDeadlineSeconds: 600
+  serviceAccountName: tofu-executor
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: pr-number
+      - name: branch
+      - name: sha
+      - name: author
+        default: ""
+  templates:
+    - name: main
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        - name: github-token
+          emptyDir: {}
+        - name: tools
+          emptyDir: {}
+        - name: github-app-secret
+          secret:
+            secretName: github-app-private-key
+      initContainers:
+        - name: github-auth
+          image: registry.infra.tgy.io/tools/argo-tools:latest
+          command: [github-auth.sh]
+          env:
+            - name: GITHUB_APP_ID
+              value: "2998228"
+            - name: GITHUB_APP_INSTALLATION_ID
+              value: "113765957"
+          securityContext:
+            runAsUser: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: github-app-secret
+              mountPath: /github-app
+              readOnly: true
+            - name: github-token
+              mountPath: /github-token
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+        - name: copy-tools
+          image: registry.infra.tgy.io/tools/argo-tools:latest
+          command: [sh, -c]
+          args:
+            - cp /usr/local/bin/jq /usr/local/bin/gh /tools/
+          securityContext:
+            runAsUser: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: tools
+              mountPath: /tools
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+        - name: git-clone
+          image: alpine/git:v2.54.0
+          command: [sh, -c]
+          args:
+            - |
+              GITHUB_TOKEN=$(cat /github-token/token)
+              git clone --depth 1 -b "${BRANCH}" "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/home-unifi.git" /workspace
+          env:
+            - name: BRANCH
+              value: "{{workflow.parameters.branch}}"
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: github-token
+              mountPath: /github-token
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+      container:
+        image: ghcr.io/opentofu/opentofu:1.12.5
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+        command: [sh, -c]
+        args:
+          - |
+            set -uo pipefail
+            export GITHUB_TOKEN=$(cat /github-token/token)
+            export PATH="/tools:$PATH"
+
+            REPO="Tsuguya/home-unifi"
+            PR="{{workflow.parameters.pr-number}}"
+            SHA="{{workflow.parameters.sha}}"
+            AUTHOR="{{workflow.parameters.author}}"
+            RUN_URL="https://argo.infra.tgy.io/workflows/argo/{{workflow.name}}"
+
+            # The commit status is the merge gate, so it is posted as pending
+            # before anything else can fail. A workflow that never starts, or
+            # one that dies mid-run, leaves the check unreported and GitHub
+            # blocks the merge — the whole point of using a status here rather
+            # than only a PR comment.
+            post_status() {
+              gh api "repos/$REPO/statuses/$SHA" \
+                -f state="$1" \
+                -f context=tofu-plan \
+                -f description="$2" \
+                -f target_url="$RUN_URL" >/dev/null
+            }
+
+            post_status pending "Running tofu plan"
+
+            cd /workspace
+
+            if ! OUTPUT=$(tofu fmt -check -recursive 2>&1); then
+              STATE=failure
+              DESC="tofu fmt -check: files need formatting"
+            elif ! OUTPUT=$(tofu init -input=false -no-color 2>&1); then
+              STATE=error
+              DESC="tofu init failed"
+            elif ! OUTPUT=$(tofu validate -no-color 2>&1); then
+              STATE=failure
+              DESC="tofu validate failed"
+            else
+              # -lock=false: this only ever reads state, and a PR plan must not
+              # block a concurrent apply run from the workstation.
+              OUTPUT=$(tofu plan -detailed-exitcode -lock=false -no-color 2>&1) && CODE=0 || CODE=$?
+              if [ "$CODE" = "0" ]; then
+                STATE=success
+                DESC="No changes"
+              elif [ "$CODE" = "2" ]; then
+                # A diff is the normal case for a hand-written change, so it
+                # stays green. The gate exists to prove the plan ran, not to
+                # forbid changes; read the comment for what it would do.
+                STATE=success
+                DESC="Changes detected - review the plan before merging"
+              else
+                STATE=error
+                DESC="tofu plan failed (exit $CODE)"
+              fi
+            fi
+
+            jq -n \
+              --arg desc "$DESC" \
+              --arg output "$OUTPUT" \
+              '{body: ("### Tofu Plan: " + $desc + "\n\n<details>\n<summary>Output</summary>\n\n```\n" + $output + "\n```\n\n</details>")}' \
+              | gh api "repos/$REPO/issues/$PR/comments" --input -
+
+            post_status "$STATE" "$DESC"
+
+            # Provider and lockfile bumps are only merged unattended when the
+            # plan is empty; anything with a diff waits for a human.
+            if [ "$DESC" = "No changes" ] && [ "$AUTHOR" = "renovate[bot]" ]; then
+              gh api "repos/$REPO/pulls/$PR/merge" --method PUT -f merge_method=squash
+            fi
+
+            [ "$STATE" = "success" ]
+        env:
+          - name: TF_VAR_api_url
+            valueFrom:
+              secretKeyRef:
+                name: unifi-tofu-credentials
+                key: api_url
+          - name: TF_VAR_api_key
+            valueFrom:
+              secretKeyRef:
+                name: unifi-tofu-credentials
+                key: api_key
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+          - name: github-token
+            mountPath: /github-token
+            readOnly: true
+          - name: tools
+            mountPath: /tools
+            readOnly: true

--- a/manifests/secrets/argo-home-unifi-github-webhook.yaml
+++ b/manifests/secrets/argo-home-unifi-github-webhook.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-unifi-github-webhook
+  namespace: argo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: home-unifi-github-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: home-unifi-github-webhook
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/manifests/secrets/argo-unifi-tofu-credentials.yaml
+++ b/manifests/secrets/argo-unifi-tofu-credentials.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unifi-tofu-credentials
+  namespace: argo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: unifi-tofu-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: unifi-tofu-credentials
+        metadataPolicy: None
+        nullBytePolicy: Ignore


### PR DESCRIPTION
home-unifi に CI が無く、provider bump の安全性が手元の `tofu plan` でしか確認できていなかった。実際 terrifi `~> 0.9` の更新では、v0.9.1 で `terrifi_client_group` の実体が v1 `rest/usergroup` から v2 `network-members-group` に差し替わっており、plan がビルトインの "Default" とは別のオブジェクトを新規作成しようとしていた。

GitHub-hosted runner では LAN 上の UniFi コントローラにも state backend にも到達できないため、plan はクラスタ内で回すしかない。home-cloudflare で実績のある構成（github EventSource エントリ + Sensor + WorkflowTemplate）をそのまま流用する。

## 変更

| ファイル | 内容 |
|---|---|
| `manifests/argo/tofu-unifi.yaml` | WorkflowTemplate `tofu-unifi-plan`（新規） |
| `manifests/argo/tofu-eventsource.yaml` | EventSource エントリ `unifi`（endpoint `/unifi`, `pull_request`）+ Sensor `tofu-unifi` |
| `manifests/argo/netpol-sensor.yaml` | sensor egress に `tofu-unifi` |
| `manifests/argo/netpol-eventbus.yaml` | eventbus ingress に `tofu-unifi` |
| `manifests/secrets/argo-unifi-tofu-credentials.yaml` | ESO（1Password `unifi-tofu-credentials`） |
| `manifests/secrets/argo-home-unifi-github-webhook.yaml` | ESO（webhook secret） |

## 設計上の判断

**apply トリガーは作らない。** home-cloudflare と違い home-unifi は手動 `make apply` のまま。UniFi を壊すと家全体がネットから切れるため。この Sensor は plan しかしない。

**結果は PR コメントだけでなく `tofu-plan` commit status に書く。** 差分ありは success 扱い（手書きの変更は差分があって当然で、failure にすると正当な変更が全部ブロックされる）。このチェックの意味は「plan が実際に走ったことの証明」で、差分の中身はコメントで読む。実行開始時に pending を先に打つので、**workflow が途中で死んだ場合も起動しなかった場合もチェック未報告のままマージがブロックされる**（fail-closed）。

Renovate の PR は従来どおり自動マージするが、**plan が空のときだけ**。

## CNP

workflow pod 側は追加不要。既存 `netpol-workflow-pods` の `toCIDR: 0.0.0.0/0` port 443 が 192.168.1.1 をカバーしていることを実測で確認済み（HTTP 401 = 到達）。Sensor は例のごとく egress と eventbus ingress の両方が必要。

## 検証

- 全 6 ファイル `kubectl apply --dry-run=server` 通過
- App (tgy-cluster-bot) の installation に `home-unifi` を追加済み

## マージ後の手動作業

1. GitHub に webhook 登録: `https://argo-hook.tgy.io/unifi`, events: `pull_request`
2. 一度 PR で緑を確認してから home-unifi の ruleset に `required_status_checks: tofu-plan` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpXBfyiVYij1VyQyQgCzE4
