### PR TITLE
Deploy the trading collectors from their own repository

### DIFF
--- a/apps/trading.yaml
+++ b/apps/trading.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trading
+  namespace: argocd
+spec:
+  project: apps
+  source:
+    # マニフェストは private リポに置く。CNP の egress ルールが取引先と
+    # データソースを列挙するため、ここには出さない。
+    repoURL: https://github.com/Tsuguya/home-trading.git
+    targetRevision: main
+    path: manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: trading
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/manifests/argocd/appproject-apps.yaml
+++ b/manifests/argocd/appproject-apps.yaml
@@ -10,6 +10,9 @@ spec:
     - https://valkey.io/valkey-helm/
     - https://helm.goharbor.io
     - https://github.com/Tsuguya/home-cluster.git
+    # trading のマニフェストは private リポに置く
+    # （CNP の egress ルールが取引先とデータソースを列挙するため）
+    - https://github.com/Tsuguya/home-trading.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: nextcloud
@@ -21,6 +24,8 @@ spec:
       namespace: horenso
     - server: https://kubernetes.default.svc
       namespace: memory
+    - server: https://kubernetes.default.svc
+      namespace: trading
   clusterResourceWhitelist:
     - group: '*'
       kind: CustomResourceDefinition


### PR DESCRIPTION
Adds the `trading` ArgoCD Application and the two entries the `apps` project needs for it: the `home-trading` repo in `sourceRepos`, and the `trading` namespace in `destinations`.

The manifests themselves stay in `home-trading` (private). Their CiliumNetworkPolicy enumerates the egress destinations — the data sources and the broker — and this repo is public. The ArgoCD repo credential already covers `github.com/Tsuguya`, so no new secret is involved.

A side effect worth noting: `image-existence` in this repo runs `crane manifest` unauthenticated, so manifests referencing a private Harbor project could not have lived here anyway. `home-trading` runs `kubeconform` for schema validation instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN