### PR TITLE
fix(trivy): put scanJobsConcurrentLimit where the chart reads it

### DIFF
--- a/helm-values/trivy-operator/values.yaml
+++ b/helm-values/trivy-operator/values.yaml
@@ -4,6 +4,15 @@ operator:
   # ClusterVulnerabilityReport も併せて無効になるが、workload 単位の
   # VulnerabilityReport は影響なし。SBOM が必要なら Harbor 側で保管する
   sbomGenerationEnabled: false
+  # チャートが読むのはここ。以前はトップレベルに書かれていて黙って無視され、
+  # 既定の 10 で動いていた（2026-08-22 に wn-03 の NVMe が飽和して発覚。
+  # Renovate の Argo Workflow Pod が大量に立ち、その 1.96GB のイメージを
+  # 同時 7 本がスキャンのために引いていた）。
+  #
+  #   $ helm template ... -f helm-values/trivy-operator/values.yaml \
+  #       | grep OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
+  #   OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "10"   ← 3 が届いていなかった
+  scanJobsConcurrentLimit: 3
 
 resources:
   requests:
@@ -12,7 +21,6 @@ resources:
   limits:
     memory: 768Mi
 
-scanJobsConcurrentLimit: 3
 
 trivy:
   ignoreUnfixed: true


### PR DESCRIPTION
## The bug

`scanJobsConcurrentLimit: 3` sat at the **top level** of `values.yaml`, but the chart reads `operator.scanJobsConcurrentLimit`. Helm ignores unknown top-level keys silently, so the intended limit never applied and the operator ran on the chart default of **10**.

Rendering the chart against our own values file shows it:

```
$ helm template t aqua/trivy-operator --version 0.35.0 \
    -f helm-values/trivy-operator/values.yaml \
    | grep OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "10"
```

The deployed operator carries no such env var at all — the same thing from the other side. After the fix it renders `"3"`.

This is the same shape as `ignoredAuthors` in `renovate.jsonc`: a key in the wrong place, silently dropped, no warning anywhere.

## How it surfaced

`NodeDiskIOSaturation` on **wn-03** (`nvme0n1`, `dm-1`) from 02:58 UTC.

Merging today's PRs fired the Renovate webhook sensors, which start an Argo Workflow per repository. `trivy-operator` scans every new pod, and `ghcr.io/renovatebot/renovate` is **1.96 GB**. Seven scan jobs were active simultaneously, all pulling it — on the node that also hosts the `harbor-registry` that serves those blobs and is currently crashlooping (339 restarts, [task #433](https://horenso.infra.tgy.io)).

Scan targets confirmed from the pod labels:

```
renovate-home-cloudflare   renovate-home-cluster ×2   renovate-home-infra
renovate-home-trading      renovate-periodic-1787367600
```

## Checked the rest of the file too

Rather than assuming this was the only misplaced key, every setting was verified against the rendered output:

| setting | reaches the chart |
|---|---|
| `resources` limits 768Mi | yes |
| `trivy.ignoreUnfixed` | yes |
| `trivy` cache backend memory | yes |
| `serviceMonitor` | yes |
| `nodeCollector` tolerations | yes |
| `operator.sbomGenerationEnabled` | yes |

Only `scanJobsConcurrentLimit` was wrong.

## Note

This lowers concurrency; it does not remove the underlying load. Today's Renovate changes make digest updates flow faster, so the burst pattern will recur — the two `Pin dependencies` batches still queued will change 30 references across 14 images in one go.