### PR TITLE
Point Renovate at a credential that spans both projects

### DIFF
--- a/manifests/secrets/argo-renovate-harbor-robot.yaml
+++ b/manifests/secrets/argo-renovate-harbor-robot.yaml
@@ -13,9 +13,13 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   dataFrom:
+    # robot$trading+pull を使う。trading には明示権限があり、tools は public
+    # プロジェクトなので同じ認証情報で両方読める。
+    # robot$tools+renovate は project レベルで、Harbor の仕様上 1 プロジェクトしか
+    # 見られない（trading を足そうとすると apply が 400 で落ちる）。
     - extract:
         conversionStrategy: Default
         decodingStrategy: None
-        key: harbor-robot-renovate
+        key: harbor-robot-trading-pull
         metadataPolicy: None
         nullBytePolicy: Ignore


### PR DESCRIPTION
Renovate now watches `home-trading`, so it has to resolve digests in the `trading` project. Its current robot is project-scoped to `tools`, and Harbor rejects a second project on a project-level robot — [home-harbor#10](https://github.com/Tsuguya/home-harbor/pull/10) removes that failed attempt.

Recreating the robot as system-level would work but changes its name and secret, so it would mean a rotation. Unnecessary: `robot$trading+pull` already reads both projects — `trading` by explicit grant, `tools` because it is public. Verified:

```
trading/home-trading  tags/list -> 200
tools/memory          tags/list -> 200
tools/argo-tools      tags/list -> 200
```

`pull` alone suffices; the `list` actions govern the Harbor API, not the registry v2 API that the docker datasource uses. The credential is read-only, which is all a digest lookup needs.

`harbor-robot-renovate` stays in Harbor for now and can be removed once this is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN