### PR TITLE
Let the reviewer read the check rollup

### DIFF
--- a/.github/workflows/_claude-review.yml
+++ b/.github/workflows/_claude-review.yml
@@ -43,6 +43,9 @@ jobs:
       pull-requests: write # approve and comment; and the gh pr checks call below
       issues: write # PR conversation comments go through the issues API
       id-token: write # mints the App token via OIDC; without it nothing runs at all
+      checks: read # gh pr checks below reads the rollup through GraphQL, which
+      # returns "Resource not accessible by integration" for a check the token
+      # cannot see — and one unreadable check fails the whole query
     steps:
       # Renovate rebases constantly, so the head SHA is not a stable identity
       # for "this PR was already judged" — PR #487 collected 28 approvals across

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,5 +36,7 @@ jobs:
       pull-requests: write # review, approve, comment
       issues: write # PR conversation comments
       id-token: write # claude-code-action exchanges an OIDC token
+      checks: read # the reusable workflow reads the check rollup; a caller
+      # cannot grant less than the callee asks for
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
レビュアーの待機ステップが落ちていた。home-cloudflare#28 の実ログ:

```
##[error]gh pr checks failed: GraphQL: Resource not accessible by integration
                              (node.statusCheckRollup.nodes.0...)
```

## 原因

`gh pr checks` は GraphQL の `statusCheckRollup` を辿る。**トークンが読めないチェックが1つでもあるとクエリ全体が失敗する**（そのチェックだけ省かれるのではない）。job の `permissions` に `checks: read` が無かった。

callee と caller の**両方**に足す必要がある。呼び出し側は呼び先が要求するスコープを下回れないため。

## 却下したのは私の判断ミス

`gha-review` の correctness レビュアーが**まさにこれを指摘していた**。私は「実 run で `gh pr checks` が動いているのを確認した」として誤検知に分類した。

その観察が示していたのは「**その run の rollup に含まれるチェックがたまたま全部読めた**」ことだけで、権限が足りていることではなかった。

## 新しい壊れ方ではない

旧実装は `|| true` でこのエラーを握り潰し、「まだゲートが無い」と解釈して20分待ってから `Timed out waiting for CI Gate` を出していた。**原因を誤って名指しする**、まさに直そうとしていた症状そのもの。今回の変更で本当の原因が表に出たので発見できた。

## 検証

5リポとも `actionlint` clean / `zizmor` pedantic clean（memory の8件は今回と無関係な既存分）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT
