### PR TITLE
Give the collectors a database

### DIFF
--- a/manifests/database/netpol-shared-pg.yaml
+++ b/manifests/database/netpol-shared-pg.yaml
@@ -9,6 +9,10 @@ spec:
       cnpg.io/cluster: shared-pg
   ingress:
     - fromEndpoints:
+        # 収集ジョブが Sharadar の価格データ等を投入する。
+        - matchLabels:
+            io.kubernetes.pod.namespace: trading
+            trading: collector
         - matchLabels:
             app.kubernetes.io/name: grafana
             io.kubernetes.pod.namespace: monitoring

--- a/manifests/database/shared-pg.yaml
+++ b/manifests/database/shared-pg.yaml
@@ -86,3 +86,10 @@ spec:
         login: true
         passwordSecret:
           name: horenso-pg-credentials
+      - name: trading
+        ensure: present
+        connectionLimit: -1
+        inherit: true
+        login: true
+        passwordSecret:
+          name: trading-pg-credentials

--- a/manifests/database/trading-database.yaml
+++ b/manifests/database/trading-database.yaml
@@ -1,0 +1,16 @@
+# postInitSQL は bootstrap 時にしか走らないので、稼働中のクラスタに
+# データベースを足すには Database CRD を使う。
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: trading
+  namespace: database
+spec:
+  cluster:
+    name: shared-pg
+  name: trading
+  owner: trading
+  ensure: present
+  # 収集した生データを投入する。誤って Database オブジェクトを消したときに
+  # 中身まで落ちないよう retain にする。
+  databaseReclaimPolicy: retain

--- a/manifests/secrets/database-trading-pg-credentials.yaml
+++ b/manifests/secrets/database-trading-pg-credentials.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: trading-pg-credentials
+  namespace: database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: trading-pg-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: trading-pg-credentials
+        metadataPolicy: None
+        nullBytePolicy: Ignore


### PR DESCRIPTION
Sharadar's five-year bulk export is 8.6M rows over 10k tickers (176 MB compressed, 603 MB as CSV), so the price data needs a real database rather than object storage.

`postInitSQL` only runs at bootstrap, so it cannot add a database to a running cluster. The database therefore comes from a `Database` resource, while the role joins `managed.roles`, which does apply continuously.

- `databaseReclaimPolicy: retain` — deleting the Kubernetes object by accident should not drop the ingested data
- the collector label, not the whole namespace, gets through to port 5432
- the password was generated inside 1Password, so it never touched local disk

Disk is not a concern: the volume reports 624 GB free and every existing database together comes to about 235 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN