### PR TITLE
fix(argo): prune stale entries when updating aqua checksums

### DIFF
--- a/manifests/argo/aqua-checksum.yaml
+++ b/manifests/argo/aqua-checksum.yaml
@@ -119,7 +119,13 @@ spec:
             # aqua downloads every package to hash it, so this needs the same
             # network reach as the CI it is fixing. AQUA_GLOBAL_CONFIG is
             # cleared so only the repository's own aqua.yaml is considered.
-            AQUA_GLOBAL_CONFIG="" aqua update-checksum -a
+            #
+            # --prune は aqua.yaml が参照しなくなったエントリを削除する。付けないと
+            # update-checksum は追記しかせず、版が上がるたびに古いエントリが残り
+            # 続ける（home-cluster#562 は registry v4.553.0 の追加が +5/-0 で、
+            # v4.552.0 が残った）。古いエントリを読む者はいないが上限なく増える。
+            # しかも `aqua i` も削除しないので、CI の lint-aqua では気づけない。
+            AQUA_GLOBAL_CONFIG="" aqua update-checksum -a --prune
 
             git add aqua-checksums.json
             if git diff --cached --quiet; then


### PR DESCRIPTION
## What

`aqua update-checksum -a` → `aqua update-checksum -a --prune` in the cluster-side workflow.

## Why

`update-checksum` **only appends**. Every version bump leaves the previous entry behind permanently. [#562](https://github.com/Tsuguya/home-cluster/pull/562) is the clean example — the bot's commit is **`+5/-0`**:

```
+  "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.553.0/registry.yaml",
+  "checksum": "A0610103BC291509498CA448B8E9FB09588A1999FD0E391D1BEBEA8E596348A0",
```

`v4.552.0` stays. Same for yq — `v4.53.3` and `v4.53.4` are both in the file on `main` right now.

## Why it would not have been noticed

Nothing reads the stale entries, so nothing breaks today. But it grows without bound, and **the `lint-aqua` check added earlier today cannot see it**: that check runs `aqua i` and looks for a `git diff`, and `aqua i` does not remove entries either. The file only ever grows, so the check stays green.

A detector that can only see additions does not catch an append-only leak. Caught by review, not by CI.

## Note

`--deep` is *not* the flag for this — it has had no meaning since aqua v2.0.0 and is slated for removal in v3.0.0 (aquaproj/aqua#1769).