### PR TITLE
Give the structure test somewhere to unpack the image

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -247,7 +247,9 @@ spec:
         - name: docker-config
           emptyDir: {}
         - name: work
-          emptyDir: {}
+          # tarball とその展開先を両方置く。イメージ 1 個ぶん。
+          emptyDir:
+            sizeLimit: 8Gi
       initContainers:
         - name: setup-registry-auth
           image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
@@ -298,7 +300,11 @@ spec:
             container-structure-test test --driver tar --image /work/image.tar               --config /work/structure-test.yaml
         env:
           - name: HOME
-            value: /tmp
+            value: /work
+          # tar ドライバは tarball を一時ディレクトリに展開する。既定の /tmp は
+          # readOnlyRootFilesystem で書けないので、書ける方に向ける。
+          - name: TMPDIR
+            value: /work
           - name: DOCKER_CONFIG
             value: /docker-config
         securityContext:


### PR DESCRIPTION
Third follow-up on the structure-test step, found by actually running it.

```
Error: error creating driver: processing tar image reference:
  mkdir /tmp/extracttar156569996: read-only file system
```

`--driver tar` extracts the tarball to a temp directory, and the container has `readOnlyRootFilesystem: true`. Every one of the eight assertions reported failure for that single environmental reason — which reads exactly like a badly broken image, the most confusing direction for this to fail in.

`TMPDIR` now points at the same emptyDir the tarball is pulled into, so the space requirement is in one place and bounded there (`sizeLimit: 8Gi`).

**The gate itself worked correctly the whole time.** `structure-test` failed, `sign` never ran, and the image sat in Harbor unsigned — so nothing was signed while the check was effectively inoperative. That is the property worth having, and it held under a failure I did not anticipate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm3dJv31BohNXxk9APK9XN