### PR TITLE
ci: check that aqua-checksums.json is in step with aqua.yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -407,7 +407,7 @@ jobs:
   # ワークフローの lint は 6 リポジトリ共通なので home-actions に寄せてある。
   # ツールのピンは向こう側にあり、ここは呼び先の SHA を追うだけ。
   lint-workflows:
-    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@bd99e01e99bcce1b845aa7abae3b3ed3b61f464f # v1.1.0
+    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
     permissions:
       contents: read
 
@@ -415,12 +415,21 @@ jobs:
   # 出ない）、バリデータだけがこの層の間違いを検出できる。home-cluster は
   # `ignoredAuthors` の綴り違いを 5 週間放置していた。
   lint-renovate:
-    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@bd99e01e99bcce1b845aa7abae3b3ed3b61f464f # v1.1.0
+    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
+    permissions:
+      contents: read
+
+  # aqua-checksums.json が aqua.yaml と一致しているかの検査。`aqua i` だけでは
+  # registry ref のズレを取りこぼす（aqua が自分で追記して exit 0 になる）ので、
+  # 実インストール後の git 差分で見る。直すのはクラスタ側の aqua-checksum
+  # ワークフローで、こちらはそれが直せていないことを赤にする側。
+  lint-aqua:
+    uses: Tsuguya/home-actions/.github/workflows/lint-aqua.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
     permissions:
       contents: read
   gate:
     name: CI Gate
-    needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, lint-workflows, lint-renovate]
+    needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, lint-workflows, lint-renovate, lint-aqua]
     # `!cancelled()` rather than `always()`: under always(), cancelling a run
     # leaves every leaf reporting `cancelled`, which falls through the case
     # below and records the required check as a failure. A cancelled run has no


### PR DESCRIPTION
## What

Calls [`lint-aqua`](https://github.com/Tsuguya/home-actions/releases/tag/v1.2.0) from home-actions, and repins the other home-actions calls to v1.2.0 so one version is in use here rather than three.

## Why

`aqua.yaml` sets `require_checksum: true`, so a version bump that leaves `aqua-checksums.json` behind breaks installs. The cluster-side `aqua-checksum` workflow repairs that on Renovate branches — but **nothing reported when it had not**, and it had been failing since the day it was added:

```
Error 35, Failed 4, successes 0
84 distinct pods, 2246 timeout lines in 48h of Loki
```

Repair without detection is the shape of several things found today: `trivy`'s concurrency limit sat misplaced for six months, `ignoredAuthors` sat misspelled for five weeks. Same failure mode — the fixing side existed, the reporting side did not.

## `aqua i` alone is not the detector

Two kinds of drift, and it only catches one. Measured on `digest-cooldown`'s own config:

| drift | `aqua i` |
|---|---|
| package version | **exit 1**, `checksum is required` |
| registry ref (`v4.552.0` → `v4.553.0`) | **exit 0** — aqua appends the missing entry itself |

So the job installs for real, then checks `git diff` on `aqua-checksums.json`. A rewrite means the committed file was stale.

Both cases were verified against a scratch clone before this shipped, including the passing one — a check that only ever goes red is not a check.

## Expect this to go red somewhere

There are open `aquaproj/aqua-registry` PRs across several repositories carrying exactly this drift. `digest-cooldown#6` has `aqua.yaml` at `v4.553.0` against a checksum file still recording `v4.552.0`, and its CI is currently green. Those should start failing, which is the point.
