### PR TITLE
Give Kyverno credentials for the private trading project

### DIFF
--- a/manifests/argo/tofu-harbor.yaml
+++ b/manifests/argo/tofu-harbor.yaml
@@ -112,6 +112,11 @@ spec:
               secretKeyRef:
                 name: harbor-tofu-credentials
                 key: robot_renovate_secret
+          - name: TF_VAR_robot_trading_pull_secret
+            valueFrom:
+              secretKeyRef:
+                name: harbor-tofu-credentials
+                key: robot_trading_pull_secret
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -275,3 +280,8 @@ spec:
               secretKeyRef:
                 name: harbor-tofu-credentials
                 key: robot_renovate_secret
+          - name: TF_VAR_robot_trading_pull_secret
+            valueFrom:
+              secretKeyRef:
+                name: harbor-tofu-credentials
+                key: robot_trading_pull_secret

--- a/manifests/kyverno/clusterpolicy-verify-images.yaml
+++ b/manifests/kyverno/clusterpolicy-verify-images.yaml
@@ -29,6 +29,12 @@ spec:
                       -----END PUBLIC KEY-----
                     signatureAlgorithm: sha256
                   signatureAlgorithm: sha256
+          # trading プロジェクトは private なので、署名 (.sig) を引くのに認証が要る。
+          # 認証情報は kyverno namespace の Secret から取る（pull 専用ロボット）。
+          imageRegistryCredentials:
+            allowInsecureRegistry: false
+            secrets:
+              - harbor-trading-pull
           mutateDigest: true
           required: true
           verifyDigest: true

--- a/manifests/secrets/harbor-tofu-credentials.yaml
+++ b/manifests/secrets/harbor-tofu-credentials.yaml
@@ -29,3 +29,7 @@ spec:
       remoteRef:
         key: harbor-robot-renovate
         property: password
+    - secretKey: robot_trading_pull_secret
+      remoteRef:
+        key: harbor-robot-trading-pull
+        property: password

--- a/manifests/secrets/harbor-trading-pull.yaml
+++ b/manifests/secrets/harbor-trading-pull.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: harbor-trading-pull
+  namespace: kyverno
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: harbor-trading-pull
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      mergePolicy: Replace
+      data:
+        .dockerconfigjson: |
+          {"auths":{"registry.infra.tgy.io":{"username":"{{ .username }}","password":"{{ .password }}","auth":"{{ printf "%s:%s" .username .password | b64enc }}"}}}
+  data:
+    # pull 専用ロボット。Kyverno は署名の取得にしか使わない。
+    - secretKey: username
+      remoteRef:
+        key: harbor-robot-trading-pull
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: harbor-robot-trading-pull
+        property: password


### PR DESCRIPTION
The `trading` CronJobs are blocked at admission:

```
verify-image-signatures: failed to verify image registry.infra.tgy.io/trading/home-trading@sha256:dc11317…
  GET .../manifests/sha256-dc11317….sig: UNAUTHORIZED: unauthorized to access repository
```

The signature is valid — Kyverno just cannot read it, because verification fetches the `.sig` tag from the registry and the project is private. `--registryCredentialHelpers` covers `default,google,amazon,azure,github`, none of which apply to Harbor.

Adds a pull-only robot for the project (`robot$trading+pull`) and wires it through:

- `harbor-tofu-credentials` gains `robot_trading_pull_secret`, and both the plan and apply templates pass it as `TF_VAR_robot_trading_pull_secret`
- a `dockerconfigjson` secret in the `kyverno` namespace, referenced from the policy's `imageRegistryCredentials`

Pull-only is the point: `robot$tools` can push, so giving it to the runtime would let a collector overwrite the image it runs from.

The matching robot resource lands in `home-harbor` and must merge **after** this, or the apply fails on the undeclared variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN