### PR TITLE
chore(renovate): adopt config:best-practices

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -4,10 +4,24 @@
   // The aqua preset is pinned rather than floating: it owns which files the aqua
   // manager reads, and a preset-side change would silently re-scope this repo.
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests",
+    // config:best-practices = config:recommended + docker:pinDigests
+    // + helpers:pinGitHubActionDigests + :configMigration + :pinDevDependencies
+    // + abandonments:recommended + security:minimumReleaseAgeNpm
+    // + :maintainLockFilesWeekly. The two presets listed separately before are
+    // both inside it now.
+    "config:best-practices",
     "github>aquaproj/aqua-renovate-config#2.13.0"
   ],
+
+  // docker:pinDigests now covers every image, which replaces the two scoped pin
+  // rules this file used to carry. Keeping the reason they existed: pinning our
+  // own registry.infra.tgy.io images is not a supply-chain measure — they are our
+  // builds, which is why digest-cooldown skips them — it is availability. Harbor
+  // retention deletes artifacts and Kyverno's mutateDigest bakes the resolved
+  // digest into every Pod at admission, so an unpinned :latest is a Pod that
+  // pulls fine today and cannot restart once its artifact ages out, with no way
+  // to roll forward either, since verifyDigest rejects a digest-less Deployment
+  // update. memory died exactly that way on 2026-08-19.
 
   // Queue the merge on GitHub's side so branch protection still runs; Renovate
   // never merges locally past a required check.
@@ -151,6 +165,19 @@
   "packageRules": [
     {
       "description": [
+        "docker:pinDigests, which arrives with config:best-practices, reaches ArgoCD",
+        "Applications too. apps/spin-operator.yaml is the one OCI Helm chart here —",
+        "repoURL ghcr.io/spinframework/charts, targetRevision \"0.6.1\" — and Renovate",
+        "sees it on the docker datasource like any image. Pinning would rewrite that",
+        "into 0.6.1@sha256:..., but the field is a chart version, not an image",
+        "reference. Every other Application uses an https:// chart repo, which the",
+        "docker datasource never touches."
+      ],
+      "matchManagers": ["argocd"],
+      "pinDigests": false
+    },
+    {
+      "description": [
         "First-party code does not soak. minimumReleaseAge buys time for someone",
         "else to notice a poisoned release before we take it; there is no someone",
         "else here — we wrote it, reviewed it and merged it. Waiting three days on",
@@ -251,26 +278,6 @@
       "matchManagers": ["github-actions"],
       "matchDepNames": ["Tsuguya/home-cluster"],
       "enabled": false
-    },
-    {
-      "description": "Pin external image digests in build pipelines (gated by digest-cooldown workflow)",
-      "matchFileNames": ["manifests/image-build/**", "manifests/talos-build/**"],
-      "matchDatasources": ["docker"],
-      "pinDigests": true
-    },
-    {
-      "description": [
-        "Pin first-party digests too. Not for supply chain — these are our own builds,",
-        "which is why digest-cooldown skips them — but for availability: Harbor",
-        "retention deletes artifacts, and Kyverno's mutateDigest bakes the resolved",
-        "digest into every Pod at admission. An unpinned :latest is a Pod that pulls",
-        "fine today and cannot restart once its artifact ages out, with no way to roll",
-        "it forward either, since verifyDigest rejects a digest-less Deployment update.",
-        "memory died exactly that way on 2026-08-19. Pinning also makes it knowable",
-        "from git which tools image a Workflow actually ran."
-      ],
-      "matchPackageNames": ["registry.infra.tgy.io/**"],
-      "pinDigests": true
     },
     {
       "description": [


### PR DESCRIPTION
## What

`config:recommended` + `helpers:pinGitHubActionDigests` → **`config:best-practices`**. Both of the old presets are inside it.

What it actually adds beyond what was already configured:

| preset | effect here |
|---|---|
| `docker:pinDigests` | pin every image by digest — **the real change**, measured below |
| `:configMigration` | opens a PR when a spelling goes deprecated |
| `:pinDevDependencies` | exact devDependency pins (npm/pnpm repos) |
| `abandonments:recommended` | flags deps with no release in a year |
| `security:minimumReleaseAgeNpm` | redundant, the 3-day baseline already covers it |
| `:maintainLockFilesWeekly` | overridden by the explicit `lockFileMaintenance` block where one exists |

## Pinning impact, measured

Ran a local extract rather than guessing:

```
$ renovate --platform=local --dry-run=extract     # home-cluster
docker references: 116   already pinned: 86   newly pinned: 30   (14 distinct images)
```

The 30 are `alpine`, `alpine/git`, `ghcr.io/opentofu/opentofu`, `cloudflare/cloudflared`, `kanidm/server`, `seaweedfs`, `dbmate`, `suse/kubectl`, `pluto`, the three `qnapsystem/*`, and `spin-operator`. All flow through the existing digest-cooldown gate and the patch/digest automerge rule, so the human cost is nil.

`ghcr.io/tsuguya/imager` shows `currentValue: undefined` — its tag is `{{inputs.parameters.version}}` — so pinning is a no-op there.

## The measurement found a case where blanket pinning is wrong

`apps/spin-operator.yaml` is the **only OCI Helm chart** in the tree:

```yaml
- repoURL: ghcr.io/spinframework/charts
  chart: spin-operator
  targetRevision: "0.6.1"
```

Renovate sees it on the `docker` datasource like any image, so `docker:pinDigests` would rewrite it to `0.6.1@sha256:...` — but that field is a **chart version**, not an image reference. The `argocd` manager is excluded for exactly that. Every other Application uses an `https://` chart repo, which the docker datasource never touches.

Confirmed the exclusion targets the right manager: `apps/*.yaml` is read by the `argocd` manager, since `kubernetes` is scoped to `manifests/` and `kustomize/` in this config.

## Cleanup

With pinning global, two scoped pin rules here are dead weight and are removed. The reason they existed is kept as a comment — pinning our own `registry.infra.tgy.io` images is **availability, not supply chain**: Harbor retention deletes artifacts and Kyverno's `mutateDigest` bakes the resolved digest into every Pod at admission, which is how `memory` died on 2026-08-19.

Same for the explicit `matchCategories: ["docker"], pinDigests: true` rules in horenso / memory / images — now provided by the preset.

## home-trading

Gains the 3-day baseline the other twelve already had. It was the only repository automerging `pin` / `digest` / `patch` / `minor` with **no soak interval at all**.

## Validation

`renovate-config-validator --strict` 44.31.0 clean on all 13, no migration warnings.
