### PR TITLE
Pin the memory image digest so a dead Pod can restart

### DIFF
--- a/manifests/memory/deployment.yaml
+++ b/manifests/memory/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: memory
-          image: registry.infra.tgy.io/tools/memory:latest
+          image: registry.infra.tgy.io/tools/memory:latest@sha256:2f420d151c2ad4b1a01203415c1ce7109d7cde1f4844c10342a8c80086c8b464
           ports:
             - containerPort: 3000
               protocol: TCP


### PR DESCRIPTION
memory が 2026-08-19 11:05 から `ImagePullBackOff` で停止していた。要求している `sha256:1a8973…` は Harbor にもう存在しない。

## 何が起きたか

1. `manifests/memory/deployment.yaml` は `:latest` 指定（digest ピンなし）
2. Kyverno の `mutateDigest: true` が admission 時に digest を解決して Pod spec に焼き込む
3. Harbor の retention（直近 pull 5 件）がその artifact を削除。memory は調子が良い日で 1 日 5 ビルドするので、焼き込まれた digest は数時間〜数日で消える
4. Pod は既存レイヤで動き続けるが、11:05 に exit 137 で死んだ瞬間に復帰不能
5. 署名は artifact の accessory なので、`no signatures found` も同じ削除が原因

さらに `verifyDigest` の autogen ルールが「digest のない Deployment の更新」を拒否するため、`kubectl rollout restart` も admission で弾かれる。**digest をピンしない限りこの Deployment は直せない。**

## 変更

horenso と同じ形にピンする（現在の `latest` = `sha256:2f420d15…`）。Renovate の docker digest 更新が追従し、first-party レジストリは digest-cooldown の対象外なので鮮度は落ちない。

retention 側の一般化対策は Tsuguya/home-harbor#8。