### PR TITLE
Parameterise the Harbor project in the image build

### DIFF
--- a/manifests/argo/single-repo-build-sensor.yaml
+++ b/manifests/argo/single-repo-build-sensor.yaml
@@ -77,6 +77,9 @@ spec:
                       value: memory
                     - name: commit-sha
                       value: ""
+                    # commit-sha は位置参照 (parameters.2.value) されているので末尾に足す
+                    - name: project
+                      value: tools
           parameters:
             - src:
                 dependencyName: memory-push
@@ -105,6 +108,9 @@ spec:
                       value: horenso
                     - name: commit-sha
                       value: ""
+                    # commit-sha は位置参照 (parameters.2.value) されているので末尾に足す
+                    - name: project
+                      value: tools
           parameters:
             - src:
                 dependencyName: horenso-push

--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -11,6 +11,10 @@ spec:
     parameters:
       - name: repo-url
       - name: image-name
+      # push 先の Harbor プロジェクト。既定は tools（public）。
+      # 公開したくないイメージは private なプロジェクトを明示する。
+      - name: project
+        value: tools
       - name: commit-sha
         value: main
   podMetadata:
@@ -169,7 +173,7 @@ spec:
               --frontend dockerfile.v0 \
               --local context=/workspace \
               --local dockerfile=/workspace \
-              --output 'type=image,"name=registry.infra.tgy.io/tools/{{workflow.parameters.image-name}}:{{workflow.parameters.commit-sha}},registry.infra.tgy.io/tools/{{workflow.parameters.image-name}}:latest",push=true' \
+              --output 'type=image,"name=registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}:{{workflow.parameters.commit-sha}},registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}:latest",push=true' \
               --metadata-file /workspace/metadata.json
             jq -r '."containerimage.digest"' /workspace/metadata.json > /workspace/digest
         env:
@@ -263,7 +267,7 @@ spec:
         command: [sh, -c]
         args:
           - |
-            IMAGE="registry.infra.tgy.io/tools/{{workflow.parameters.image-name}}@{{inputs.parameters.digest}}"
+            IMAGE="registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}@{{inputs.parameters.digest}}"
             cosign sign --registry-referrers-mode=legacy --new-bundle-format=false --use-signing-config=false --key /cosign/cosign.key --yes "$IMAGE"
         env:
           - name: HOME

--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -11,10 +11,9 @@ spec:
     parameters:
       - name: repo-url
       - name: image-name
-      # push 先の Harbor プロジェクト。既定は tools（public）。
-      # 公開したくないイメージは private なプロジェクトを明示する。
+      # push 先の Harbor プロジェクト。既定値を持たせない —— tools は public なので、
+      # 指定漏れが「意図せず公開」になるより、起動時に落ちるほうが安全。
       - name: project
-        value: tools
       - name: commit-sha
         value: main
   podMetadata:


### PR DESCRIPTION
`single-repo-image-build` pinned its push target to `registry.infra.tgy.io/tools/`. That project is public and anonymously pullable from the internet, so an image that should not be published had no way to be built, and re-running a build would silently undo a manual move into a private project.

Adds a `project` parameter with **no default**: defaulting to `tools` would have meant a forgotten parameter publishes the image, so a missing value now fails at submit time instead. Both sensor triggers state `project: tools` explicitly.

The sensor addresses `commit-sha` positionally (`spec.arguments.parameters.2.value`), so `project` is appended last rather than inserted — inserting it would have shifted the commit sha onto the wrong parameter.

Both the buildkit `--output` and the `cosign sign` target are parameterised; the `argo-tools` image reference is deliberately left pinned to `tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN