### PR TITLE
Feed the registry credential to Kyverno's client, not the policy

### DIFF
--- a/helm-values/kyverno/values.yaml
+++ b/helm-values/kyverno/values.yaml
@@ -54,3 +54,10 @@ features:
 
 webhooksCleanup:
   enabled: true
+
+# 署名検証はレジストリから .sig を引くため、private プロジェクトには認証が要る。
+# ポリシー側の imageRegistryCredentials ではレジストリクライアントに届かない
+# （起動ログの `setup registry client... secrets=` が空のまま）。
+# --imagePullSecrets に渡るのはこの値なので、ここで指定する。
+existingImagePullSecrets:
+  - harbor-trading-pull

--- a/manifests/kyverno/clusterpolicy-verify-images.yaml
+++ b/manifests/kyverno/clusterpolicy-verify-images.yaml
@@ -29,12 +29,6 @@ spec:
                       -----END PUBLIC KEY-----
                     signatureAlgorithm: sha256
                   signatureAlgorithm: sha256
-          # trading プロジェクトは private なので、署名 (.sig) を引くのに認証が要る。
-          # 認証情報は kyverno namespace の Secret から取る（pull 専用ロボット）。
-          imageRegistryCredentials:
-            allowInsecureRegistry: false
-            secrets:
-              - harbor-trading-pull
           mutateDigest: true
           required: true
           verifyDigest: true


### PR DESCRIPTION
Follow-up to #496. The credential was in place and readable, but verification still failed:

```
UNAUTHORIZED: unauthorized to access repository: trading/home-trading, action: pull
```

The admission controller's startup log explains it — the registry client is built with no secrets at all:

```
setup registry client... insecure=false secrets= v=2
```

`imageRegistryCredentials` on the rule does not feed that client. The chart's `existingImagePullSecrets` is what sets `--imagePullSecrets`, so the secret name goes there instead, and the rule-level block is removed rather than left as configuration that looks like it applies.

Restarting the admission controller first ruled out `useCache` holding a stale failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN