### PR TITLE
fix(argo): retry the home-unifi automerge past the status race

### DIFF
--- a/manifests/argo/tofu-unifi.yaml
+++ b/manifests/argo/tofu-unifi.yaml
@@ -170,8 +170,20 @@ spec:
 
             # Provider and lockfile bumps are only merged unattended when the
             # plan is empty; anything with a diff waits for a human.
+            #
+            # tofu-plan is a required check, and the status posted a moment ago
+            # is not always visible to the merge endpoint yet -- it answers 405
+            # until it settles. Without the retry the PR just sits there green
+            # and unmerged, which reads as "automerge is broken" rather than as
+            # a race.
             if [ "$DESC" = "No changes" ] && [ "$AUTHOR" = "renovate[bot]" ]; then
-              gh api "repos/$REPO/pulls/$PR/merge" --method PUT -f merge_method=squash
+              for attempt in 1 2 3 4 5; do
+                if gh api "repos/$REPO/pulls/$PR/merge" --method PUT -f merge_method=squash; then
+                  break
+                fi
+                echo "merge attempt $attempt failed; retrying"
+                sleep 10
+              done
             fi
 
             [ "$STATE" = "success" ]


### PR DESCRIPTION
`tofu-plan` を required status check にすると、同じスクリプトが直前に書いた status を merge エンドポイントがまだ見えていないことがあり、405 が返る。1 回しか試さないと PR が緑のまま未マージで残り、「automerge が壊れている」ように見える。10 秒間隔で 5 回までリトライする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpXBfyiVYij1VyQyQgCzE4