### PR TITLE
Pin first-party image digests as well

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,8 +83,8 @@
   ],
   "packageRules": [
     {
-      "description": "Automerge patch updates",
-      "matchUpdateTypes": ["patch", "digest"],
+      "description": "Automerge patch updates. pinDigest is here because pinning changes nothing that runs — it writes down the digest the registry already resolves the tag to — and leaving those PRs for a human is what leaves a new service unpinned in the meantime. External images still soak: the digest-cooldown status holds their PR for three days regardless of automerge.",
+      "matchUpdateTypes": ["patch", "digest", "pinDigest"],
       "automerge": true
     },
     {
@@ -140,9 +140,9 @@
       "pinDigests": true
     },
     {
-      "description": "Do not pin first-party signed images (own registry)",
+      "description": "Pin first-party digests too. Not for supply chain — these are our own builds, which is why digest-cooldown skips them — but for availability: Harbor retention deletes artifacts, and Kyverno's mutateDigest bakes the resolved digest into every Pod at admission. An unpinned :latest is a Pod that pulls fine today and cannot restart once its artifact ages out, with no way to roll it forward either, since verifyDigest rejects a digest-less Deployment update. memory died exactly that way on 2026-08-19. Pinning also makes it knowable from git which tools image a Workflow actually ran.",
       "matchPackageNames": ["registry.infra.tgy.io/**"],
-      "pinDigests": false
+      "pinDigests": true
     },
     {
       "description": "Digest age gate is unenforceable (renovate#38656 for docker, no commit timestamp for action digests) and leaves renovate/stability-days pending forever; digest-cooldown workflow gates instead",


### PR DESCRIPTION
`registry.infra.tgy.io/**` の `pinDigests: false` を `true` に反転する。#500 の一般化。

## なぜ除外されていたか

`b649dfe`（digest-cooldown 導入）で "First-party signed images are exempt" として入った。**cooldown を skip する判断としては正しい** — 自前ビルド・自前署名なので「上流が乗っ取られる」前提が成り立たず、3 日の soak は何も買わない。

ただそのとき `pinDigests` まで一緒に落ちた。ピンは供給網のためではなく**可用性**のためにある、という観点が当時の判断材料に入っていなかった。

## 何が起きるか（memory が実際に踏んだ）

1. Harbor の retention が artifact を消す
2. Kyverno の `mutateDigest` は admission 時に `:latest` を digest へ解決し Pod spec に焼き込む
3. → Pod はキャッシュ済みレイヤで動き続けるが、死んだ瞬間に存在しない digest を要求して復帰不能
4. → しかも `verifyDigest` が digest なしの Deployment 更新を拒否するので `rollout restart` も通らない

2026-08-19、memory はこの状態で 4 時間停止した（#500）。

## WorkflowTemplate も対象に含める

`argo-tools:latest` など 40 箇所ほどがピンされる。これらの Pod は毎回 admission を通って `mutateDigest` が解決し直すので**元から危険ではなかった**が、

- Renovate は同一 depName を 1 ブランチにまとめるので、churn は「再ビルドごとに 1 PR」で済む
- 見返りに「どの Workflow がどの tools イメージで走ったか」が git から確定する

ので、例外を作らず一律ピンにする。

## 追従

`digest-cooldown` の `skip-registries` に first-party が入っているので soak なし。`pinDigest` を automerge の updateTypes に追加した（ピンは「レジストリが既に解決している digest を書き下すだけ」で挙動を変えないため。外部イメージは digest-cooldown の commit status が 3 日間 pending のままなので automerge しても soak は効く）。Renovate は 4 時間おき（`0 */4 * * *`）。

マージ後、初回の pin PR が 40 箇所ほどに出る見込み。