### PR TITLE
Fail when a valueFiles path does not resolve

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,7 +99,16 @@ jobs:
               while IFS= read -r vf; do
                 [[ -z "$vf" || "$vf" == "null" ]] && continue
                 actual="${vf/\$values\//}"
-                [[ -f "$actual" ]] && values_args+=("-f" "$actual")
+                # Fail rather than drop. Skipping a missing values file renders
+                # the chart with its own defaults, which passes kubeconform and
+                # reports green — while ArgoCD, which cannot resolve the same
+                # path, fails to sync. A rename under helm-values/ or a dropped
+                # $values/ prefix would otherwise reach main unnoticed.
+                if [[ ! -f "$actual" ]]; then
+                  echo "::error file=$app_file::valueFiles entry '$vf' resolves to '$actual', which does not exist"
+                  exit 1
+                fi
+                values_args+=("-f" "$actual")
               done < <(yq ".spec.sources[$i].helm.valueFiles[]" "$app_file" 2>/dev/null || true)
               echo ">>> $app_name: $chart@$revision"
               if is_oci "$repo_url"; then
@@ -179,7 +188,16 @@ jobs:
               while IFS= read -r vf; do
                 [[ -z "$vf" || "$vf" == "null" ]] && continue
                 actual="${vf/\$values\//}"
-                [[ -f "$actual" ]] && values_args+=("-f" "$actual")
+                # Fail rather than drop. Skipping a missing values file renders
+                # the chart with its own defaults, which passes kubeconform and
+                # reports green — while ArgoCD, which cannot resolve the same
+                # path, fails to sync. A rename under helm-values/ or a dropped
+                # $values/ prefix would otherwise reach main unnoticed.
+                if [[ ! -f "$actual" ]]; then
+                  echo "::error file=$app_file::valueFiles entry '$vf' resolves to '$actual', which does not exist"
+                  exit 1
+                fi
+                values_args+=("-f" "$actual")
               done < <(yq ".spec.sources[$i].helm.valueFiles[]" "$app_file" 2>/dev/null || true)
               if is_oci "$repo_url"; then
                 chart_ref="oci://${repo_url}/${chart}"


### PR DESCRIPTION
`gha-review` の HIGH のうち、**本番に壊れた設定が緑のまま届く唯一の経路**を塞ぐ。

## 何が起きていたか

`helm-template` と `image-existence` は、どちらも `-f` 引数をこう組み立てていた。

```bash
actual="${vf/\$values\//}"
[[ -f "$actual" ]] && values_args+=("-f" "$actual")
```

`apps/*.yaml` が指すパスにファイルが無ければ、**警告も出さず黙って除外される**。結果:

1. `helm template` が **chart 自身のデフォルト値**でレンダリングする
2. `kubeconform` はそれを受け入れる
3. ジョブは緑
4. 一方 ArgoCD は同じパスを解決できず sync error

つまり「PR で変更した values が検証された」という CI の主張が成立しない。`selfHeal: true` なので、緑のままマージされたものがそのまま本番に向かう。

`image-existence` も同じ欠落をするため、**検査対象の image が chart デフォルト側**になり、実際に配備される image は検査されていなかった。

該当するのは `helm-values/` のリネーム、ディレクトリ移動、`$values/` プレフィックスの付け忘れ。

## 変更

存在しないパスを fail-closed にした（2箇所とも）。

```bash
if [[ ! -f "$actual" ]]; then
  echo "::error file=$app_file::valueFiles entry '$vf' resolves to '$actual', which does not exist"
  exit 1
fi
values_args+=("-f" "$actual")
```

## 影響

`apps/` の **valueFiles 31件すべてが現時点で解決できている**ので、今の結果は変わらない。将来のズレを黙って通さなくなるだけ。

## ガードの検出力を確認済み

「テストを足した」は「守られている」ではないので、同じループ構造で**落ちるべきものが落ちること**を確認した。

```
[存在するパス]   OK: values_args=-f helm-values/argocd/values.yaml   -> exit=0
[存在しないパス] ::error ... which does not exist                   -> exit=1
```

`while ... done < <(...)` はサブシェルにならないため `exit` が `run:` ブロック全体に伝播する（`cmd | while` だと伝播しないので、この構造であることが前提）。

## 検証

`actionlint` clean / `zizmor` clean。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT
