### PR TITLE
fix(argo): let aqua-checksum pods reach the artifact repository

### DIFF
--- a/manifests/argo/netpol-aqua-checksum.yaml
+++ b/manifests/argo/netpol-aqua-checksum.yaml
@@ -19,7 +19,18 @@ metadata:
 #   argo/aqua-checksum-… <> 192.168.10.231:6443 (kube-apiserver)
 #     Policy denied DROPPED (TCP Flags: SYN)
 #
-# netpol-workflow-pods excludes these pods by label, so nothing else grants it.
+# The artifact repository is the other one. Argo's `wait` uploads each step's
+# log to SeaweedFS, so a workflow pod needs the filer on 8333 regardless of what
+# the workflow itself talks to. Adding only the API left these pods dropping on
+# seaweedfs instead:
+#
+#   argo/aqua-checksum-6mwhw <> seaweedfs/seaweedfs-filer-…:8333
+#     Policy denied DROPPED (TCP Flags: SYN)
+#
+# netpol-workflow-pods excludes these pods by label, so nothing else grants
+# either of them. What is deliberately *not* copied from that policy: its
+# blanket toCIDR 0.0.0.0/0 on 443, which the FQDN list below replaces on
+# purpose, and Talos apid on 50000, which this workflow has no talosctl to use.
 spec:
   endpointSelector:
     matchLabels:
@@ -30,6 +41,15 @@ spec:
       toPorts:
         - ports:
             - port: "6443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: seaweedfs
+            app.kubernetes.io/component: filer
+            io.kubernetes.pod.namespace: seaweedfs
+      toPorts:
+        - ports:
+            - port: "8333"
               protocol: TCP
     - toFQDNs:
         - matchName: "github.com"


### PR DESCRIPTION
## My previous fix was incomplete

[#551](https://github.com/Tsuguya/home-cluster/pull/551) added the Kubernetes API and stopped there. It was necessary but not sufficient — with the API reachable, the pods moved straight on to the next thing the policy does not allow:

```
argo/aqua-checksum-6mwhw <> seaweedfs/seaweedfs-filer-98bdbccd5-pndtm:8333
  Policy denied DROPPED (TCP Flags: SYN)
```

Argo's `wait` container uploads each step's log to the artifact repository, so **any** workflow pod needs the SeaweedFS filer on 8333 regardless of what the workflow itself talks to. `netpol-workflow-pods` grants it to every other workflow pod; these are excluded from that policy by label, so it has to be spelled out here.

## Compared the whole policy this time

Rather than fixing one drop, waiting, and finding the next:

| `netpol-workflow-pods` grants | in `aqua-checksum`? |
|---|---|
| `toEntities: kube-apiserver` :6443 | ✅ added in #551 |
| `toEndpoints: seaweedfs filer` :8333 | ⬅ **this PR** |
| `toCIDR: 0.0.0.0/0` :443 | deliberately **not** copied — the FQDN list replaces it, which is why this policy exists separately |
| `toEntities: kube-apiserver,remote-node,host` :50000 | deliberately **not** copied — Talos apid, and this workflow has no `talosctl` to use it |

## Progress so far

The API fix did work — the `kube-apiserver` denials are gone from Hubble. The workflows still fail, now on the artifact upload instead.

Baseline remains **Error 35 / Failed 4 / successes 0**.