### PR TITLE
Let the trading collector reach the filer

### DIFF
--- a/manifests/seaweedfs/netpol-filer.yaml
+++ b/manifests/seaweedfs/netpol-filer.yaml
@@ -47,6 +47,10 @@ spec:
             app: harbor
             component: registry
             io.kubernetes.pod.namespace: harbor
+        # 収集ジョブが生データを書き込む。namespace 全体ではなく collector だけを許す。
+        - matchLabels:
+            io.kubernetes.pod.namespace: trading
+            trading: collector
       toPorts:
         - ports:
             - port: "8333"


### PR DESCRIPTION
The collector's own policy allows egress to the filer, but the filer's ingress is an explicit allowlist and `trading` is not on it, so writes to S3 time out:

```
ConnectTimeoutError after 32.4s: http://seaweedfs-filer.seaweedfs:8333/trading/...
```

Nothing in the collector's policy hints at this — the deny is on the receiving side.

Grants the collector label rather than the namespace, so only the workload that writes raw data gets through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN