### PR TITLE
fix(argo): let aqua-checksum pods reach the Kubernetes API

### DIFF
--- a/manifests/argo/netpol-aqua-checksum.yaml
+++ b/manifests/argo/netpol-aqua-checksum.yaml
@@ -6,12 +6,31 @@ metadata:
 # The workflow clones a branch, downloads every package aqua.yaml names so it
 # can hash them, and commits the result back through the API — so it needs
 # github.com for the clone, api.github.com for the commit, and the release
-# CDN for the artifacts themselves. Nothing else.
+# CDN for the artifacts themselves.
+#
+# It also needs the Kubernetes API, which the first version of this policy
+# missed. Argo's `wait` sidecar posts each step's outcome to
+# workflowtaskresults, and with that blocked the container retries until the
+# workflow times out — so every run since this policy was introduced failed,
+# 33 Error and 4 Failed with no successes at all. The pod never reaches the
+# service VIP either: kube-proxy replacement translates 10.96.0.1:443 to the
+# control plane's own address, which is what Hubble records being dropped.
+#
+#   argo/aqua-checksum-… <> 192.168.10.231:6443 (kube-apiserver)
+#     Policy denied DROPPED (TCP Flags: SYN)
+#
+# netpol-workflow-pods excludes these pods by label, so nothing else grants it.
 spec:
   endpointSelector:
     matchLabels:
       aqua-checksum: "true"
   egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
     - toFQDNs:
         - matchName: "github.com"
         - matchName: "api.github.com"


### PR DESCRIPTION
## The gap

The policy introduced with this workflow allowed `github.com`, `api.github.com`, the release CDN and `discord.com` — and, per its own comment, *"Nothing else."*

Argo's `wait` sidecar also posts each step's outcome to `workflowtaskresults`. With the API blocked it retries until the workflow times out.

## It never worked

Not intermittent. Measured:

| | |
|---|---|
| Workflow outcomes | **Error 33, Failed 4, Running 2, successes 0** |
| Loki, last 48h | 2246 timeout lines across **84 distinct pods** |
| First occurrence | `2026-08-20T23:25Z` — the first run after the policy landed |

```
{"level":"WARN","msg":"failed to patch task result",
 "error":"Post \"https://10.96.0.1:443/apis/argoproj.io/v1alpha1/namespaces/argo/workflowtaskresults\":
          dial tcp 10.96.0.1:443: i/o timeout"}
```

## Confirmed by the dropped flow, not inferred

```
argo/aqua-checksum-87z2z-send-… <> 192.168.10.231:6443 (kube-apiserver)
  Policy denied DROPPED (TCP Flags: SYN)
```

Note the destination: **not** the service VIP. kube-proxy replacement translates `10.96.0.1:443` to the control plane's own address before policy is evaluated, which is why the rule needs `toEntities: kube-apiserver` on `6443` rather than anything aimed at `10.96.0.1`.

`netpol-workflow-pods` excludes these pods by label (`aqua-checksum: DoesNotExist`), so nothing else was going to grant it.

## Shape

Matches how `claude-code`, `external-secrets`, `spin-operator`, `nfs-provisioner` and `trivy-node-collector` reach the API in this repository.