### PR TITLE
Keep signatures public so Kyverno can read them

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -14,6 +14,11 @@ spec:
       # push 先の Harbor プロジェクト。既定値を持たせない —— tools は public なので、
       # 指定漏れが「意図せず公開」になるより、起動時に落ちるほうが安全。
       - name: project
+      # 署名の保管先。private プロジェクトのイメージは、署名だけ public に置く必要がある——
+      # Kyverno は --imagePullSecrets を署名取得に使わない (kyverno/kyverno#15120)。
+      # 空なら従来どおりイメージと同じリポジトリに署名する。
+      - name: signature-repository
+        value: ""
       - name: commit-sha
         value: main
   podMetadata:
@@ -266,13 +271,18 @@ spec:
         command: [sh, -c]
         args:
           - |
+            set -eu
             IMAGE="registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}@{{inputs.parameters.digest}}"
+            # 空のまま渡すと cosign が空リポジトリを参照しようとするので落とす。
+            [ -n "${COSIGN_REPOSITORY:-}" ] || unset COSIGN_REPOSITORY
             cosign sign --registry-referrers-mode=legacy --new-bundle-format=false --use-signing-config=false --key /cosign/cosign.key --yes "$IMAGE"
         env:
           - name: HOME
             value: /tmp
           - name: COSIGN_PASSWORD
             value: ""
+          - name: COSIGN_REPOSITORY
+            value: "{{workflow.parameters.signature-repository}}"
           - name: DOCKER_CONFIG
             value: /docker-config
           - name: HARBOR_USER

--- a/manifests/kyverno/clusterpolicy-verify-images.yaml
+++ b/manifests/kyverno/clusterpolicy-verify-images.yaml
@@ -59,6 +59,7 @@ spec:
                       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEwj7kCwLmafF4470wPuk97Lhbho0
                       vEW3MUXEhm/9OLNUYmftu7R9VmlcnRl3CufXhVWRqpB/tbJXJWlYO5kV+g==
                       -----END PUBLIC KEY-----
+                    signatureAlgorithm: sha256
                   signatureAlgorithm: sha256
           mutateDigest: true
           required: true

--- a/manifests/kyverno/clusterpolicy-verify-images.yaml
+++ b/manifests/kyverno/clusterpolicy-verify-images.yaml
@@ -19,6 +19,10 @@ spec:
       verifyImages:
         - imageReferences:
             - "registry.infra.tgy.io/*"
+          # trading は署名を別リポジトリに置くので下のルールで扱う。
+          # ここを tools/* に狭めると新規プロジェクトが検証対象から外れてしまう。
+          skipImageReferences:
+            - "registry.infra.tgy.io/trading/*"
           attestors:
             - entries:
                 - keys:
@@ -28,6 +32,33 @@ spec:
                       vEW3MUXEhm/9OLNUYmftu7R9VmlcnRl3CufXhVWRqpB/tbJXJWlYO5kV+g==
                       -----END PUBLIC KEY-----
                     signatureAlgorithm: sha256
+                  signatureAlgorithm: sha256
+          mutateDigest: true
+          required: true
+          verifyDigest: true
+          useCache: true
+    # private プロジェクトのイメージ。Kyverno は --imagePullSecrets を署名の取得に
+    # 使わない (kyverno/kyverno#15120) ため、署名だけ public な tools/signatures に置く。
+    # 署名は digest に対する署名でしかなく、公開してもイメージの中身は漏れない。
+    - name: verify-cosign-signature-private
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      skipBackgroundRequests: true
+      verifyImages:
+        - imageReferences:
+            - "registry.infra.tgy.io/trading/*"
+          repository: registry.infra.tgy.io/tools/signatures
+          attestors:
+            - entries:
+                - keys:
+                    publicKeys: |-
+                      -----BEGIN PUBLIC KEY-----
+                      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEwj7kCwLmafF4470wPuk97Lhbho0
+                      vEW3MUXEhm/9OLNUYmftu7R9VmlcnRl3CufXhVWRqpB/tbJXJWlYO5kV+g==
+                      -----END PUBLIC KEY-----
                   signatureAlgorithm: sha256
           mutateDigest: true
           required: true


### PR DESCRIPTION
Kyverno cannot verify images in the private `trading` project. Ruled out in order: the secret's contents (auth field matches 1Password), RBAC (`can-i get secret/harbor-trading-pull` → yes), a cached failure (restarted the admission controller), and the robot itself — `cosign verify` fetches the same `.sig` with the same credential without trouble. The registry client even reports `secrets=harbor-trading-pull` at startup.

It is [kyverno/kyverno#15120](https://github.com/kyverno/kyverno/issues/15120), still open: `--imagePullSecrets` is not used when fetching a signature.

A signature covers a digest and reveals nothing about the image, so it can live in a public repository at no cost. Builds now take a `signature-repository` parameter (empty by default, so existing builds are unchanged) which sets `COSIGN_REPOSITORY`, and a second policy rule verifies `trading/*` against `tools/signatures`.

The first rule keeps `registry.infra.tgy.io/*` and gains `skipImageReferences` for trading, rather than being narrowed to `tools/*` — narrowing would let a future project fall outside verification entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN