### PR TITLE
Fix aqua checksums from the cluster instead of by hand

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -107,7 +107,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **redis-secret-init** (Job) | (deny world) | kube-apiserver |
 | **cloudflared** | (deny world) | *.v2.argotunnel.com + cftunnel.com + h2.cftunnel.com + quic.cftunnel.com:443/7844 (7844 TCP+UDP), server:8080, eventsource (argo):12000, kanidm (kanidm):8443, nextcloud (nextcloud):80, harbor-nginx (harbor):8443 |
 
-## argo (21 policies)
+## argo (22 policies)
 
 | Component | Ingress | Egress |
 |---|---|---|
@@ -124,12 +124,13 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **talos-extension-bump-sensor** | (none) | kube-apiserver, eventbus:4222 |
 | **events-controller** | host → 8081 | kube-apiserver, eventbus:8222 |
 | **eventbus** | eventsource (github-webhook), alertmanager-eventsource (alertmanager-webhook), task-dispatch-eventsource (task-dispatch), task-status-sync-eventsource (task-status-sync), argocd-deployed-eventsource (argocd-deployed), sensors (tofu-cloudflare, tofu-unifi, tofu-harbor, upgrade-k8s, pxe-sync, talos-build, images-build, single-repo-build, alert-investigate, task-dispatch, task-status-sync, talos-extension-bump, renovate-webhook) → 4222; self → 6222/7777; events-controller → 8222 | self:6222/7777 |
-| **workflow-pods** (backup-workflow, pxe-sync, talos-build, kanidm-repl-exchange, kanidm-backup除外) | (deny world) | kube-apiserver, HTTPS 443, kube-apiserver/remote-node/host:50000 (Talos apid — node IP は node identity を持つので toCIDR では一致しない), seaweedfs-filer (seaweedfs):8333 |
+| **workflow-pods** (backup-workflow, pxe-sync, talos-build, kanidm-repl-exchange, kanidm-backup, aqua-checksum除外) | (deny world) | kube-apiserver, HTTPS 443, kube-apiserver/remote-node/host:50000 (Talos apid — node IP は node identity を持つので toCIDR では一致しない), seaweedfs-filer (seaweedfs):8333 |
 | **etcd-backup** (backup-workflow=true) | (deny world) | kube-apiserver:6443/50000 (Talos apid), *.r2.cloudflarestorage.com:443, seaweedfs-filer (seaweedfs):8333 |
 | **pxe-sync** (pxe-sync=true) | (deny world) | kube-apiserver, github.com + api.github.com + *.githubusercontent.com + dl-cdn.alpinelinux.org :443, seaweedfs-filer (seaweedfs):8333, QNAP NAS (192.168.5.240):2049 (NFS) |
 | **kanidm-backup** (kanidm-backup=true) | (deny world) | kube-apiserver, *.r2.cloudflarestorage.com:443, seaweedfs-filer (seaweedfs):8333 |
 | **kanidm-repl-exchange** (kanidm-repl-exchange=true) | (deny world) | kube-apiserver, seaweedfs-filer (seaweedfs):8333 |
 | **image-digest-audit** (image-digest-audit=true) | (none) | harbor-nginx (harbor):8443 |
+| **aqua-checksum** (aqua-checksum=true) | (deny world) | github.com + api.github.com + *.githubusercontent.com :443 |
 | **renovate** (renovate=true) | (none) | harbor-nginx (harbor):8443 |
 | **tofu-harbor** (tofu-harbor=true) | (none) | harbor-nginx (harbor):8443 |
 

--- a/manifests/argo/aqua-checksum-sensor.yaml
+++ b/manifests/argo/aqua-checksum-sensor.yaml
@@ -1,0 +1,198 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: aqua-checksum
+  namespace: argo
+# Fires the aqua-checksum workflow on Renovate pull requests, so a bump that
+# moves an aqua package does not sit red waiting for someone to run
+# `aqua update-checksum -a` by hand.
+#
+# One trigger per repository rather than one trigger with four conditions:
+# a trigger's parameters are resolved against a named dependency, so a shared
+# trigger could not read the repository and branch out of whichever event
+# actually arrived.
+#
+# Only four of the seven repositories with an aqua.yaml are here. home-rss and
+# home-actions have no webhook at all, and home-trading's sends push only —
+# those are GitHub-side settings, not manifests.
+spec:
+  template:
+    serviceAccountName: workflow-executor
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    container:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 64Mi
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+  dependencies:
+    - name: home-cluster
+      eventSourceName: github-webhook
+      eventName: renovate-home-cluster
+      filters:
+        script: &aquaFilter |-
+          if event.body == nil then return false end
+          local pr = event.body.pull_request
+          if pr == nil then return false end
+          local action = event.body.action
+          if action ~= "opened" and action ~= "synchronize" and action ~= "reopened" then
+            return false
+          end
+          if pr.state ~= "open" or pr.draft == true then return false end
+          if pr.head == nil or pr.head.ref == nil then return false end
+          -- Renovate's branches only. Nothing else should have a file rewritten
+          -- under it by a workflow holding an App token.
+          if string.sub(pr.head.ref, 1, 9) ~= "renovate/" then return false end
+          -- and never a fork: the workflow clones the head branch, so a fork
+          -- would put someone else's aqua.yaml in front of the App key.
+          if pr.head.repo == nil or event.body.repository == nil then return false end
+          if pr.head.repo.full_name ~= event.body.repository.full_name then return false end
+          return true
+    - name: home-infra
+      eventSourceName: github-webhook
+      eventName: renovate-home-infra
+      filters:
+        script: *aquaFilter
+    - name: home-cloudflare
+      eventSourceName: github-webhook
+      eventName: renovate-home-cloudflare
+      filters:
+        script: *aquaFilter
+    - name: home-harbor
+      eventSourceName: github-webhook
+      eventName: harbor
+      filters:
+        script: *aquaFilter
+  triggers:
+    - template:
+        name: aqua-checksum-home-cluster
+        conditions: "home-cluster"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-cluster
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-cluster
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-home-infra
+        conditions: "home-infra"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-infra
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-infra
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-home-cloudflare
+        conditions: "home-cloudflare"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-cloudflare
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-cloudflare
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-home-harbor
+        conditions: "home-harbor"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-harbor
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-harbor
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters

--- a/manifests/argo/aqua-checksum.yaml
+++ b/manifests/argo/aqua-checksum.yaml
@@ -1,0 +1,156 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-checksum-executor
+  namespace: argo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aqua-checksum-executor
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-edit
+subjects:
+  - kind: ServiceAccount
+    name: aqua-checksum-executor
+    namespace: argo
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: aqua-checksum
+  namespace: argo
+# Regenerates aqua-checksums.json on a Renovate branch that moved an aqua
+# package, and commits it back.
+#
+# aqua.yaml sets require_checksum: true in every repository that has one, so a
+# version bump without the matching checksum fails at install with
+# `checksum is required` — measured, not theoretical. Renovate cannot produce
+# the checksum itself: containerbase has no aqua tool definition, so the binary
+# does not exist in the image Renovate runs in.
+#
+# The alternative was a GitHub App private key in each repository's Actions
+# secrets. Doing it here instead keeps the key in one place, and makes adding a
+# repository a manifest change rather than something only a human can do.
+#
+# The commit is made through the Git Data API by github-signed-commit.sh, which
+# has two consequences that matter: it is signed by GitHub (Verified), and it
+# comes from the App — so unlike a GITHUB_TOKEN push it re-triggers the failed
+# workflow instead of leaving a stale red check.
+#
+# Renovate drops this commit whenever it rebases the branch, and this workflow
+# then re-adds it on the resulting synchronize. That is the intended behaviour:
+# the alternative is Renovate treating the branch as modified and refusing to
+# update it at all, which strands the PR. See ignoredAuthors in renovate.json.
+spec:
+  serviceAccountName: aqua-checksum-executor
+  entrypoint: main
+  activeDeadlineSeconds: 900
+  podMetadata:
+    labels:
+      aqua-checksum: "true"
+  arguments:
+    parameters:
+      - name: repository # Tsuguya/<name>
+      - name: branch # the pull request's head branch
+  templates:
+    - name: main
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        - name: github-token
+          emptyDir: {}
+        - name: github-app-secret
+          secret:
+            secretName: github-app-private-key
+      initContainers:
+        - name: github-auth
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:2b553887ff8c4ecfae6af8c0b37ac29c5d2c0bf49e26f6536ef0c56d7238bc3b
+          command: [github-auth.sh]
+          env:
+            - name: GITHUB_APP_ID
+              value: "2998228"
+            - name: GITHUB_APP_INSTALLATION_ID
+              value: "113765957"
+          securityContext:
+            runAsUser: 65532
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: github-app-secret
+              mountPath: /github-app
+              readOnly: true
+            - name: github-token
+              mountPath: /github-token
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      container:
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:2b553887ff8c4ecfae6af8c0b37ac29c5d2c0bf49e26f6536ef0c56d7238bc3b
+        command: [sh, -c]
+        args:
+          - |
+            set -euo pipefail
+            GH_TOKEN=$(cat /github-token/token)
+            export GH_TOKEN
+            # aqua reads GITHUB_TOKEN for the release downloads below; without
+            # it the anonymous rate limit applies and update-checksum -a is
+            # exactly the operation that hits it.
+            GITHUB_TOKEN="$GH_TOKEN"
+            export GITHUB_TOKEN
+
+            git clone --depth 1 --branch "{{workflow.parameters.branch}}" \
+              "https://x-access-token:${GH_TOKEN}@github.com/{{workflow.parameters.repository}}.git" /workspace
+            cd /workspace
+
+            if [ ! -f aqua.yaml ]; then
+              echo "no aqua.yaml in {{workflow.parameters.repository}} — nothing to do"
+              exit 0
+            fi
+
+            # aqua downloads every package to hash it, so this needs the same
+            # network reach as the CI it is fixing. AQUA_GLOBAL_CONFIG is
+            # cleared so only the repository's own aqua.yaml is considered.
+            AQUA_GLOBAL_CONFIG="" aqua update-checksum -a
+
+            git add aqua-checksums.json
+            if git diff --cached --quiet; then
+              echo "aqua-checksums.json already matches aqua.yaml — nothing to commit"
+              exit 0
+            fi
+
+            # Signed via the Git Data API, and authored by the App — which is
+            # what makes the failed check run again.
+            github-signed-commit.sh \
+              -r "{{workflow.parameters.repository}}" \
+              -b "{{workflow.parameters.branch}}" \
+              -m "ci: update aqua-checksums.json"
+        env:
+          # aqua writes its package tree under HOME; the image's user cannot
+          # write to the default one.
+          - name: HOME
+            value: /workspace
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+          - name: github-token
+            mountPath: /github-token
+            readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 512Mi

--- a/manifests/argo/netpol-aqua-checksum.yaml
+++ b/manifests/argo/netpol-aqua-checksum.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: aqua-checksum
+  namespace: argo
+# The workflow clones a branch, downloads every package aqua.yaml names so it
+# can hash them, and commits the result back through the API — so it needs
+# github.com for the clone, api.github.com for the commit, and the release
+# CDN for the artifacts themselves. Nothing else.
+spec:
+  endpointSelector:
+    matchLabels:
+      aqua-checksum: "true"
+  egress:
+    - toFQDNs:
+        - matchName: "github.com"
+        - matchName: "api.github.com"
+        - matchPattern: "*.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/manifests/argo/netpol-workflow-pods.yaml
+++ b/manifests/argo/netpol-workflow-pods.yaml
@@ -18,6 +18,8 @@ spec:
         operator: DoesNotExist
       - key: kanidm-backup
         operator: DoesNotExist
+      - key: aqua-checksum
+        operator: DoesNotExist
   ingressDeny:
     - fromEntities:
         - world

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
   "platformAutomerge": true,
   "automergeStrategy": "squash",
   "rebaseWhen": "behind-base-branch",
+  "ignoredAuthors": [
+    "265309552+tsuguya-home-cluster[bot]@users.noreply.github.com",
+    "noreply@github.com"
+  ],
   "minimumReleaseAge": "3 days",
   "constraints": {
     "npm": ">=11.10.0"


### PR DESCRIPTION
Renovate が aqua パッケージを上げた PR を、クラスタ側で自動的に緑にする。

## 解く問題

7リポの `aqua.yaml` は `require_checksum: true`。バージョンが動くと `aqua-checksums.json` が合わなくなり、**必ず**ここで落ちる（実測）。

```
ERR install the package ... error="checksum is required"
```

まだ発生していないのは、aqua 導入が 8/16 で **Renovate による aqua 更新がまだ来ていない**から。さきほど残り2リポに aqua preset を入れたので、次の実行から来る。

## なぜクラスタ側か

| 案 | 判定 |
|---|---|
| Renovate の `postUpgradeTasks` | ❌ containerbase に **aqua のツール定義が無い** |
| `aquaproj/update-checksum-action` 既定 | ❌ `github.token` の push は**ワークフローを再発火しない**ので赤が残る |
| App 秘密鍵を7リポの Actions secret へ | ⭕ 動くが**鍵を7箇所に複製**し、新規リポのたびに人手が要る |
| **クラスタ側**（これ） | ⭕ 鍵は1箇所。**新規リポの追加がマニフェスト変更で完結する** |

最後の点が決め手。secret 方式はリポを増やすたびに人間の作業が発生する。

## 仕組み

```
Renovate PR (pull_request: opened/synchronize/reopened)
  ↓ 既存の github-webhook EventSource
Sensor: renovate/* ブランチ かつ 同一リポ（fork 除外）
  ↓
WorkflowTemplate aqua-checksum
  ├ github-auth.sh        → App インストールトークン
  ├ clone → aqua update-checksum -a
  └ 差分あり → github-signed-commit.sh
```

`github-signed-commit.sh` は Git Data API 経由なので、**GitHub の鍵で署名され（Verified）**、かつ **App 名義**になる。後者が要点で、`GITHUB_TOKEN` の push と違い**落ちたチェックが再実行される**。

## `ignoredAuthors` が要る理由

Renovate の `isBranchModified()` は、ブランチ上の全コミットの **author と committer の両方**を `gitAuthor` と突き合わせ、一致しないものがあれば「他人が触った」と判断して**そのブランチの更新を止める**（`lib/util/git/index.ts:955-1030`）。

止まると PR が stale 化して automerge も効かなくなるので、App と GitHub の committer アドレスを `ignoredAuthors` に列挙して**通常どおり rebase させる**。

その結果、**rebase のたびにこのコミットは消える**。消えれば CI が再び赤になり、`synchronize` でセンサーが再発火して付け直す。これは意図した挙動で、**収束する**（base が止まれば緑で固まる）。止まるほうが実害が大きい。

## CNP

`netpol-workflow-pods` の `toCIDR 0.0.0.0/0:443` が既定で当たってしまうので、CLAUDE.md の方針（接続先を FQDN で絞る）に従って**除外し**、`github.com` / `api.github.com` / `*.githubusercontent.com` だけを許可する専用ポリシーを置いた。pxe-sync / talos-build と同じ扱い。`docs/network-policies.md` も更新済み（argo 21 → 22）。

## 対象は4リポのみ

`pull_request` を配信している webhook があるのは home-cluster / home-infra / home-cloudflare / home-harbor。

| リポ | 不足 |
|---|---|
| home-rss | webhook 自体が無い |
| home-actions | webhook 自体が無い |
| home-trading | `push` のみ配信 |

これらは GitHub 側の設定なのでマニフェストでは足せない。**webhook secret の 1Password 登録とリポジトリ側の webhook 追加**が要る。

## 検証

`kubeconform` 434リソース Valid。`renovate.json` パース確認。

⚠️ **実動作は未検証**。Renovate が実際に aqua パッケージを上げるまで発火しない。初回は `home-trading` の kubeconform v0.7.0 → v0.8.0 になる見込みだが、home-trading はまだ配線対象外なので、最初に検証できるのは他4リポのいずれか。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT