### PR TITLE
fix(renovate): stop age-gating updates the gate cannot evaluate

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -151,6 +151,27 @@
   "packageRules": [
     {
       "description": [
+        "First-party code does not soak. minimumReleaseAge buys time for someone",
+        "else to notice a poisoned release before we take it; there is no someone",
+        "else here — we wrote it, reviewed it and merged it. Waiting three days on",
+        "our own reusable workflow only delays fixes to the thing that gates every",
+        "other check."
+      ],
+      "matchPackageNames": ["Tsuguya/**"],
+      "minimumReleaseAge": "0"
+    },
+    {
+      "description": [
+        "Lock file maintenance refreshes transitive versions; there is no single",
+        "release to age, so the gate can never be satisfied. horenso#66 was stuck",
+        "pending on it with automerge enabled, which means it would never have",
+        "merged at all. The resolution-time cooldown in .npmrc is what soaks these."
+      ],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": "0"
+    },
+    {
+      "description": [
         "Automerge patch updates. pinDigest is here because pinning changes nothing",
         "that runs — it writes down the digest the registry already resolves the tag",
         "to — and leaving those PRs for a human is what leaves a new service unpinned",


### PR DESCRIPTION
## The bug

Two PRs in horenso are not slow — they are **structurally unmergeable**:

| PR | | |
|---|---|---|
| [#22](https://github.com/Tsuguya/horenso/pull/22) | Pin Node.js to c610fcd | `renovate/stability-days=PENDING` for **84 days** |
| [#66](https://github.com/Tsuguya/horenso/pull/66) | Lock file maintenance | same, and it has `automerge: true` |

Neither can ever clear:

- A **digest** carries no release date ([renovate#38656](https://github.com/renovatebot/renovate/issues/38656)), so `minimumReleaseAge` cannot be evaluated. Renovate sets `renovate/stability-days` and never satisfies it.
- **Lock file maintenance** refreshes transitive versions. There is no single release to age, so the same thing happens — and with automerge on, that PR would never have merged at all.

`home-cluster` already carried the digest escape, with a comment saying exactly this. The other repositories did not, so the workaround only ever protected one repo.

## First-party updates

`minimumReleaseAge` buys time for **someone else** to notice a poisoned release before we take it. There is no someone else for `Tsuguya/*` — we wrote it, reviewed it and merged it. A three-day wait on our own reusable workflow only delays fixes to the thing that gates every other check.

## Verified, not assumed

Ran a local extract rather than guessing at the match target:

```
$ renovate --platform=local --dry-run=extract
"depName": "Tsuguya/home-actions"
```

Plain `owner/repo`, which `Tsuguya/**` covers.

Config validated with `renovate-config-validator --strict` 44.31.0.
