### PR TITLE
ci: validate the Renovate config on every PR

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -410,9 +410,17 @@ jobs:
     uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@3064ee406bba7318e489e8d2d1af270e943fdd50 # v0
     permissions:
       contents: read
+
+  # Renovate 設定の検証。Renovate は知らないキーを黙って捨てるので（PR も警告も
+  # 出ない）、バリデータだけがこの層の間違いを検出できる。home-cluster は
+  # `ignoredAuthors` の綴り違いを 5 週間放置していた。
+  lint-renovate:
+    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@2e7f65a9ac3492f91652e2cbd4e267202b5dabfd # v0
+    permissions:
+      contents: read
   gate:
     name: CI Gate
-    needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, lint-workflows]
+    needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, lint-workflows, lint-renovate]
     # `!cancelled()` rather than `always()`: under always(), cancelling a run
     # leaves every leaf reporting `cancelled`, which falls through the case
     # below and records the required check as a failure. A cancelled run has no


### PR DESCRIPTION
## What

Calls the `lint-renovate` reusable workflow added in [home-actions#7](https://github.com/Tsuguya/home-actions/pull/7), and adds it to the `CI Gate` needs.

## Why

Nothing in CI has ever looked at the Renovate config, and Renovate **silently discards keys it does not recognise** — no PR, no warning, nothing a human sees. Two real cases found while auditing all 13 repositories:

- `home-cluster` carried `ignoredAuthors` for five weeks. The real option is `gitIgnoredAuthors`; the setting was doing nothing, so bot commits kept reading as human edits and Renovate stopped updating those branches.
- `images` shipped two custom managers with double-escaped regexes (`\\\\S+`), which match a literal backslash and therefore no Dockerfile at all. `crane` and `container-structure-test` were unmaintained pins.

Only `renovate-config-validator` detects either.

## --strict

Fails on a needed migration as well as on errors. `:configMigration` opens a PR that **rewrites the config file**, so letting deprecated spellings accumulate means it eventually reflows a hand-formatted, commented file. Failing on them keeps the file already-migrated.