### PR TITLE
fix(argo): let aqua-checksum reach Sigstore's TUF root

### DIFF
--- a/manifests/argo/netpol-aqua-checksum.yaml
+++ b/manifests/argo/netpol-aqua-checksum.yaml
@@ -59,6 +59,18 @@ spec:
         # that every workflow runs is selected by this policy rather than by
         # netpol-workflow-pods' blanket 443 — and without this it times out.
         - matchName: "discord.com"
+        # aqua は checksum を記録する前に、上流の署名を cosign で検証する。
+        # bundle 検証自体はオフラインで完結するが、信頼のルートだけは Sigstore
+        # の TUF から取りに行くので、ここが塞がると全パッケージが落ちる:
+        #
+        #   Get "https://tuf-repo-cdn.sigstore.dev/15.root.json": i/o timeout
+        #   → Verification by Cosign failed temporarily, retrying (×5)
+        #   → aqua failed: it failed to update some packages' checksums
+        #
+        # 接続先は strace で実測した。外部に出るのは github.com /
+        # *.githubusercontent.com / このホストの 3 つだけで、rekor と fulcio
+        # には接続しない（bundle に必要な材料が入っているため）。
+        - matchName: "tuf-repo-cdn.sigstore.dev"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## The third gap

aqua verifies the upstream signature with cosign **before** it records a checksum. Bundle verification is otherwise offline, but the trust root comes from Sigstore's TUF — so with that host blocked, every package fails:

```
Get "https://tuf-repo-cdn.sigstore.dev/15.root.json": dial tcp 34.117.62.14:443: i/o timeout
→ Verification by Cosign failed temporarily, retrying (×5)
→ ERR update checksums  package_name=mikefarah/yq
→ aqua failed: it failed to update some packages' checksums
```

Seen on [#557](https://github.com/Tsuguya/home-cluster/pull/557), where `mikefarah/yq` moved to v4.53.4 and `aqua-checksums.json` still records v4.53.3.

## Measured, not guessed

`strace -f -e trace=connect` on the same `aqua update-checksum` locally. Outbound connections are **exactly three**:

| IP | host | status |
|---|---|---|
| `20.27.177.113` | github.com | already allowed |
| `185.199.10x.133` | \*.githubusercontent.com | already allowed |
| `34.117.62.14` | **tuf-repo-cdn.sigstore.dev** | ⬅ this PR |

`rekor.sigstore.dev` (`34.36.47.134`) and `fulcio.sigstore.dev` (`34.36.164.164`) never appear — the bundle carries what verification needs, so they are deliberately not added. Same reasoning that kept Talos apid off this policy in #554.

Note `34.117.62.14` is the exact address in the cluster's error message, which is how the trace and the failure were tied together.

## The previous two fixes did work

| | |
|---|---|
| [#551](https://github.com/Tsuguya/home-cluster/pull/551) | Kubernetes API — `kube-apiserver` denials gone from Hubble |
| [#554](https://github.com/Tsuguya/home-cluster/pull/554) | artifact repository — SeaweedFS denials gone |
| this | Sigstore TUF |

The **first `aqua-checksum` run ever to reach `Succeeded`** happened after those two (`aqua-checksum-6wzzw`, 05:26:27). It got there because its repository had nothing to change. The two runs with real work reached cosign and stopped here.

## On the process

#554 said comparing against `netpol-workflow-pods` in full meant no more one-drop-at-a-time. That was only half right — the comparison finds what *every* workflow pod needs, and cannot surface what this workflow needs because of what it runs. Deriving the requirements from the program's behaviour, which is what the strace did, is the part that was missing.