### PR TITLE
Build home-trading images on push

### DIFF
--- a/manifests/argo/single-repo-build-sensor.yaml
+++ b/manifests/argo/single-repo-build-sensor.yaml
@@ -53,6 +53,31 @@ spec:
       eventName: horenso
       filters:
         script: *buildFilter
+    - name: home-trading-push
+      eventSourceName: github-webhook
+      eventName: home-trading
+      filters:
+        # Python なので共通フィルタ（src/ や package.json）は当たらない。
+        # schemas/ を含めるのは、ベンダー DDL がイメージに焼かれているため。
+        script: |-
+          if event.body == nil or event.body.ref ~= "refs/heads/main" or event.body.commits == nil then
+            return false
+          end
+          for _, c in ipairs(event.body.commits) do
+            for _, list in ipairs({c.added or {}, c.modified or {}, c.removed or {}}) do
+              for _, f in ipairs(list) do
+                if string.find(f, "Dockerfile", 1, true)
+                  or string.find(f, "collectors/", 1, true)
+                  or string.find(f, "execution/", 1, true)
+                  or string.find(f, "strategies/", 1, true)
+                  or string.find(f, "schemas/", 1, true)
+                  or string.find(f, "requirements", 1, true) then
+                  return true
+                end
+              end
+            end
+          end
+          return false
   triggers:
     - template:
         name: memory-build
@@ -114,5 +139,40 @@ spec:
           parameters:
             - src:
                 dependencyName: horenso-push
+                dataKey: body.after
+              dest: spec.arguments.parameters.2.value
+    - template:
+        name: home-trading-build
+        conditions: "home-trading-push"
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: home-trading-build-
+                namespace: image-build
+              spec:
+                workflowTemplateRef:
+                  name: single-repo-image-build
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: github.com/Tsuguya/home-trading
+                    - name: image-name
+                      value: home-trading
+                    - name: commit-sha
+                      value: ""
+                    # commit-sha は位置参照 (parameters.2.value) されているので末尾に足す
+                    - name: project
+                      value: trading
+                    # trading は private プロジェクト。Kyverno が署名を読めるよう
+                    # 署名だけ public な tools/signatures に置く（kyverno#15120）。
+                    - name: signature-repository
+                      value: registry.infra.tgy.io/tools/signatures
+          parameters:
+            - src:
+                dependencyName: home-trading-push
                 dataKey: body.after
               dest: spec.arguments.parameters.2.value

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -114,6 +114,20 @@ spec:
         key: credential
       active: false
       contentType: json
+    home-trading:
+      owner: Tsuguya
+      repository: home-trading
+      webhook:
+        endpoint: /home-trading
+        port: "12000"
+        method: POST
+      events:
+        - push
+      webhookSecret:
+        name: home-trading-github-webhook
+        key: credential
+      active: false
+      contentType: json
     renovate-home-cluster:
       owner: Tsuguya
       repository: home-cluster

--- a/manifests/secrets/argo-home-trading-github-webhook.yaml
+++ b/manifests/secrets/argo-home-trading-github-webhook.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-trading-github-webhook
+  namespace: argo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: home-trading-github-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: home-trading-github-webhook
+        metadataPolicy: None
+        nullBytePolicy: Ignore


### PR DESCRIPTION
The first `home-trading` image was built by submitting a Workflow by hand. That works exactly once, and then becomes the reason a collector quietly runs against month-old code. This wires the repo into the existing `single-repo-build` sensor so a push to `main` rebuilds it.

The shared `&buildFilter` anchor could not be reused — it matches `src/` and `package.json`, which a Python repo has neither of. This dependency gets its own filter keyed on `collectors/`, `execution/`, `strategies/` and `requirements`. It also watches `schemas/`: the Sharadar vendor DDL is read from disk at runtime and is now baked into the image, so a change there has to reach the running job.

Signatures are published to `tools/signatures` rather than beside the image, because `trading` is a private Harbor project and Kyverno cannot read signatures out of one (kyverno#15120) — same arrangement the manual build already used.

The webhook is registered on the repo and the shared secret is in 1Password as `home-trading-github-webhook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN