### PR TITLE
feat(digest-cooldown): wire up the bypass label

### DIFF
--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -50,3 +50,22 @@ jobs:
           # Report success on PRs with nothing to gate so this status can be a
           # required check without deadlocking unrelated PRs.
           always-report: true
+          # Escape hatch. Not a security boundary — anyone who can label a PR
+          # can use it — but an auditable one: exactly one label designates a
+          # bypass, so a label search finds every PR that took it, and each use
+          # is logged as a notice in the run.
+          #
+          # The case it exists for is a pin whose digest is already what the
+          # tag resolves to. Pinning it records what every new pull would fetch
+          # anyway, so waiting out the cooldown buys nothing: the exposure is
+          # identical pinned or not. A digest *bump* is the opposite and should
+          # keep soaking.
+          #
+          # First-seen instants are never reset, so removing the label resumes
+          # the original cooldown rather than restarting it. The triggers above
+          # already include labeled/unlabeled, which is what makes the status
+          # re-evaluate when the label goes on or off.
+          #
+          # bypass-requires-status is deliberately left unset: it gates the
+          # bypass on a provenance-verify status, and nothing here posts one.
+          bypass-label: digest-cooldown-bypass


### PR DESCRIPTION
## What

Passes `bypass-label: digest-cooldown-bypass` to the digest-cooldown action.

The action has supported this since v1.0.0 ([action.yml#L108](https://github.com/Tsuguya/digest-cooldown/blob/main/action.yml#L108)) and the triggers here already include `labeled` / `unlabeled` — the documented prerequisite. The input was simply never passed, so no label did anything and the only way past the required status was an admin override, which leaves no trace tied to the PR.

## Why now

`#542 Pin dependencies` is blocked for 3 days on 8 external digests, and #487 has been blocked since 08-17.

For a **pin**, the cooldown buys nothing. Renovate writes down the digest the tag *already resolves to*, so every new pull fetches that image whether it is pinned or not — the exposure is identical either way. `renovate.jsonc` already says as much about automerge:

> pinDigest is here because pinning changes nothing that runs — it writes down the digest the registry already resolves the tag to

A digest **bump** is the opposite case and keeps soaking.

## Not a security boundary, but auditable

Anyone who can label a PR can use it. The difference from an admin merge is traceability: exactly one label designates a bypass, so a label search finds every PR that took one, and each use is logged as a notice in the run. First-seen instants are never reset, so removing the label resumes the original cooldown rather than restarting it.

`bypass-requires-status` is left unset deliberately — it gates the bypass on a `provenance-verify` status, and nothing here posts one, so setting it would make the label inert.

## Verified before writing this

The pinned action SHA (`8cef1af`, v1.0.0) does carry the input — checked the file at that revision, and its input list is byte-identical to `main`. No pin bump needed.