### PR TITLE
Stop lint.yaml from passing while checking less than it claims

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` on top of the default opened/synchronize/reopened. Changing a
+    # PR's base is an `edited` activity, so a PR opened against another branch
+    # and later retargeted at main never matched `branches:` and never produced
+    # a CI Gate check at all — the required context stays "Expected — Waiting
+    # for status to be reported" and the PR cannot merge until someone pushes
+    # to it. digest-cooldown.yml already subscribes to `edited`.
+    types: [opened, synchronize, reopened, edited]
 
 # Nothing here needs the token by default. The one job that does (zizmor's
 # SARIF upload) names its own scope, so a new job added below starts with no
@@ -26,6 +33,7 @@ jobs:
   kubeconform:
     name: kubeconform
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -54,6 +62,7 @@ jobs:
   helm-template:
     name: helm template
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -140,6 +149,7 @@ jobs:
   image-existence:
     name: image existence
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -214,10 +224,17 @@ jobs:
                 alias="r$(echo "$repo_url" | sha256sum | cut -c1-8)"
                 chart_ref="$alias/$chart"
               fi
-              helm template "$release_name" "$chart_ref" \
-                --version "$revision" \
-                --namespace "$namespace" \
-                "${values_args[@]}" >> "$all_yaml" 2>/dev/null || true
+              # `|| true` used to hide this entirely. Whether the chart renders
+              # at all is helm-template's job; what matters here is that a
+              # failure drops that chart's images out of the set below without
+              # changing this step's result, so the check quietly covers less
+              # than it reports. Name the chart instead of losing it silently.
+              if ! helm template "$release_name" "$chart_ref" \
+                   --version "$revision" \
+                   --namespace "$namespace" \
+                   "${values_args[@]}" >> "$all_yaml" 2>/dev/null; then
+                echo "::warning file=$app_file::helm template failed for ${chart}@${revision}; its images are not being checked"
+              fi
               echo "---" >> "$all_yaml"
             done
           done
@@ -234,6 +251,19 @@ jobs:
             | sort -u)
 
           echo "Checking ${#images[@]} unique images..."
+          # A collapse here means the extraction broke, not that the cluster
+          # shrank: the images come from `image:` lines in rendered charts, and
+          # a chart moving to repository/tag fields, an indentation change, or
+          # an over-broad exclude above would quietly reduce this to a handful
+          # while every remaining image still passes. 74 as of 2026-08-21, of
+          # which 14 come from manifests/ and kustomize/ — so anything near
+          # that floor means the helm half produced nothing. Re-baseline this
+          # deliberately when the real number moves.
+          MIN_IMAGES=60
+          if (( ${#images[@]} < MIN_IMAGES )); then
+            echo "::error::only ${#images[@]} images extracted, expected at least ${MIN_IMAGES} — the extraction pipeline is broken, not the cluster"
+            exit 1
+          fi
           for img in "${images[@]}"; do
             if crane manifest "$img" >/dev/null 2>&1; then
               echo "  OK   $img"
@@ -263,6 +293,7 @@ jobs:
   argo-lint:
     name: argo lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -284,9 +315,20 @@ jobs:
           app_version=$(helm show chart "argo/$chart" --version "$chart_version" | yq '.appVersion')
           echo "$chart@$chart_version -> argo-workflows $app_version"
 
+          # app_version reaches a URL that is downloaded, unpacked into
+          # /usr/local/bin and executed, and the checksums.txt it is verified
+          # against comes from that same URL — so the signature check only
+          # proves the two files agree, not where they came from. The value
+          # itself is the appVersion of whatever chart apps/argo-workflows.yaml
+          # points at, which a pull request can change. Constrain its shape
+          # before it becomes a path.
+          if [[ ! "$app_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::refusing to build a download URL from appVersion '${app_version}'"
+            exit 1
+          fi
           base="https://github.com/argoproj/argo-workflows/releases/download/${app_version}"
-          curl -fsSL "$base/argo-linux-amd64.gz" -o argo-linux-amd64.gz
-          curl -fsSL "$base/argo-workflows-cli-checksums.txt" -o checksums.txt
+          curl -fsSL --max-time 120 "$base/argo-linux-amd64.gz" -o argo-linux-amd64.gz
+          curl -fsSL --max-time 60 "$base/argo-workflows-cli-checksums.txt" -o checksums.txt
           grep ' argo-linux-amd64.gz$' checksums.txt | sha256sum -c -
           gunzip -c argo-linux-amd64.gz > /usr/local/bin/argo
           chmod +x /usr/local/bin/argo
@@ -302,6 +344,15 @@ jobs:
               manifests/ kustomize/ | sort -u
           )
           printf 'linting %d files\n' "${#files[@]}"
+          # The discovery above matches `kind:` only at column 0, so a manifest
+          # that is indented (embedded in a ConfigMap, a kustomize patch) or
+          # that lives outside these two directories is never linted. There is
+          # no symptom when that happens — argo lint is simply handed fewer
+          # files and reports success — so fail on an empty set at least.
+          if (( ${#files[@]} == 0 )); then
+            echo "::error::no Argo Workflow manifests matched; the discovery above is broken"
+            exit 1
+          fi
           # a finding exits non-zero and the runner's shell is bash -e, so the
           # findings have to survive the assignment to be classified below
           out=$(argo lint --offline --no-color -o simple "${files[@]}" 2>&1) || true
@@ -329,6 +380,7 @@ jobs:
   mcp:
     name: mcp config
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -361,8 +413,13 @@ jobs:
   gate:
     name: CI Gate
     needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, lint-workflows]
-    if: ${{ always() }}
+    # `!cancelled()` rather than `always()`: under always(), cancelling a run
+    # leaves every leaf reporting `cancelled`, which falls through the case
+    # below and records the required check as a failure. A cancelled run has no
+    # verdict to give, so the gate should be skipped along with it.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {}
     steps:
       - name: Aggregate results


### PR DESCRIPTION
`gha-review` の指摘のうち、`lint.yaml` に関わる MEDIUM 4件と LOW 2件。**全部「名前が主張する検証をせずに緑になる」**という同じ型。

## image existence — 何件検査したか誰も知らなかった

`helm template` の失敗が `|| true` で捨てられていたので、レンダリングできなくなったチャートは**そのまま image 集合から消え**、ステップは少ない対象で緑のまま。

- 下限 `MIN_IMAGES=60` を追加（現在74件、うち14件が `manifests/` + `kustomize/` 由来 = **helm 側が丸ごと消えても60を割る**）
- 失敗したチャートを `::warning` で名指し

## argo lint — 取りこぼしが成功と見分けられなかった

対象ファイルの列挙が**行頭 `kind:` 固定**なので、インデントされた manifest（ConfigMap 埋め込み、kustomize patch）や別ディレクトリのものは lint されない。しかも「少ないファイルを渡された」状態は成功と全く同じに見える。0件で落とすようにした。

## argo CLI — checksum が出所を保証していなかった

```bash
base=".../releases/download/${app_version}"
curl "$base/argo-linux-amd64.gz"
curl "$base/argo-workflows-cli-checksums.txt"   # ← 同じ URL から
sha256sum -c -
gunzip -c ... > /usr/local/bin/argo && argo version --short
```

**バイナリと checksums.txt が同一の `$base` から来る**ので、この検証は「2つのファイルが互いに一致すること」しか示さない。`$app_version` は `apps/argo-workflows.yaml` が指すチャートの appVersion で、**PR から変更できる**。取得物はそのまま `/usr/local/bin/argo` に置かれて実行される。

形式を制約するようにした。実値で確認済み:

```
v4.1.1           通す      ../../evil/v1.0.0   拒否
v4.1.0-rc2       通す      v3.7.2/../../x      拒否
v3.7.18          通す      latest / 空文字      拒否
```

`--max-time` も両方に追加（どちらにも無かった）。

## base 付け替えで PR が永久 pending になった

`pull_request` に `edited` が無かった。**PR の base 変更は `edited` アクティビティ**なので、main 以外に開いた PR を main へ付け替えても発火せず、`CI Gate` の check run が一度も作られない。必須チェックなので「Expected — Waiting for status to be reported」で固着する。`digest-cooldown.yml` は元から `edited` を購読していて、この非対称が発生源だった。

## キャンセルが「失敗」として記録されていた

`if: ${{ always() }}` だと run をキャンセルしたとき全 leaf が `cancelled` になり、集約の `*)` に落ちて**必須チェックが赤で記録される**。`!cancelled()` にして run と一緒にスキップされるようにした。

## timeout-minutes

6ジョブすべてに追加（既定6時間だった）。レジストリ・チャートリポジトリ・npm に外部通信するジョブが5つある。

```
kubeconform 10 / helm template 20 / image existence 20
argo lint 10 / mcp config 10 / CI Gate 5
```

## 検証

`actionlint` clean / `zizmor` pedantic clean。appVersion パターンは実値と traversal 双方で確認。

## この PR に入れていないもの

- **L-5** `kustomize/` が kubeconform の対象外 — `kubectl kustomize` が要るので aqua.yaml への追加とセット。別 PR
- **M-11** helm 作業の二重実行とキャッシュ — 構造変更なので別途

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT