### PR TITLE
ci: repin home-actions to the tagged v1.0.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -407,7 +407,7 @@ jobs:
   # ワークフローの lint は 6 リポジトリ共通なので home-actions に寄せてある。
   # ツールのピンは向こう側にあり、ここは呼び先の SHA を追うだけ。
   lint-workflows:
-    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@3064ee406bba7318e489e8d2d1af270e943fdd50 # v0
+    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@876259d7c298c76ff25ee2b5ee2ac4de89b28f52 # v1.0.0
     permissions:
       contents: read
 
@@ -415,7 +415,7 @@ jobs:
   # 出ない）、バリデータだけがこの層の間違いを検出できる。home-cluster は
   # `ignoredAuthors` の綴り違いを 5 週間放置していた。
   lint-renovate:
-    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@2e7f65a9ac3492f91652e2cbd4e267202b5dabfd # v0
+    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@876259d7c298c76ff25ee2b5ee2ac4de89b28f52 # v1.0.0
     permissions:
       contents: read
   gate:


### PR DESCRIPTION
## The bug

`home-actions` had **no tags and no releases**. Every consumer pinned it as `@<sha> # v0`, and that `v0` pointed at nothing, so Renovate's `helpers:pinGitHubActionDigests` could never resolve it:

```
⚠️ Renovate failed to look up the following dependencies:
   Could not determine new digest for update (github-tags package Tsuguya/home-actions)
```

That surfaced only as a warning buried in the Dependency Dashboard, so nobody saw it. **Every pin bump in these repositories was made by hand** — and the pins had already drifted two commits behind `main`.

A repository whose stated reason to exist is that *pins drift when nobody owns them* had exactly that problem for its own consumers.

## The fix

[home-actions v1.0.0](https://github.com/Tsuguya/home-actions/releases/tag/v1.0.0) tagged at `876259d`, and all 18 pins across 12 repositories repinned to it.

Verified the lookup actually works now rather than assuming:

```
$ renovate --platform=local --dry-run=lookup
"depName": "Tsuguya/home-actions",
"replaceString": "...lint-renovate.yml@876259d7... # v1.0.0",
"packageName": "Tsuguya/home-actions"
→ no lookup failures
```

## Comment format

Full patch version, matching what is already there:

| format | count |
|---|---|
| `# vX.Y.Z` | 106 |
| `# stable` | 1 (dtolnay/rust-toolchain — intentional, that action publishes no tags) |
| `# vX` | 0 |

Also matches the decision recorded in `talos-custom-build` `20f264f` — *"name the patch version in action pins, not the major tag"*. `# v0` was the one outlier.

**No moving `v1` tag.** Every consumer pins by SHA, so nothing would ever read `@v1`, and a mutable tag is a supply-chain liability with no reader.

## Checked

`actionlint` clean. `zizmor --persona=pedantic` run **online** against both the branch and `main` in every repository — finding sets identical, so this change introduces none.
