### PR TITLE
ci: repin home-actions to v1.1.0 and stop pinning actionlint here

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -407,7 +407,7 @@ jobs:
   # ワークフローの lint は 6 リポジトリ共通なので home-actions に寄せてある。
   # ツールのピンは向こう側にあり、ここは呼び先の SHA を追うだけ。
   lint-workflows:
-    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@876259d7c298c76ff25ee2b5ee2ac4de89b28f52 # v1.0.0
+    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@bd99e01e99bcce1b845aa7abae3b3ed3b61f464f # v1.1.0
     permissions:
       contents: read
 
@@ -415,7 +415,7 @@ jobs:
   # 出ない）、バリデータだけがこの層の間違いを検出できる。home-cluster は
   # `ignoredAuthors` の綴り違いを 5 週間放置していた。
   lint-renovate:
-    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@876259d7c298c76ff25ee2b5ee2ac4de89b28f52 # v1.0.0
+    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@bd99e01e99bcce1b845aa7abae3b3ed3b61f464f # v1.1.0
     permissions:
       contents: read
   gate:

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -11,11 +11,6 @@
       "algorithm": "sha512"
     },
     {
-      "id": "github_release/github.com/rhysd/actionlint/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz",
-      "checksum": "8ACA8DB96F1B94770F1B0D72B6DDDCB1EBB8123CB3712530B08CC387B349A3D8",
-      "algorithm": "sha256"
-    },
-    {
       "id": "github_release/github.com/yannh/kubeconform/v0.8.0/kubeconform-linux-amd64.tar.gz",
       "checksum": "9BC2BFFBF71F261128533EDAF912153948B7FF238F9A531AE6D34466EC287883",
       "algorithm": "sha256"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -28,4 +28,3 @@ packages:
   - name: mikefarah/yq@v4.53.3
   # provides `crane`
   - name: google/go-containerregistry@v0.21.9
-  - name: rhysd/actionlint@v1.7.12


### PR DESCRIPTION
## What

Repins to [home-actions v1.1.0](https://github.com/Tsuguya/home-actions/releases/tag/v1.1.0), which resolves `actionlint`'s pin from its own repository instead of from the caller. It sparse-checks-out its `aqua.yaml` at `job.workflow_sha` and points `AQUA_CONFIG` at it, so the workflow and the tool it runs are frozen at the same commit as the SHA pinned here.

The copy of that pin carried in this repository now has no reader, so it goes.

## Verified, not assumed

home-actions' own CI **cannot** prove this works: it lints itself, so an `aqua.yaml` sits at the root of the caller checkout either way — the sparse-checkout could be inert and the job would still go green.

`talos-custom-build` has no `aqua.yaml` at all, so it was repinned first with its config deleted ([#21](https://github.com/Tsuguya/talos-custom-build/pull/21)). Its log:

```
呼び出し側リポに aqua ファイル: なし
AQUA_CONFIG: _tooling/aqua.yaml
[INFO] aqua is installed into /home/runner/.local/share/aquaproj-aqua/bin/aqua
actionlint -no-color        → lint-workflows / actionlint -> success
```

`AQUA_CONFIG` supplied the tool. Only then was this rolled out.

## Checksums

`aqua update-checksum` adds entries but leaves stale ones behind — the removed `actionlint` entry survived the first pass. Re-run with `--prune`, confirmed zero `rhysd/actionlint` entries remain and `aqua i -l` still resolves.
