### PR TITLE
Tell a stalled CI apart from a broken gh in the review wait

### DIFF
--- a/.github/workflows/_claude-review.yml
+++ b/.github/workflows/_claude-review.yml
@@ -90,33 +90,51 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          CHECK: CI Gate
         run: |
           set -euo pipefail
-          # `gh pr checks` exits non-zero whenever anything is pending or red,
-          # which is most of the loop — hence the `|| true` on the substitution.
+          err="${RUNNER_TEMP}/gh-pr-checks.err"
           for _ in $(seq 1 40); do
-            bucket=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket \
-                       --jq '[.[] | select(.name == "CI Gate") | .bucket] | first // ""' \
-                     2>/dev/null || true)
+            # `gh pr checks` exits non-zero whenever anything is pending or
+            # red, which is most of this loop, so the exit status cannot tell
+            # "CI is still running" apart from "gh could not reach GitHub".
+            # Decide on the output instead: a JSON array means the call worked.
+            # Folding both into one empty string is how an expired token used
+            # to burn the full 20 minutes here and then report a CI timeout.
+            checks=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket 2>"$err") || true
+            if ! printf '%s' "${checks}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+              if grep -q 'no checks reported' "$err"; then
+                sleep 30    # the check does not exist yet — keep waiting
+                continue
+              fi
+              echo "::error::gh pr checks failed: $(tr '\n' ' ' < "$err")"
+              exit 1
+            fi
+            # Every check reported under this name has to be green, not just
+            # whichever one the API happened to list first.
+            bucket=$(printf '%s' "${checks}" | jq -r --arg name "$CHECK" '
+              [.[] | select(.name == $name) | .bucket] as $b
+              | if ($b | length) == 0 then ""
+                elif ($b | index("pending")) then "pending"
+                elif ($b | all(. == "pass")) then "pass"
+                else ($b | join(",")) end')
             case "${bucket}" in
               pass)
                 echo "proceed=true" >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
               ""|pending)
-                # "" also covers the window before the gate check exists at all
                 sleep 30
                 ;;
               *)
-                echo "::notice::CI Gate concluded '${bucket}' — nothing to review."
+                echo "::notice::${CHECK} concluded '${bucket}' — nothing to review."
                 echo "proceed=false" >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
             esac
           done
-          echo "::error::Timed out after 20 minutes waiting for CI Gate."
+          echo "::error::Timed out after 20 minutes waiting for ${CHECK}."
           exit 1
-
       # No credential is left behind, and claude-code-action does not want one.
       # Passing a prompt selects its agent mode, where configureGitAuth() runs
       # first and explicitly unsets the http.<server>/.extraheader that


### PR DESCRIPTION
`gha-review` の MEDIUM のうち、**5リポ横断で同型**だったものを直す。

## 何が壊れていたか

CI 完了を待つループが、あらゆる失敗を1つの空文字に潰していた。

```bash
bucket=$(gh pr checks ... --jq '... | first // ""' 2>/dev/null || true)
case "${bucket}" in
  ""|pending) sleep 30 ;;
```

`gh pr checks` は pending でも red でも非ゼロ終了するため、**終了コードでは「CI がまだ走っている」と「gh が GitHub に届かなかった」を区別できない**。トークン失効・レート制限・DNS 失敗はすべて `""` になり pending 側の枝に落ちて、20分使い切ってから

```
::error::Timed out after 20 minutes waiting for CI Gate.
```

と出る。**ログを読む唯一のタイミングで、間違った原因を名指しする**という壊れ方をしていた。

## 直し方

終了コードではなく**出力で判断する**。JSON 配列が返ってきていれば呼び出しは成功しており、終了コードが何であれ関係ない。`no checks reported` のときだけ待機を続け、それ以外は gh が実際に出力した内容を添えて即座に落とす。

## `first` もやめた

同じ名前で複数のチェックが報告されうる（再実行、同一 head で重なった run）。`first` は**順序不定の1件**を拾うので、レビュアーが「承認しようとしているコミットのものではないチェック」を根拠に approve しうる。同名のチェックが全部緑であることを要求する形に変えた。

## 検出力の確認

スタブした `gh` で6経路すべてを実行し、**落ちるべきものが落ちること**を確認した。

| ケース | exit | output | メッセージ |
|---|---|---|---|
| green | 0 | `proceed=true` | — |
| red | 0 | `proceed=false` | `CI Gate concluded 'fail'` |
| **同名 pass+fail** | 0 | `proceed=false` | `CI Gate concluded 'pass,fail'` |
| チェック未作成 | 1 | — | 待機継続 → タイムアウト |
| **認証失敗 (401)** | 1 | — | `gh pr checks failed: gh: Bad credentials (HTTP 401)` |
| **ネットワーク断** | 1 | — | `gh pr checks failed: dial tcp: lookup api.github.com...` |

太字が旧実装では区別できていなかったもの。

## 検証

`actionlint` clean / `zizmor` clean（memory の残り8件は今回と無関係な既存分）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT
