### PR TITLE
fix(renovate): hold talos-extensions to a weekly window

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -251,11 +251,30 @@
       ]
     },
     {
-      "description": "Group Talos system extensions",
+      "description": [
+        "Group Talos system extensions. siderolabs rebuilds all three under the",
+        "same version tags at once — the three digests in #487 shared a first-seen",
+        "instant to the millisecond — so they belong in one PR.",
+        "",
+        "The weekly window is what makes that PR reachable. Rebuild intervals",
+        "measured from the signature tags run 1 to 12 days, and three of the last",
+        "seven were under three days: 07-21→07-23, 08-04→08-06, 08-19→08-20. Every",
+        "rebuild re-targets the branch to a new digest, which restarts the",
+        "digest-cooldown clock, so a PR opened during a fast stretch can never",
+        "reach three days. #487 was reset twice that way — opened 08-17, first-seen",
+        "dragged to 08-20.",
+        "",
+        "updateNotScheduled is what actually holds it: schedule alone still permits",
+        "out-of-schedule updates to an existing branch. Same fix as the one on",
+        "ghcr.io/renovatebot/renovate above, for the same reason."
+      ],
       "groupName": "talos-extensions",
       // Extension versions must match the Talos release they are installed into,
-      // so this pair always moves under review, never unattended.
+      // and they are applied with a Talos upgrade rather than continuously, so
+      // there is nothing to gain from tracking them daily.
       "automerge": false,
+      "schedule": ["before 6am on monday"],
+      "updateNotScheduled": false,
       "matchPackageNames": [
         "/^ghcr.io/siderolabs/(iscsi-tools|spin|kata-containers)$/"
       ]


### PR DESCRIPTION
## The problem

siderolabs rebuilds `iscsi-tools`, `spin` and `kata-containers` **under their existing version tags**. Every rebuild re-targets the grouped branch to a new digest, which restarts the digest-cooldown clock.

`#487` is the case in point — opened **08-17**, still blocked five days later. Its state comment shows why:

```json
{"sha256:287e3cee…":"2026-08-20T16:18:41.556Z",
 "sha256:3a121a44…":"2026-08-20T16:18:41.556Z",
 "sha256:926d24df…":"2026-08-20T16:18:41.556Z"}
```

All three first-seen instants are identical to the millisecond — confirming the three are rebuilt as a set, and that the clock was reset to 08-20 rather than running from 08-17.

## Measured rebuild cadence

Read from the cosign signature tags on `siderolabs/iscsi-tools`:

| | interval |
|---|---|
| 07-17 → 07-21 | 4d |
| 07-21 → 07-23 | **2d** |
| 07-23 → 08-04 | 12d |
| 08-04 → 08-06 | **2d** |
| 08-06 → 08-14 | 8d |
| 08-14 → 08-19 | 5d |
| 08-19 → 08-20 | **1d** |

Irregular, 1–12 days, and **three of seven under the three-day cooldown**. #487 will happen to clear on 08-23 if nothing is rebuilt before then, but that is luck, not design.

## The fix

`schedule: ["before 6am on monday"]` + `updateNotScheduled: false`.

`updateNotScheduled` is the part that actually holds it — `schedule` alone still permits out-of-schedule updates to an existing branch. This is the same fix already applied to `ghcr.io/renovatebot/renovate` in this file, added there after that image sat on a stale version for six weeks for exactly this reason.

## Nothing is lost

These are `automerge: false` and are applied with a Talos upgrade rather than continuously, so there is no value in tracking them daily.