### PR TITLE
Let the digest audit through nginx

### DIFF
--- a/manifests/harbor/netpol-nginx.yaml
+++ b/manifests/harbor/netpol-nginx.yaml
@@ -42,6 +42,9 @@ spec:
             app.kubernetes.io/managed-by: trivy-operator
             io.kubernetes.pod.namespace: trivy-system
         - matchLabels:
+            image-digest-audit: "true"
+            io.kubernetes.pod.namespace: argo
+        - matchLabels:
             renovate: "true"
             io.kubernetes.pod.namespace: argo
         - matchLabels:


### PR DESCRIPTION
#504 の続き。監査 Workflow 側の egress は開けたが、**Harbor nginx 側の ingress 許可リストに入れ忘れていた**。

実際に走らせた結果:

```
curl: (28) Failed to connect to registry.infra.tgy.io:443 after 134876 ms
MISSING   registry.infra.tgy.io/tools/argo-tools:latest@sha256:2b6e5cbf…
MISSING   registry.infra.tgy.io/tools/horenso:latest@sha256:8a9bd7a3…
MISSING   registry.infra.tgy.io/tools/memory:latest@sha256:2f420d15…
```

3 件とも実在するイメージなので、これは監査の偽陽性。`manifests/harbor/netpol-nginx.yaml` の `fromEndpoints` に `image-digest-audit: "true"` (namespace argo) を追加する。renovate / tofu-harbor と同じ形。

なおロジック自体は正しく動いていた — 参照の収集（3 件）、repo と digest の分解、ルールマッチングはすべて期待通り。到達できなかっただけ。