### PR TITLE
Start Renovate from home-trading's webhook too

### DIFF
--- a/manifests/argo/renovate-webhook-sensor.yaml
+++ b/manifests/argo/renovate-webhook-sensor.yaml
@@ -78,6 +78,14 @@ spec:
       eventName: renovate-home-cloudflare
       filters:
         script: *renovateFilter
+    # Reuses the endpoint the build and aqua-checksum sensors already consume,
+    # rather than a renovate-* one of its own: the webhook and its secret exist,
+    # and one more consumer of the same event costs nothing.
+    - name: home-trading
+      eventSourceName: github-webhook
+      eventName: home-trading
+      filters:
+        script: *renovateFilter
   triggers:
     - template:
         name: renovate-home-cluster
@@ -136,3 +144,22 @@ spec:
                   parameters:
                     - name: repositories
                       value: '["Tsuguya/home-cloudflare"]'
+    - template:
+        name: renovate-home-trading
+        conditions: "home-trading"
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: renovate-home-trading-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: renovate
+                arguments:
+                  parameters:
+                    - name: repositories
+                      value: '["Tsuguya/home-trading"]'

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -126,6 +126,10 @@ spec:
         # pull_request is here for aqua-checksum, which needs the head branch of
         # a Renovate PR; the existing push consumer ignores it.
         - pull_request
+        # issues is here for renovate-webhook: ticking a box on the Dependency
+        # Dashboard arrives as an issue body edit, and without it the only way
+        # to start a run is to wait out the four-hour cron.
+        - issues
       webhookSecret:
         name: home-trading-github-webhook
         key: credential


### PR DESCRIPTION
セルフホスト対象4リポのうち、**home-trading だけ renovate webhook が無かった**。

```
セルフホスト        home-cluster / home-infra / home-cloudflare / home-trading
renovate 依存        home-cluster / home-infra / home-cloudflare
                                                    ↑ home-trading だけ欠落
```

Dependency Dashboard のチェックボックスを押しても**4時間の cron を待つ**しかない状態だった（他3リポは即座に反応する）。

## 新しい webhook も secret も作っていない

`/home-trading` エンドポイントは既に build sensor と aqua-checksum sensor が使っている。**同じイベントの消費者が1つ増えるだけ**なので、同一リポに2つ目の secret を 1Password に置く必要がない。

- GitHub 側の webhook events: `push, pull_request` → **`+ issues`**（チェックボックスは issue の body 編集として届く）
- EventSource の entry に `issues` を追加
- `renovate-webhook` センサーに依存とトリガを追加（フィルタは他3リポと共有のアンカー `*renovateFilter`）

## Cloud 側の6リポは対象外

`home-harbor` / `memory` / `images` / `home-rss` / `home-actions` / `talos-custom-build` は **Renovate Cloud で足りるという判断で意図的に分けている**もの。Mend 側が自前で webhook を持つので、クラスタ側の整備は無関係。

## 検証

`kubeconform` 436リソース Valid。GitHub 側の webhook 更新も適用済み（`pull_request,push,issues`）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo3gy2BqoyqCRVuJPbxFkT