### PR TITLE
Put gate-authors back to the account that actually authors the PRs

### DIFF
--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -46,13 +46,7 @@ jobs:
           # The self-hosted Renovate runs as our own GitHub App, so its PRs are
           # NOT authored by renovate[bot]; the action's default would silently
           # degrade every PR to the pure-digest-bump baseline.
-          # Both, to match the reviewer's author gate in _claude-review.yml. The
-          # self-hosted Renovate runs as the App, so renovate[bot] should not
-          # appear — but if it ever did, the reviewer would still approve and
-          # merge it while the cooldown silently degraded to the pure-digest
-          # baseline. The two lists disagreeing in the direction of the weaker
-          # gate is the part worth fixing.
-          gate-authors: tsuguya-home-cluster[bot],renovate[bot]
+          gate-authors: tsuguya-home-cluster[bot]
           # Report success on PRs with nothing to gate so this status can be a
           # required check without deadlocking unrelated PRs.
           always-report: true


### PR DESCRIPTION
[#524](https://github.com/Tsuguya/home-cluster/pull/524) で入れた `gate-authors` への `renovate[bot]` 追加を戻す。

## なぜ入れるべきでなかったか

指摘の根拠は「`digest-cooldown` は1アカウントしか gate していないのに `_claude-review.yml` は2つ受け入れている」という**対称性**だった。しかし1行上のコメントがこう書いてある。

```yaml
# The self-hosted Renovate runs as our own GitHub App, so its PRs are
# NOT authored by renovate[bot]; the action's default would silently
# degrade every PR to the pure-digest-bump baseline.
gate-authors: tsuguya-home-cluster[bot]
```

**`renovate[bot]` はこのリポジトリが到達しない状態**であり、そう書いてある。レビュアー側に2エントリあるのは App 移行前の名残にすぎない。

つまりこの変更は、**起こりえないケースのために意図的に絞ってある設定を広げ、ファイルが明記している判断を薄めた**だけだった。

## 教訓

`digest-cooldown.yml` は既に設計レビューを何度も通っているファイルで、`pull_request_target` の使用も schedule の死活も検討済み。この種の「チェックリストの項目をそのまま転記した」指摘は、Phase 3 の「採用していない規約を根拠に指摘するな」で落とすべきものだった。

同レビューの他2件（`dangerous-triggers`、schedule 失敗の通知）は却下できていたが、これはすり抜けた。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT