### PR TITLE
fix(talos-build): retry the build steps on transient ghcr.io failures

### DIFF
--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -27,7 +27,8 @@ metadata:
   name: talos-secureboot-build
   namespace: talos-build
 spec:
-  activeDeadlineSeconds: 3600
+  # ビルドテンプレートは最大3回まで再試行するので、その最悪ケースを収める
+  activeDeadlineSeconds: 7200
   synchronization:
     mutexes:
       - name: talos-secureboot-build
@@ -97,6 +98,12 @@ spec:
                   value: "{{steps.resolve-version.outputs.parameters.version}}"
 
     - name: resolve-version
+      retryStrategy:
+        limit: 3
+        retryPolicy: Always
+        backoff:
+          duration: 10s
+          factor: 2
       inputs:
         parameters:
           - name: version
@@ -146,6 +153,16 @@ spec:
             memory: 64Mi
 
     - name: build-and-push-installer
+      # ghcr.io からの extension pull が HTTP/2 PROTOCOL_ERROR で落ちることがある。
+      # ハングを 30 分で打ち切って（正常時は約 16 分）作り直す。
+      activeDeadlineSeconds: 1800
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: 1m
+          factor: 2
+          maxDuration: 5m
       inputs:
         parameters:
           - name: version
@@ -272,6 +289,16 @@ spec:
             readOnly: true
 
     - name: build-and-push-iso
+      # ghcr.io からの extension pull が HTTP/2 PROTOCOL_ERROR で落ちることがある。
+      # ハングを 30 分で打ち切って（正常時は約 16 分）作り直す。
+      activeDeadlineSeconds: 1800
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: 1m
+          factor: 2
+          maxDuration: 5m
       inputs:
         parameters:
           - name: version
@@ -441,6 +468,12 @@ spec:
             readOnly: true
 
     - name: finalize-release
+      retryStrategy:
+        limit: 3
+        retryPolicy: Always
+        backoff:
+          duration: 10s
+          factor: 2
       inputs:
         parameters:
           - name: version


### PR DESCRIPTION
## 何が起きたか

`talos-extension-rebuild-sh7q2` が 52 分かけて失敗し `KubePodNotReady` が発火した。

```
10:45:32  pulling ghcr.io/siderolabs/spin:v0.25.1@sha256:cf814e77...
          ← 16分ハング
11:01:33  stream error: stream ID 7; PROTOCOL_ERROR; received from peer
```

同じ Pod の `build-secureboot-iso` が 6 分前に**同じ digest を 2 秒で pull できている**（同一ノード wn-01）。ghcr.io 側の一過性障害で、ビルドの問題ではない。

再試行の仕組みが無かったため Failed のまま終わり、37 分後の Renovate bump がたまたま同じ v1.13.8 を再ビルドしたおかげで成果物が揃っただけだった。

## 変更

| 対象 | 内容 |
|---|---|
| 全 Pod テンプレート | `retryStrategy` を追加（build 系 limit 2 / 短時間系 limit 3、指数バックオフ） |
| `build-and-push-installer` / `build-and-push-iso` | `activeDeadlineSeconds: 1800` — 正常時は約 16 分なので、ハングを 30 分で打ち切って作り直す |
| workflow | `activeDeadlineSeconds` 3600 → 7200（3 回試行の最悪ケースを収める） |

`retryPolicy: Always` は exit 1（今回のケース）と deadline 超過の両方を拾う。

## 再実行の安全性

retry は Pod ごと作り直すので push ステップも再実行されるが、全て冪等:

- `push-installer.sh` — `crane push` は固定タグへの上書き
- `push-iso.sh` — `gh release upload --clobber`
- `finalize-release.sh` — `gh release edit`

## 検証

- `kubectl apply --dry-run=server` 通過
- ログは Loki に残っていたので原因まで特定済み（`archiveLogs` は不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1JyBqLxMTAvywiwqR61jW