### PR TITLE
Rebuild an image when anything it is built from changes

### DIFF
--- a/manifests/argo/images-sensor.yaml
+++ b/manifests/argo/images-sensor.yaml
@@ -37,7 +37,11 @@ spec:
           for _, c in ipairs(event.body.commits) do
             for _, list in ipairs({c.added or {}, c.modified or {}, c.removed or {}}) do
               for _, f in ipairs(list) do
-                if string.find(f, "Dockerfile", 1, true) then
+                -- any file inside a subdirectory, not just a Dockerfile: the
+                -- scripts COPYed into an image live beside it, and matching
+                -- only Dockerfile meant changing one never rebuilt anything.
+                -- detect-changes decides which of those are image directories.
+                if string.find(f, "/", 1, true) then
                   return true
                 end
               end

--- a/manifests/image-build/workflowtemplate.yaml
+++ b/manifests/image-build/workflowtemplate.yaml
@@ -99,10 +99,19 @@ spec:
             cd /tmp
             git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/images.git" repo
             cd repo
+            # Every directory that holds a Dockerfile is an image.
+            find . -name Dockerfile -not -path './.git/*' \
+              | sed 's|^./||;s|/Dockerfile$||' | sort -u > /tmp/image-dirs
             if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-              find . -name Dockerfile -not -path './.git/*' | sed 's|^./||;s|/Dockerfile$||' | sort -u
+              cat /tmp/image-dirs
             else
-              git diff --name-only "$BEFORE".."$AFTER" -- '*/Dockerfile' | sed 's|/Dockerfile$||' | sort -u
+              # Any file in one of those directories, not just its Dockerfile.
+              # github-auth.sh and github-signed-commit.sh are COPYed into
+              # argo-tools, so matching only */Dockerfile left the published
+              # image stale against its own sources with nothing to show for it.
+              git diff --name-only "$BEFORE".."$AFTER" \
+                | awk -F/ 'NF > 1 { print $1 }' | sort -u \
+                | while read -r d; do grep -qxF "$d" /tmp/image-dirs && echo "$d"; done
             fi | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "\"%s\"",$0} END{print "]"}' > /tmp/changed-dirs
         env:
           - name: BEFORE


### PR DESCRIPTION
[images#28](https://github.com/Tsuguya/images/pull/28)（`github-signed-commit.sh` の修正）をマージしても**イメージがリビルドされなかった**。

## 原因

sensor のフィルタと `detect-changes` の両方が **`Dockerfile` を含むパスしか見ていない**。

```lua
if string.find(f, "Dockerfile", 1, true) then return true end
```
```sh
git diff --name-only "$BEFORE".."$AFTER" -- '*/Dockerfile'
```

`argo-tools/Dockerfile` は

```dockerfile
COPY --chmod=755 github-auth.sh github-signed-commit.sh /usr/local/bin/
```

としてスクリプトを取り込むのに、**そのスクリプトを変えてもビルドが走らない**。公開イメージが自分のソースに対して古いまま、しかも**それを示すものが何も出ない**。

## 変更

- **sensor**: サブディレクトリ内の任意ファイルで発火（粗いフィルタのまま、判定は下流に委ねる）
- **detect-changes**: 変更されたトップレベルディレクトリと「Dockerfile を持つディレクトリ」の積集合を取る

## 検証

壊れていたケースと、壊してはいけないケースの両方を実際に流して確認した。

```
argo-tools/github-signed-commit.sh    -> ["argo-tools"]     ← 今回のケース
argo-tools/Dockerfile                 -> ["argo-tools"]     ← 従来も維持
argo-tools/x.sh + claude-code/Docker… -> ["argo-tools","claude-code"]
renovate.json                         -> []
.github/workflows/lint.yaml           -> []
```

## この後

マージ後、`argo-tools` を手動で1回リビルドして修正版スクリプトを反映させる（#28 の push は既に過ぎているため）。その digest を使って `aqua-checksum` 側の残り2件（`safe.directory`、onExit 通知の CNP）とまとめて入れる。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT