### PR TITLE
fix(kanidm): put automatic_refresh on one side only

### DIFF
--- a/manifests/argo/kanidm-repl-cert-exchange.yaml
+++ b/manifests/argo/kanidm-repl-cert-exchange.yaml
@@ -73,11 +73,28 @@ spec:
 
             CERT_0=$(cat /tmp/cert-0)
             CERT_1=$(cat /tmp/cert-1)
+            # kanidm-0 が primary、kanidm-1 が secondary。
+            #
+            # automatic_refresh は「分岐したとき自分を相手の内容で作り直す」設定
+            # で、**片側にだけ**付ける。両側に付けると双方が consumer 役を要求し
+            # 合い、どちらも supplier を引き受けないので永久にデッドロックする。
+            # 上流ドキュメントもそう書いている:
+            #
+            #   The secondary can have automatic_refresh = true ... while the
+            #   primary should not have this setting. This means that if
+            #   database issues occur the content of the primary will take
+            #   precedence over the secondary.
+            #
+            # 実際、両側に付けていたせいで RUV 分岐が自動回復せず、2026-07-03 と
+            # 2026-08-22 の 2 回、手動の refresh-replication-consumer が必要に
+            # なった。2 回目は 7 時間以上デッドロックしたままだった。
+            #
+            # primary を ordinal 0 にしているのは、StatefulSet が 0 から順に
+            # 起動するため。分岐時は kanidm-0 の内容が残る。
             cat > /tmp/partner-0.toml << EOF
             [replication."repl://kanidm-1.kanidm-headless.kanidm.svc.cluster.local:8444"]
             type = "mutual-pull"
             partner_cert = "${CERT_1}"
-            automatic_refresh = true
             EOF
 
             cat > /tmp/partner-1.toml << EOF


### PR DESCRIPTION
## The bug

Both partner files carried `automatic_refresh = true`:

```toml
partner-0.toml   type = "mutual-pull"   automatic_refresh = true
partner-1.toml   type = "mutual-pull"   automatic_refresh = true
```

That is what made the RUV divergence unrecoverable. Each node asks to be the *consumer* and refresh itself from the other; neither will act as supplier; the deadlock holds indefinitely. It held for **over seven hours** on 2026-08-22 before being broken by hand.

## The asymmetry is the tiebreak

[Upstream](https://kanidm.github.io/kanidm/stable/repl/deployment.html) documents this as the whole point of the setting:

> The secondary can have `automatic_refresh = true` enabled to pull changes from the primary automatically, **while the primary should not have this setting**. This means that if database issues occur **the content of the primary will take precedence over the secondary**.

Symmetric config has no tiebreak. So "automatic_refresh is enabled but has never once fired" — which is what the logs showed — was not a kanidm bug. It was this configuration.

`kanidm-0` becomes the primary because a StatefulSet starts at ordinal 0. On a future divergence `kanidm-1` refreshes itself from `kanidm-0` with nobody intervening.

## Twice now

| | trigger |
|---|---|
| 2026-07-03 (task #293) | 1.10.3 → 1.10.4 upgrade; both nodes independently created schema entries |
| 2026-08-22 (task #435/#436) | the `1.11.1` tag was re-pushed, so the two replicas ran different images |

Both times the configured automatic refresh could not fire. Both times the fix was a manual `refresh-replication-consumer`, and both times the recovery procedure that got written down was never executed — [horenso#76](https://github.com/Tsuguya/horenso/issues/76) explains why the first one was unreadable.

## Cost

Unchanged from what was already true: a write landing on the secondary while diverged is lost when it refreshes. That is exactly what today's manual repair did — only now it happens without a five-minute SSO outage.

## Applying

`kanidm-repl-cert-exchange` runs daily at 05:00 UTC and rewrites the secret, so this takes effect on the next run. The current pods are already consistent (refreshed today), so there is nothing to reconcile in the meantime.