### PR TITLE
Wire the remaining three repositories into aqua-checksum

### DIFF
--- a/manifests/argo/aqua-checksum-sensor.yaml
+++ b/manifests/argo/aqua-checksum-sensor.yaml
@@ -12,9 +12,7 @@ metadata:
 # trigger could not read the repository and branch out of whichever event
 # actually arrived.
 #
-# Only four of the seven repositories with an aqua.yaml are here. home-rss and
-# home-actions have no webhook at all, and home-trading's sends push only —
-# those are GitHub-side settings, not manifests.
+# All seven repositories that have an aqua.yaml.
 spec:
   template:
     serviceAccountName: workflow-executor
@@ -73,6 +71,21 @@ spec:
     - name: home-harbor
       eventSourceName: github-webhook
       eventName: harbor
+      filters:
+        script: *aquaFilter
+    - name: home-rss
+      eventSourceName: github-webhook
+      eventName: home-rss
+      filters:
+        script: *aquaFilter
+    - name: home-actions
+      eventSourceName: github-webhook
+      eventName: home-actions
+      filters:
+        script: *aquaFilter
+    - name: home-trading
+      eventSourceName: github-webhook
+      eventName: home-trading
       filters:
         script: *aquaFilter
   triggers:
@@ -178,6 +191,96 @@ spec:
               dest: spec.arguments.parameters.0.value
             - src:
                 dependencyName: home-harbor
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-home-rss
+        conditions: "home-rss"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-rss
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-rss
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-home-actions
+        conditions: "home-actions"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-actions
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-actions
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-home-trading
+        conditions: "home-trading"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: home-trading
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: home-trading
                 dataKey: body.pull_request.head.ref
               dest: spec.arguments.parameters.1.value
           source:

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -123,8 +123,39 @@ spec:
         method: POST
       events:
         - push
+        # pull_request is here for aqua-checksum, which needs the head branch of
+        # a Renovate PR; the existing push consumer ignores it.
+        - pull_request
       webhookSecret:
         name: home-trading-github-webhook
+        key: credential
+      active: false
+      contentType: json
+    home-rss:
+      owner: Tsuguya
+      repository: home-rss
+      webhook:
+        endpoint: /home-rss
+        port: "12000"
+        method: POST
+      events:
+        - pull_request
+      webhookSecret:
+        name: home-rss-github-webhook
+        key: credential
+      active: false
+      contentType: json
+    home-actions:
+      owner: Tsuguya
+      repository: home-actions
+      webhook:
+        endpoint: /home-actions
+        port: "12000"
+        method: POST
+      events:
+        - pull_request
+      webhookSecret:
+        name: home-actions-github-webhook
         key: credential
       active: false
       contentType: json

--- a/manifests/secrets/argo-home-actions-github-webhook.yaml
+++ b/manifests/secrets/argo-home-actions-github-webhook.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-actions-github-webhook
+  namespace: argo
+# Mapped field by field rather than with dataFrom/extract, unlike the older
+# webhook secrets. op will only generate a value for Login and Password items,
+# not for API Credential — so the item is a Password, whose field is
+# `password`, and the mapping is what keeps the Secret key `credential` that
+# every EventSource entry already expects.
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: home-actions-github-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: credential
+      remoteRef:
+        key: home-actions-github-webhook
+        property: password

--- a/manifests/secrets/argo-home-rss-github-webhook.yaml
+++ b/manifests/secrets/argo-home-rss-github-webhook.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-rss-github-webhook
+  namespace: argo
+# Mapped field by field rather than with dataFrom/extract, unlike the older
+# webhook secrets. op will only generate a value for Login and Password items,
+# not for API Credential — so the item is a Password, whose field is
+# `password`, and the mapping is what keeps the Secret key `credential` that
+# every EventSource entry already expects.
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: home-rss-github-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: credential
+      remoteRef:
+        key: home-rss-github-webhook
+        property: password


### PR DESCRIPTION
[#526](https://github.com/Tsuguya/home-cluster/pull/526) で 4/7 リポだけ配線していた残りを埋める。

## GitHub 側（実施済み）

| リポ | 変更 |
|---|---|
| `home-rss` | webhook 新規作成（`pull_request`）|
| `home-actions` | webhook 新規作成（`pull_request`）|
| `home-trading` | 既存 webhook に `pull_request` を追加 |

これで7リポすべてが `pull_request` を配信する。

```
home-cluster     renovate-home-cluster:[issues,pull_request,push]
home-infra       renovate-home-infra:[issues,pull_request,push]
home-cloudflare  renovate-home-cloudflare:[issues,pull_request,push]
home-harbor      harbor:[pull_request,push]
home-rss         home-rss:[pull_request]
home-actions     home-actions:[pull_request]
home-trading     home-trading:[pull_request,push]
```

## 1Password のカテゴリを変えた理由

既存の webhook secret は `API Credential` カテゴリで、ESO が `dataFrom: extract` で全フィールドを取っている。しかし **`op` は Login と Password のカテゴリでしか値を生成できない**（`create` も `edit` も同じ制約）。

```
[ERROR] generating a password is only supported for Login and Password items
```

自分で生成して渡すと、値がコマンドの argv とセッションのログに残る。[[onepassword-cli]] の方針（値を手元に通さない）に反するので、**アイテムを Password カテゴリにして op に生成させ**、ExternalSecret 側でフィールドを写像した。

```yaml
  data:
    - secretKey: credential      # EventSource が期待するキー
      remoteRef:
        key: home-rss-github-webhook
        property: password       # op が生成したフィールド
```

**違いは 1Password のアイテム内で完結する。** Secret のキーは既存と同じ `credential` なので、EventSource 側は一切変わらない。

## 検証

`kubeconform` 436リソース Valid。Sensor の依存7件とトリガ7件が1対1で対応し、各トリガの `parameters` が自分の `dependencyName` を参照していることをスクリプトで確認済み。

⚠️ 実動作は Renovate が aqua パッケージを上げるまで未検証なのは #526 と同じ。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT