### PR TITLE
Split the Claude reviewer and CI fixer out of lint.yaml

### DIFF
--- a/.github/workflows/_claude-review.yml
+++ b/.github/workflows/_claude-review.yml
@@ -1,0 +1,145 @@
+name: AI review (reusable)
+
+# The reviewer itself. Called only from claude-review.yml, which pins this file
+# to @main — so everything below is read from the default branch regardless of
+# what the PR under review contains. That is the point: the reviewer's model,
+# tool allow-list, prompt and action version cannot be rewritten by the change
+# it is reviewing, and bumping any of them does not make the caller (the file
+# claude-code-action validates) differ from main.
+#
+# Renovate's action bumps land here. The caller stays frozen.
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: "Claude Code OAuth token used by claude-code-action"
+        required: true
+
+permissions: {}
+
+jobs:
+  review:
+    # The caller job is already named "AI review"; a reusable check renders as
+    # "<caller job> / <callee job>", so keep this one short.
+    name: review
+    if: >-
+      contains(fromJSON('["renovate[bot]", "tsuguya-home-cluster[bot]"]'),
+               github.event.pull_request.user.login) &&
+      !contains(github.event.pull_request.body, '**Automerge**: Enabled') &&
+      !contains(github.event.pull_request.title, 'gateway-api')
+    runs-on: ubuntu-latest
+    # The wait below can idle for up to 20 minutes; this stops a hung review
+    # from holding a runner for the default six hours on top of that.
+    timeout-minutes: 40
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      # Stands in for the `needs: [kubeconform, helm-template, image-existence]`
+      # this job had while it lived in lint.yaml. A separate workflow cannot
+      # depend on another one's jobs, and this reviewer approves and merges on
+      # its own, so it waits for the aggregate gate instead — which is stricter
+      # than the old three-job dependency, and is also the check the branch
+      # ruleset requires.
+      - name: Wait for CI Gate
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # `gh pr checks` exits non-zero whenever anything is pending or red,
+          # which is most of the loop — hence the `|| true` on the substitution.
+          for _ in $(seq 1 40); do
+            bucket=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket \
+                       --jq '[.[] | select(.name == "CI Gate") | .bucket] | first // ""' \
+                     2>/dev/null || true)
+            case "${bucket}" in
+              pass)
+                echo "proceed=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              ""|pending)
+                # "" also covers the window before the gate check exists at all
+                sleep 30
+                ;;
+              *)
+                echo "::notice::CI Gate concluded '${bucket}' — nothing to review."
+                echo "proceed=false" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          done
+          echo "::error::Timed out after 20 minutes waiting for CI Gate."
+          exit 1
+
+      # No credential is left behind, and claude-code-action does not want one.
+      # Passing a prompt selects its agent mode, where configureGitAuth() runs
+      # first and explicitly unsets the http.<server>/.extraheader that
+      # actions/checkout installs, then puts its own token in the remote URL.
+      #
+      # Restore this if the job is ever switched to tag mode (the @claude
+      # mention flow): there setupBranch() runs `git fetch` at modes/tag/index.ts
+      # before the auth is configured, so it would fetch with no credential.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.ci.outputs.proceed == 'true'
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.ci.outputs.proceed == 'true'
+        with:
+          node-version: "24"
+
+      - name: Install MCP server dependencies
+        if: steps.ci.outputs.proceed == 'true'
+        run: npm ci
+        working-directory: .github/mcp/pr-review
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        if: steps.ci.outputs.proceed == 'true'
+
+      # Pinned to v1.0.99 — v1.0.100+ has a regression where install.sh
+      # silently fails and the SDK can't fall back to its bundled binary.
+      # Unpin once anthropics/claude-code-action#1260 lands.
+      - uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        if: steps.ci.outputs.proceed == 'true'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "renovate[bot],tsuguya-home-cluster[bot]"
+          claude_args: "--model claude-sonnet-5 --max-turns 30 --disallowedTools Edit,Write,NotebookEdit,WebFetch,WebSearch,Glob,Grep --allowedTools 'Bash(gh:*)' Read 'mcp__pr-review__*' --mcp-config .github/mcp/pr-review/mcp-config.json"
+          prompt: |
+            You are reviewing a Renovate dependency update PR for a Kubernetes homelab cluster managed by ArgoCD.
+
+            You have MCP tools for efficient review. Follow this workflow:
+
+            Step 1: Get PR summary
+            Use `get_pr_summary` with pr_number=${{ github.event.pull_request.number }} to get structured PR info including update type, package versions, release notes, and affected files.
+
+            Step 2: If update_type is "helm", run helm values diff
+            Use `helm_values_diff` with the chart's repo_url, chart name, old/new versions (from step 1), and user_values_path (from affected_helm_values in step 1).
+            This writes detailed diffs to /tmp/pr-review/diff/ — check the summary first.
+
+            Step 3: Check app version change
+            If `app_version_change` is present, the underlying application version also changed (e.g., ArgoCD chart bump includes ArgoCD server version bump).
+            - Check `app_version_change.level` — major/minor upgrades need careful review
+            - If `app_version_change.release_notes_file` exists, use `Read` on `/tmp/pr-review/app-release-notes.md` for upstream release notes
+            - This is often where breaking changes actually live (chart changes are usually just values, app changes affect behavior)
+
+            Step 4: Deep dive if needed
+            - If removed_keys or impact_on_user_values has entries, use `Read` on the relevant section diff files in /tmp/pr-review/diff/sections/
+            - If release_notes_summary mentions breaking/deprecated keywords, use `Read` on /tmp/pr-review/release-notes.md
+            - Read the relevant helm-values/ files to verify your understanding
+
+            Step 5: Evaluate
+            - No breaking changes affecting our values configuration
+            - No deprecated options we currently use
+            - No removed keys that we depend on
+            - No known critical bugs in the new version
+
+            Decision:
+            - SAFE: Run `gh pr review ${{ github.event.pull_request.number }} --approve -b "AI Review: <brief summary of what was checked>"` then `gh pr merge ${{ github.event.pull_request.number }} --squash`
+            - CONCERNS: Run `gh pr comment ${{ github.event.pull_request.number }} -b "<your detailed concerns>"` — do NOT approve or merge

--- a/.github/workflows/claude-fix-ci.yml
+++ b/.github/workflows/claude-fix-ci.yml
@@ -1,0 +1,134 @@
+name: AI fix CI
+
+# Runs after the Lint workflow concludes, not alongside it.
+#
+# `workflow_run` is the right trigger for two reasons. It is the only one that
+# carries the thing this job keys on — whether CI actually failed — so there is
+# no polling and no runner taken on PRs that are green. And a `workflow_run`
+# run always executes the copy of this file on the default branch, which is
+# exactly what claude-code-action's server-side check wants (its OIDC exchange
+# rejects a run whose entry-point workflow differs from main). That check is
+# what made this job unusable from lint.yaml on any PR that edited a workflow —
+# every Renovate action bump. Here it cannot fail by construction.
+#
+# ⚠️ SECURITY: `workflow_run` executes with this repository's secrets and with
+# write permissions, while checking out the head of the pull request. This repo
+# is public, so the same-repository guard in the job condition is load-bearing:
+# without it a fork PR would get arbitrary code execution with the token and
+# the Claude credentials in scope. Renovate's branches live in this repository,
+# so nothing legitimate is lost by the restriction.
+#
+# zizmor rates `workflow_run` high-severity on sight, which is the right default
+# — it is the trigger that hands secrets to code from a pull request. The
+# conditions below are the mitigation it asks for: same-repository only, and the
+# checkout is skipped entirely unless one of two specific jobs failed.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: [Lint]
+    types: [completed]
+
+concurrency:
+  # Not cancel-in-progress: the fixer pushes to the PR branch at the end of its
+  # run, and that push is made with claude-code-action's own token, so Lint runs
+  # again and this workflow fires again. Cancelling would kill the run that just
+  # did the work; queueing lets it finish and the follow-up see the result.
+  group: ai-fix-ci-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  fix:
+    # `pull_requests[0]` is populated for same-repo pull requests only, so it
+    # doubles as a fork filter; the explicit head_repository comparison is kept
+    # because that behaviour is a documented side effect rather than a promise.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.pull_requests[0] &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # pushes the fix to the PR branch
+      pull-requests: write # adds the ai-fix label
+      issues: write # PR conversation comments
+      actions: read # read the failed run's jobs and logs
+      id-token: write # claude-code-action exchanges an OIDC token
+    steps:
+      # `conclusion == 'failure'` above only says the workflow failed. This job
+      # has always been scoped to the two manifest-validation jobs — a red
+      # actionlint or zizmor is a workflow problem, not something to point a
+      # manifest fixer at — so narrow it back down to those.
+      - name: Check which jobs failed
+        id: failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          names=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
+                    --jq '.jobs[] | select(.conclusion == "failure") | .name')
+          echo "Failed jobs: ${names//$'\n'/, }"
+          if printf '%s\n' "$names" | grep -qxE 'kubeconform|helm-template'; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Neither kubeconform nor helm-template failed — nothing for this job to fix."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # This job pushes, but not through anything actions/checkout leaves in
+      # .git/config — the push goes through the remote URL claude-code-action
+      # rewrites in agent mode. `token:` is still needed for the clone itself.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.failed.outputs.proceed == 'true'
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Add ai-fix label
+        if: steps.failed.outputs.proceed == 'true'
+        run: gh pr edit "$PR" --repo "$REPO" --add-label "ai-fix"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPO: ${{ github.repository }}
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        if: steps.failed.outputs.proceed == 'true'
+
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        if: steps.failed.outputs.proceed == 'true'
+        with:
+          aqua_version: v2.62.3
+
+      # Pinned to v1.0.99 — v1.0.100+ has a regression where install.sh
+      # silently fails and the SDK can't fall back to its bundled binary.
+      # Unpin once anthropics/claude-code-action#1260 lands.
+      - uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        if: steps.failed.outputs.proceed == 'true'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "renovate[bot],tsuguya-home-cluster[bot]"
+          direct_prompt: |
+            This PR has failing CI checks. Fix them.
+
+            PR: #${{ github.event.workflow_run.pull_requests[0].number }}
+            Branch: ${{ github.event.workflow_run.head_branch }}
+            Failed run: ${{ github.event.workflow_run.id }}
+
+            ## Instructions
+
+            1. Run `gh run view ${{ github.event.workflow_run.id }} --log-failed` to see the failure logs
+            2. Analyze the error and fix the source files
+            3. Run the same validation locally to verify:
+               - For kubeconform: `kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -summary manifests/`
+               - For helm-template: reproduce the failing helm template command from the logs
+            4. Commit and push the fix to `${{ github.event.workflow_run.head_branch }}`
+
+            ## Rules
+            - Only fix CI failures, don't make unrelated changes
+            - Commit message should describe what was fixed and why
+            - If the fix requires a schema override or skip, that's acceptable as a last resort

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,40 @@
+name: AI review
+
+# The entry point, and deliberately the one file on this path that never
+# changes.
+#
+# claude-code-action refuses to run when the workflow that invoked it differs
+# from the copy on the default branch — a sane rule, since a PR could otherwise
+# rewrite its own reviewer. Under `pull_request` a same-repo PR runs its own
+# head's copy, so whichever file carries the `on:` trigger cannot be edited by a
+# PR that still wants to be reviewed. While this job lived in lint.yaml, that
+# meant every Renovate PR bumping a pinned action digest was unreviewable, and
+# so was any branch cut before the last edit to lint.yaml.
+#
+# So: nothing that Renovate or ordinary maintenance touches may appear here.
+# Model, prompt, tool allow-list, action version and the checks it waits on all
+# live in _claude-review.yml, which is read from main no matter what the PR
+# branch says.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  ai-review:
+    # `@main` is the design, not an oversight. A SHA would have to be bumped on
+    # every change to the body, which puts this file back into Renovate's path
+    # and reintroduces the exact failure the split exists to remove.
+    uses: Tsuguya/home-cluster/.github/workflows/_claude-review.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write # the reviewer merges the PR it approves
+      pull-requests: write # review, approve, comment
+      issues: write # PR conversation comments
+      id-token: write # claude-code-action exchanges an OIDC token
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
-# Nothing here needs the token by default. The jobs that do (ai-review,
-# ai-fix-ci, zizmor's SARIF upload) name their own scopes, so a new job added
-# below starts with no permissions rather than inheriting write access.
+# Nothing here needs the token by default. The one job that does (zizmor's
+# SARIF upload) names its own scope, so a new job added below starts with no
+# permissions rather than inheriting write access.
+#
+# The Claude reviewer and CI fixer used to live in this file. They now sit in
+# claude-review.yml / claude-fix-ci.yml, because claude-code-action validates
+# its entry-point workflow against main and a PR that edits this file would
+# otherwise be unreviewable.
 permissions: {}
 
 jobs:
@@ -367,8 +372,9 @@ jobs:
   # The only required status check. Aggregates every correctness leaf so the
   # ruleset never names an individual job: adding, renaming or matrix-splitting
   # a job below can't leave a required context that is never reported (which
-  # blocks the PR forever). ai-review / ai-fix-ci are deliberately excluded —
-  # they are advisory and conditional, and ai-review merges the PR itself.
+  # blocks the PR forever). The Claude jobs are deliberately not part of it —
+  # they are advisory and conditional, and the reviewer waits on this gate
+  # rather than being gated by it.
   gate:
     name: CI Gate
     needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, actionlint, zizmor]
@@ -393,143 +399,3 @@ jobs:
               *) echo "::error::A required job concluded with: ${r}"; exit 1 ;;
             esac
           done
-
-  ai-review:
-    needs: [kubeconform, helm-template, image-existence]
-    if: >-
-      github.event_name == 'pull_request' &&
-      contains(fromJSON('["renovate[bot]", "tsuguya-home-cluster[bot]"]'),
-               github.event.pull_request.user.login) &&
-      !contains(github.event.pull_request.body, '**Automerge**: Enabled') &&
-      !contains(github.event.pull_request.title, 'gateway-api')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      # No credential is left behind, and claude-code-action does not want one.
-      # Passing a prompt selects its agent mode, where configureGitAuth() runs
-      # first and explicitly unsets the http.<server>/.extraheader that
-      # actions/checkout installs, then puts its own token in the remote URL.
-      #
-      # Restore this if the job is ever switched to tag mode (the @claude
-      # mention flow): there setupBranch() runs `git fetch` at modes/tag/index.ts
-      # before the auth is configured, so it would fetch with no credential.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-
-      - name: Install MCP server dependencies
-        run: npm ci
-        working-directory: .github/mcp/pr-review
-
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-
-      # Pinned to v1.0.99 — v1.0.100+ has a regression where install.sh
-      # silently fails and the SDK can't fall back to its bundled binary.
-      # Unpin once anthropics/claude-code-action#1260 lands.
-      - uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "renovate[bot],tsuguya-home-cluster[bot]"
-          claude_args: "--model claude-sonnet-5 --max-turns 30 --disallowedTools Edit,Write,NotebookEdit,WebFetch,WebSearch,Glob,Grep --allowedTools 'Bash(gh:*)' Read 'mcp__pr-review__*' --mcp-config .github/mcp/pr-review/mcp-config.json"
-          prompt: |
-            You are reviewing a Renovate dependency update PR for a Kubernetes homelab cluster managed by ArgoCD.
-
-            You have MCP tools for efficient review. Follow this workflow:
-
-            Step 1: Get PR summary
-            Use `get_pr_summary` with pr_number=${{ github.event.pull_request.number }} to get structured PR info including update type, package versions, release notes, and affected files.
-
-            Step 2: If update_type is "helm", run helm values diff
-            Use `helm_values_diff` with the chart's repo_url, chart name, old/new versions (from step 1), and user_values_path (from affected_helm_values in step 1).
-            This writes detailed diffs to /tmp/pr-review/diff/ — check the summary first.
-
-            Step 3: Check app version change
-            If `app_version_change` is present, the underlying application version also changed (e.g., ArgoCD chart bump includes ArgoCD server version bump).
-            - Check `app_version_change.level` — major/minor upgrades need careful review
-            - If `app_version_change.release_notes_file` exists, use `Read` on `/tmp/pr-review/app-release-notes.md` for upstream release notes
-            - This is often where breaking changes actually live (chart changes are usually just values, app changes affect behavior)
-
-            Step 4: Deep dive if needed
-            - If removed_keys or impact_on_user_values has entries, use `Read` on the relevant section diff files in /tmp/pr-review/diff/sections/
-            - If release_notes_summary mentions breaking/deprecated keywords, use `Read` on /tmp/pr-review/release-notes.md
-            - Read the relevant helm-values/ files to verify your understanding
-
-            Step 5: Evaluate
-            - No breaking changes affecting our values configuration
-            - No deprecated options we currently use
-            - No removed keys that we depend on
-            - No known critical bugs in the new version
-
-            Decision:
-            - SAFE: Run `gh pr review ${{ github.event.pull_request.number }} --approve -b "AI Review: <brief summary of what was checked>"` then `gh pr merge ${{ github.event.pull_request.number }} --squash`
-            - CONCERNS: Run `gh pr comment ${{ github.event.pull_request.number }} -b "<your detailed concerns>"` — do NOT approve or merge
-
-  ai-fix-ci:
-    needs: [kubeconform, helm-template]
-    if: >-
-      github.event_name == 'pull_request' &&
-      always() &&
-      (needs.kubeconform.result == 'failure' || needs.helm-template.result == 'failure')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      # This job pushes, but not through anything actions/checkout leaves in
-      # .git/config — the push goes through the remote URL claude-code-action
-      # rewrites in agent mode. See the note on ai-review's checkout above.
-      # `token:` is still needed for the clone itself.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-
-      - name: Add ai-fix label
-        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "ai-fix"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-
-      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
-        with:
-          aqua_version: v2.62.3
-
-      # Pinned to v1.0.99 — v1.0.100+ has a regression where install.sh
-      # silently fails and the SDK can't fall back to its bundled binary.
-      # Unpin once anthropics/claude-code-action#1260 lands.
-      - uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "renovate[bot],tsuguya-home-cluster[bot]"
-          direct_prompt: |
-            This PR has failing CI checks. Fix them.
-
-            PR: #${{ github.event.pull_request.number }}
-            Branch: ${{ github.head_ref }}
-
-            ## Instructions
-
-            1. Run `gh run list --branch ${{ github.head_ref }} --limit 1 --json databaseId --jq '.[0].databaseId'` to get the latest run ID
-            2. Run `gh run view <run-id> --log-failed` to see the failure logs
-            3. Analyze the error and fix the source files
-            4. Run the same validation locally to verify:
-               - For kubeconform: `kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -summary manifests/`
-               - For helm-template: reproduce the failing helm template command from the logs
-            5. Commit and push the fix
-
-            ## Rules
-            - Only fix CI failures, don't make unrelated changes
-            - Commit message should describe what was fixed and why
-            - If the fix requires a schema override or skip, that's acceptable as a last resort

--- a/renovate.json
+++ b/renovate.json
@@ -134,6 +134,12 @@
       "allowedVersions": "<=1.0.99"
     },
     {
+      "description": "Leave the reusable-workflow ref in claude-review.yml alone. It points at @main deliberately: claude-code-action validates its entry-point workflow against the default branch, so any PR that edits that caller cannot be reviewed. Pinning it to a SHA would put it back in this bot's path on every change to the reusable body — exactly the failure the split removes. helpers:pinGitHubActionDigests would otherwise do just that.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["Tsuguya/home-cluster"],
+      "enabled": false
+    },
+    {
       "description": "Pin external image digests in build pipelines (gated by digest-cooldown workflow)",
       "matchFileNames": ["manifests/image-build/**", "manifests/talos-build/**"],
       "matchDatasources": ["docker"],


### PR DESCRIPTION
## なぜ

`claude-code-action` の OIDC トークン交換は、**エントリポイント側のワークフロー**（`on:` を持つファイル）がデフォルトブランチの内容と一致することを要求する（サーバ側検証、エラーコード `workflow_not_found_on_default_branch`）。`pull_request` では同一リポの PR も**自分の head のワークフローファイルで実行される**ため、レビュアーが CI 本体に同居している間は:

- CI ファイルを書き換える PR は構造的に一度もレビューされない（Renovate の action digest bump が毎回これ）
- CI ファイルの最終編集より前に切られたブランチも、内容と無関係に全部落ちる

## どうしたか

エントリポイントを専用ファイルに切り出して**凍結**する。

- `claude-review.yml` — `on` / `concurrency` / `permissions` / 再利用ワークフロー参照 / `secrets` のみ。**他の `uses:` を一切置かない**＝ Renovate が触る理由が無い
- `_claude-review.yml` — モデル・プロンプト・ツール許可リスト・action バージョン・ゲート条件。常に `@main` から読まれる

`helpers:pinGitHubActionDigests` が `@main` を SHA に固定すると台無しなので、`renovate.json` に除外ルールを追加。

別ファイルになると `needs:` が使えないので、CI 通過待ちは `gh pr checks` のポーリングステップに置換した（green 以外は以降のステップをスキップ＝従来の skip と同じ見え方で、赤くはならない）。

## 検証

`actionlint` / `zizmor`（persona regular）ともに clean。

## ai-fix-ci は `workflow_run` へ

こちらは凍結ではなく**トリガそのものを変えた**（`_claude-fix-ci.yml` は不要になり 1 枚に統合）。

- `workflow_run` のランは**常にデフォルトブランチ版で実行される**ので、検証は構造的に必ず通る
- トリガが CI の結論を持っているため、**green な PR でランナーを取らない**（`pull_request` + ポーリングだと全 PR で待機していた）
- `conclusion` はワークフロー全体の結果しか無いので、`/actions/runs/{id}/jobs` を引いて `kubeconform` / `helm-template` の失敗時のみ進むよう従来のスコープを維持
- ⚠️ `workflow_run` は**ベースリポジトリの secrets 付き**で PR の head を checkout する。public リポなので `head_repository.full_name == github.repository` の同一リポガードが load-bearing
- zizmor は `workflow_run` を無条件に high で落とすため、根拠コメント付きで `# zizmor: ignore[dangerous-triggers]` を付与

公式 example `anthropics/claude-code-action` の `examples/ci-failure-auto-fix.yml` がこの用途そのもの。ピンしている v1.0.99 でも `workflow_run` はサポート済み（`src/github/context.ts`）。

## 注意

- `ai-review` / `ai-fix-ci` はどちらも `CI Gate` の `needs` に入っていないので、**required check は不変**
- **この PR の "AI review" チェックは赤くなる** — `_claude-review.yml@main` がまだ main に無いため。マージ後は解消する

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT

