### PR TITLE
Gate the structure test on a flag, not the config itself

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -37,7 +37,7 @@ spec:
         # structure-test.yaml を置いていないリポジトリでは丸ごとスキップされる。
         - - name: structure-test
             template: structure-test
-            when: "{{steps.build.outputs.parameters.structure-test}} != ''"
+            when: "{{steps.build.outputs.parameters.has-structure-test}} == yes"
             arguments:
               parameters:
                 - name: digest
@@ -192,6 +192,10 @@ spec:
               --output 'type=image,"name=registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}:{{workflow.parameters.commit-sha}},registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}:latest",push=true' \
               --metadata-file /workspace/metadata.json
             jq -r '."containerimage.digest"' /workspace/metadata.json > /workspace/digest
+            # 中身は when に入れられない（複数行が式に展開されて壊れる）。
+            # 判定は有無だけの 1 語で行う。
+            test -f /workspace/structure-test.yaml && echo yes > /workspace/has-structure-test \
+              || echo no > /workspace/has-structure-test
         env:
           - name: DOCKER_CONFIG
             value: /docker-config
@@ -224,6 +228,9 @@ spec:
             valueFrom:
               path: /workspace/structure-test.yaml
               default: ""
+          - name: has-structure-test
+            valueFrom:
+              path: /workspace/has-structure-test
 
     - name: structure-test
       inputs:

--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -37,7 +37,7 @@ spec:
         # structure-test.yaml を置いていないリポジトリでは丸ごとスキップされる。
         - - name: structure-test
             template: structure-test
-            when: "{{steps.build.outputs.parameters.has-structure-test}} == yes"
+            when: "'{{steps.build.outputs.parameters.has-structure-test}}' == 'present'"
             arguments:
               parameters:
                 - name: digest
@@ -194,8 +194,9 @@ spec:
             jq -r '."containerimage.digest"' /workspace/metadata.json > /workspace/digest
             # 中身は when に入れられない（複数行が式に展開されて壊れる）。
             # 判定は有無だけの 1 語で行う。
-            test -f /workspace/structure-test.yaml && echo yes > /workspace/has-structure-test \
-              || echo no > /workspace/has-structure-test
+            # yes/no は式パーサにブールと解釈される余地があるので使わない。
+            test -f /workspace/structure-test.yaml && echo present > /workspace/has-structure-test \
+              || echo absent > /workspace/has-structure-test
         env:
           - name: DOCKER_CONFIG
             value: /docker-config


### PR DESCRIPTION
Follow-up to #515. The `when` expression interpolated the entire `structure-test.yaml`, so a 57-line config became a 57-line expression:

```
failed to resolve references: Invalid 'when' expression '# マニフェストがイメージに期待していることを書く場所。
# ここに書いた前提が崩れたイメージは署名されず、クラスタで起動できない。
...
```

Every build with a config present failed at that step rather than running the test.

The build step now also writes a one-word file recording whether the config exists, and the condition reads that instead. The contents still travel as a separate parameter, used only inside the step body where multi-line values are fine.

The failure mode was at least the safe one — the workflow errored rather than silently skipping, so nothing got signed on the strength of a test that never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN