### PR TITLE
chore(talos-build): switch spin extension back to upstream

### DIFF
--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -210,9 +210,8 @@ spec:
             # renovate: datasource=docker depName=ghcr.io/siderolabs/iscsi-tools
             - ghcr.io/siderolabs/iscsi-tools:v0.2.0@sha256:44b290660b71cf480ba2ab237e709dd5dee2af3484b368260ee0fc6c435c820d
             - --system-extension-image
-            # self-built mirror until siderolabs publishes spin v0.25.x
-            # (build: talos-custom-build/extensions/spin)
-            - ghcr.io/tsuguya/spin:v0.25.1@sha256:013755d0cfb72578ac199358e1e3bb4e74584c7bcb80dc464cd0c3539496d751
+            # renovate: datasource=docker depName=ghcr.io/siderolabs/spin
+            - ghcr.io/siderolabs/spin:v0.25.1@sha256:cf814e779c47f28d59a3fd4ea1355581506c360c0ac55921b83ef09948107741
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
             - ghcr.io/siderolabs/kata-containers:3.32.0@sha256:dcbcaf42eff4a15260f5a6743c055f7e020c454774db84cadb585680071b130f
@@ -339,9 +338,8 @@ spec:
             # renovate: datasource=docker depName=ghcr.io/siderolabs/iscsi-tools
             - ghcr.io/siderolabs/iscsi-tools:v0.2.0@sha256:44b290660b71cf480ba2ab237e709dd5dee2af3484b368260ee0fc6c435c820d
             - --system-extension-image
-            # self-built mirror until siderolabs publishes spin v0.25.x
-            # (build: talos-custom-build/extensions/spin)
-            - ghcr.io/tsuguya/spin:v0.25.1@sha256:013755d0cfb72578ac199358e1e3bb4e74584c7bcb80dc464cd0c3539496d751
+            # renovate: datasource=docker depName=ghcr.io/siderolabs/spin
+            - ghcr.io/siderolabs/spin:v0.25.1@sha256:cf814e779c47f28d59a3fd4ea1355581506c360c0ac55921b83ef09948107741
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
             - ghcr.io/siderolabs/kata-containers:3.32.0@sha256:dcbcaf42eff4a15260f5a6743c055f7e020c454774db84cadb585680071b130f
@@ -382,9 +380,8 @@ spec:
             # renovate: datasource=docker depName=ghcr.io/siderolabs/iscsi-tools
             - ghcr.io/siderolabs/iscsi-tools:v0.2.0@sha256:44b290660b71cf480ba2ab237e709dd5dee2af3484b368260ee0fc6c435c820d
             - --system-extension-image
-            # self-built mirror until siderolabs publishes spin v0.25.x
-            # (build: talos-custom-build/extensions/spin)
-            - ghcr.io/tsuguya/spin:v0.25.1@sha256:013755d0cfb72578ac199358e1e3bb4e74584c7bcb80dc464cd0c3539496d751
+            # renovate: datasource=docker depName=ghcr.io/siderolabs/spin
+            - ghcr.io/siderolabs/spin:v0.25.1@sha256:cf814e779c47f28d59a3fd4ea1355581506c360c0ac55921b83ef09948107741
             - --system-extension-image
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
             - ghcr.io/siderolabs/kata-containers:3.32.0@sha256:dcbcaf42eff4a15260f5a6743c055f7e020c454774db84cadb585680071b130f


### PR DESCRIPTION
## 背景

home-rss の postgres TLS (`set_ca_root` / WIT `spin-postgres@4.1.0`) には containerd-shim-spin v0.25.x が必要だったが、当時 `ghcr.io/siderolabs/spin` は v0.24.0 止まりだったため自前ビルド (`ghcr.io/tsuguya/spin`) を使っていた。

**上流が v0.25.1 を publish したので撤収する。**

## 検証

上流イメージと自前ビルドを展開して比較:

| 項目 | 結果 |
|---|---|
| `containerd-shim-spin-v2` sha256 | `410d8b00926c66ef6ca359c5a9b6b98ebde979444bc5d740b6d0f1a21200f0cf` — **完全一致** |
| `/etc/cri/conf.d/10-spin.part` | 一致 |
| `manifest.yaml` | author/description のみ差異 |
| その他 | 上流のみ `usr/local/share/spdx/spin.spdx.json` を同梱 |

ランタイム挙動は同一。

## 変更

- `--system-extension-image` 3箇所を `ghcr.io/siderolabs/spin:v0.25.1@sha256:cf814e77…` に差し替え
- Renovate アノテーションを復活（以降は上流を自動追従）

## 残タスク（マージ後）

- [ ] installer 再ビルド WF 実行 → 全6ノード upgrade
- [ ] `talos-custom-build/extensions/spin/` 削除
- [ ] `ghcr.io/tsuguya/spin` パッケージ削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wety1S15GY4T3zkX62Gp4H