### PR TITLE
Make the aqua-checksum workflow actually commit

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -130,7 +130,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **kanidm-backup** (kanidm-backup=true) | (deny world) | kube-apiserver, *.r2.cloudflarestorage.com:443, seaweedfs-filer (seaweedfs):8333 |
 | **kanidm-repl-exchange** (kanidm-repl-exchange=true) | (deny world) | kube-apiserver, seaweedfs-filer (seaweedfs):8333 |
 | **image-digest-audit** (image-digest-audit=true) | (none) | harbor-nginx (harbor):8443 |
-| **aqua-checksum** (aqua-checksum=true) | (deny world) | github.com + api.github.com + *.githubusercontent.com :443 |
+| **aqua-checksum** (aqua-checksum=true) | (deny world) | github.com + api.github.com + *.githubusercontent.com + discord.com :443 |
 | **renovate** (renovate=true) | (none) | harbor-nginx (harbor):8443 |
 | **tofu-harbor** (tofu-harbor=true) | (none) | harbor-nginx (harbor):8443 |
 

--- a/manifests/argo/aqua-checksum.yaml
+++ b/manifests/argo/aqua-checksum.yaml
@@ -68,7 +68,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:2b553887ff8c4ecfae6af8c0b37ac29c5d2c0bf49e26f6536ef0c56d7238bc3b
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:b7d1229a8b93c40b7cf10e760b0b113d826febdea2004e59911224262954c719
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -94,7 +94,7 @@ spec:
             limits:
               memory: 64Mi
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:2b553887ff8c4ecfae6af8c0b37ac29c5d2c0bf49e26f6536ef0c56d7238bc3b
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:b7d1229a8b93c40b7cf10e760b0b113d826febdea2004e59911224262954c719
         command: [sh, -c]
         args:
           - |
@@ -137,6 +137,17 @@ spec:
           # aqua writes its package tree under HOME; the image's user cannot
           # write to the default one.
           - name: HOME
+            value: /workspace
+          # The clone is owned by a different uid than the one git runs as, so
+          # every git call in this step and inside github-signed-commit.sh dies
+          # with "detected dubious ownership". Passed as environment rather than
+          # `git config --global`, which would land a .gitconfig inside the
+          # clone because HOME points at it.
+          - name: GIT_CONFIG_COUNT
+            value: "1"
+          - name: GIT_CONFIG_KEY_0
+            value: safe.directory
+          - name: GIT_CONFIG_VALUE_0
             value: /workspace
         volumeMounts:
           - name: workspace

--- a/manifests/argo/netpol-aqua-checksum.yaml
+++ b/manifests/argo/netpol-aqua-checksum.yaml
@@ -16,6 +16,10 @@ spec:
         - matchName: "github.com"
         - matchName: "api.github.com"
         - matchPattern: "*.githubusercontent.com"
+        # podMetadata.labels lands on the onExit pod too, so the Discord notify
+        # that every workflow runs is selected by this policy rather than by
+        # netpol-workflow-pods' blanket 443 — and without this it times out.
+        - matchName: "discord.com"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
`home-trading#16`（`kubeconform v0.7.0 → v0.8.0`、開いた時から赤）に対して実際に流し、出てきた3件を直す。

## 1. イメージ digest 更新 — ref エンドポイント修正版

`github-signed-commit.sh` が **読み取り専用の `/git/ref/`** に PATCH していた。blob・tree・commit を全部作った後に 404 で死ぬ。`curl -sf` は 404 を **exit 22 に変換して stderr に何も出さない**ので、「コミットは存在するがブランチが動かない」という形になっていた。修正は [images#28](https://github.com/Tsuguya/images/pull/28)。

## 2. `git` の safe.directory

clone の所有者と git の実行 uid が違うため、**aqua がファイルを書いた後の `git add`** が落ちていた。

```
fatal: detected dubious ownership in repository at '/workspace'
```

`git config --global` ではなく env で渡す。`HOME=/workspace` なので `--global` だと clone の中に `.gitconfig` が落ちるため。env なら `github-signed-commit.sh` 内部の git 呼び出しにも効く。

## 3. CNP に `discord.com`

`podMetadata.labels` は **onExit Pod にも付く**。全ワークフロー共通の Discord 通知ステップが、`netpol-workflow-pods` の広い 443 ではなくこのポリシーに拾われてタイムアウトしていた。

```
wget: can't connect to remote host (162.159.135.232): Operation timed out
```

## 実地検証（commit 前に実施）

```
Signed commit created: d8f0c60
7e27ec0..d8f0c60  renovate/yannh-kubeconform-0.x -> origin/...

commit d8f0c60   verified=true  reason=valid  author=tsuguya-home-cluster[bot]
CI  00:17:26  d8f0c607  queued        ← App の push で再発火
home-trading#16: 全チェック緑、mergeState=CLEAN
files: aqua-checksums.json, aqua.yaml
```

**最後の行が設計の要**。`GITHUB_TOKEN` の push はワークフローを再発火しないが、App トークンのコミットは再発火する — この前提に実測が付いた。

## 検証

`kubeconform` 436リソース Valid。`docs/network-policies.md` も更新。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT