### PR TITLE
Make the fixer actually run, and the reviewer decide only once

### DIFF
--- a/.github/workflows/_claude-review.yml
+++ b/.github/workflows/_claude-review.yml
@@ -37,6 +37,46 @@ jobs:
       issues: write
       id-token: write
     steps:
+      # Renovate rebases constantly, so the head SHA is not a stable identity
+      # for "this PR was already judged" — PR #487 collected 28 approvals across
+      # only 5 distinct SHAs before this guard existed. Auto-merge is the record
+      # that survives a rebase: the first review enables it, and GitHub then
+      # merges the PR by itself once the required checks are green. A second
+      # review cannot make that happen sooner, and re-reviewing a PR that is
+      # merely waiting out the 3-day digest cooldown burns a Claude session per
+      # rebase for three days.
+      #
+      # This is deliberately not a correctness risk: auto-merge does not bypass
+      # anything. CI Gate and digest-cooldown are re-evaluated against whatever
+      # the branch looks like after each rebase, and GitHub refuses the merge
+      # until both are green on the current head.
+      - name: Skip if this PR has already been judged
+        id: dedupe
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          enabled=$(gh pr view "$PR" --repo "$REPO" --json autoMergeRequest \
+                      --jq '.autoMergeRequest.enabledAt // ""')
+          if [ -n "${enabled}" ]; then
+            echo "::notice::auto-merge was enabled at ${enabled} — the decision is already made."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Second gate, for the repeats that happen before any decision is
+          # reached: 23 of those 28 runs fired against a head that had not moved.
+          approved=$(gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate \
+                       --jq "[.[] | select(.user.login == \"claude[bot]\" and .state == \"APPROVED\" and .commit_id == \"${SHA}\")] | length")
+          if [ "${approved}" -gt 0 ]; then
+            echo "::notice::already approved at ${SHA} — not reviewing again."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
       # Stands in for the `needs: [kubeconform, helm-template, image-existence]`
       # this job had while it lived in lint.yaml. A separate workflow cannot
       # depend on another one's jobs, and this reviewer approves and merges on
@@ -45,6 +85,7 @@ jobs:
       # ruleset requires.
       - name: Wait for CI Gate
         id: ci
+        if: steps.dedupe.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-fix-ci.yml
+++ b/.github/workflows/claude-fix-ci.yml
@@ -112,7 +112,25 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "renovate[bot],tsuguya-home-cluster[bot]"
-          direct_prompt: |
+          # The `actions: read` in this job's `permissions:` does NOT reach the
+          # agent. src/entrypoints/run.ts overwrites GITHUB_TOKEN/GH_TOKEN with
+          # the App installation token it gets from the OIDC exchange, and that
+          # token's scopes come from DEFAULT_PERMISSIONS (contents/pull_requests/
+          # issues: write) merged with this input — nothing else. Without the
+          # line below, the `gh run view --log-failed` in the prompt is a 403.
+          additional_permissions: |
+            actions: read
+          # Match the reviewer's posture: no web access, and a turn budget so a
+          # confused run ends before the job timeout does.
+          claude_args: "--model claude-sonnet-5 --max-turns 40 --disallowedTools WebFetch,WebSearch,NotebookEdit"
+          # `prompt`, NOT `direct_prompt`. v1 removed the latter, and an unknown
+          # `with:` key only produces a warning annotation — the action then
+          # starts with an empty prompt and src/modes/detector.ts falls through
+          # to "agent mode (which won't trigger without a prompt)", so the job
+          # goes green having done nothing. Measured in run 32040557264:
+          # "Context prompt: NO PROMPT" / "No trigger found, skipping remaining
+          # steps". This job had never once run since it was written.
+          prompt: |
             This PR has failing CI checks. Fix them.
 
             PR: #${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
`gha-review` スキルを home-cluster に流して出た HIGH のうち、2件を修正する。

## 1. CI 自動修正は導入以来一度も動いていなかった

`claude-fix-ci.yml` は `direct_prompt` を渡していたが、これは **claude-code-action v1 で削除された入力**。未知の `with:` キーは warning annotation だけで失敗しないため、action は空のプロンプトで起動し、`src/modes/detector.ts` の

```js
// Default to agent mode (which won't trigger without a prompt)
return "agent";
```

に落ちていた。本番ログ（run `32040557264`, 2026-08-17）逐語:

```
##[warning]Unexpected input(s) 'direct_prompt', valid inputs are [..., 'prompt', ...]
Auto-detected mode: agent for event: pull_request
Context prompt: NO PROMPT
Trigger result: false
No trigger found, skipping remaining steps
```

outcome は `success`。App トークンと OAuth トークンを取得し、`ai-fix` ラベルまで貼ったうえで何もせず緑になっていた。`git log -S direct_prompt` は導入コミットのみ。

**入力名の変更だけでは足りない**ので、同時に2つ直した。

- **`additional_permissions: actions: read`** — job の `permissions:` にある `actions: read` は **agent には届かない**。`src/entrypoints/run.ts` が `GITHUB_TOKEN` / `GH_TOKEN` を OIDC 交換で得た App インストールトークンで上書きしており、その scope は `DEFAULT_PERMISSIONS`（contents / pull_requests / issues: write）+ `additional_permissions` のみ。これが無いと、プロンプト冒頭の `gh run view --log-failed` が初回実行でいきなり 403 になる
- **`claude_args`** — レビュアー側にはあるのに fixer には無く、web アクセスが開いたまま turn 予算も無かった

## 2. レビュアーが同じ PR を28回承認していた

PR #487 は `claude[bot]` の APPROVED が **28件**、うちユニークな SHA は **5つ**。auto-merge は初回（8/17）から立っており、3日間の digest cooldown を待つ間、Renovate の rebase ごとに新しいセッションが起動し続けていた。

rebase で head SHA が変わるため SHA は「判断済み」の識別子にならない。**auto-merge は rebase をまたいで生き残る**ので、これを主ゲートにした。SHA チェックは二段目（28回のうち23回は head が動いていない再実行だった）。

```
70249266 × 14
6f293cd3 ×  7
634b94f8 ×  5
7f0e4157 ×  1
dd8ef088 ×  1
```

### 正しさを落としていないこと

auto-merge は何もバイパスしない。`CI Gate` と `digest-cooldown` は rebase のたびに再評価され、GitHub は**現在の head で両方が緑になるまでマージしない**。再レビューを飛ばしても検証は CI 側で毎回走る。

ガードは待機ステップより**前**に置いてあるので、判断済みの PR では20分のポーリングごと省略される。

## 検証

`actionlint` clean / `zizmor` clean。`yq` で fixer の入力キーが `prompt` / `additional_permissions` / `claude_args` として正しくパースされることを確認済み。

## 残り

同レビューの HIGH は他に3件（`valueFiles` の silent drop、job permissions と agent 権限の乖離、release notes 経由の注入）、MEDIUM 13 / LOW 9。別 PR で扱う。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT
