### PR TITLE
fix(harbor): stop the registry's upload purger from crashing it

### DIFF
--- a/helm-values/harbor/values.yaml
+++ b/helm-values/harbor/values.yaml
@@ -99,6 +99,28 @@ registry:
       memory: 128Mi
     limits:
       memory: 512Mi
+  # 起動から 0〜24h のジッタ後に走る upload purger が、SeaweedFS の S3 を
+  # walk する途中で必ず panic してプロセスごと落ちる:
+  #
+  #   panic: runtime error: index out of range [0] with length 0
+  #     storage.getOutstandingUploads.func1  purgeuploads.go:73
+  #     ← s3-aws.(*driver).doWalk ← ListObjectsV2Pages
+  #
+  # exit 2 で死んで再起動、またジッタ後に同じ場所で死ぬ、の繰り返しで
+  # 6日半に 339 回再起動していた。落ちるたびに registry.infra.tgy.io が
+  # 5xx を返す窓が開き、Kyverno の verify-image-signatures が digest を
+  # 解決できず Argo の Renovate ワークフローが弾かれていた。
+  #
+  # 上流のバグ（docker/distribution の S3 driver と SeaweedFS の
+  # ListObjectsV2 レスポンスの相性）なので、こちら側では purger を止める
+  # しかない。
+  #
+  # 代償として、中断したアップロードの断片が S3 の _upload/ に残り続ける。
+  # home-harbor の GC は週次で回っている（system.tf, 土 18:00）が、それが
+  # 参照されない blob ではなく _upload/ の一時ファイルまで回収するかは
+  # 未確認。溜まるようなら別途始末する必要がある。
+  upload_purging:
+    enabled: false
 
 jobservice:
   jobLoggers:


### PR DESCRIPTION
## The crash

`harbor-registry` has restarted **339 times in six and a half days**. Every cycle is identical: start, wait out a 0–24h jitter, run the upload purger, panic inside the S3 driver walking SeaweedFS.

```
panic: runtime error: index out of range [0] with length 0
  storage.getOutstandingUploads.func1   purgeuploads.go:73
  ← s3-aws.(*driver).doWalk ← ListObjectsV2PagesWithContext
```

`exit 2` → restart → repeat.

## What it broke

Each crash opens a window where `registry.infra.tgy.io` returns 5xx. That is how an Argo Renovate run died today — Kyverno's `verify-image-signatures` could not resolve a digest:

```
failed to fetch image reference: registry.infra.tgy.io/tools/argo-tools:latest,
error: GET .../manifests/latest: unexpected status code 502 Bad Gateway
```

Anything else that resolves an image through Harbor is exposed the same way.

## The fix

Upstream bug — docker/distribution's S3 driver against SeaweedFS's `ListObjectsV2` responses — so the only lever here is to stop running the purger.

Verified the values key reaches the chart rather than trusting the recommendation:

```
$ helm template h harbor/harbor --version 1.19.2 -f helm-values/harbor/values.yaml
    maintenance:
      uploadpurging:
        enabled: false
```

## The cost

Interrupted upload fragments accumulate under `_upload/` in S3. `home-harbor` runs a weekly GC (`system.tf`, Saturdays 18:00), but **whether that reclaims `_upload` staging files rather than only unreferenced blobs is unverified**. May need separate cleanup later.

## Worth noting

The periodic cluster observation has reported this in **every run since 2026-08-19** — tasks #426 through #434, restart counts 184 → 214 → 244 → 266 → 293 → 316 → 338 — each time with this same fix attached. The observation was working; nothing was acting on it.