### PR TITLE
fix(claude-code): never let an unreadable verdict strand a workflow

### DIFF
--- a/manifests/claude-code/adjudicator-wft.yaml
+++ b/manifests/claude-code/adjudicator-wft.yaml
@@ -149,36 +149,60 @@ spec:
               exit 0
             fi
 
-            DECISION=$(grep '^DECISION:' /report/result.txt | head -1 | awk '{print $2}')
+            # Leading whitespace is tolerated, but the value itself must match
+            # exactly. Anything else is an unusable verdict, not an approval.
+            DECISION_LINES=$(grep -cE '^[[:space:]]*DECISION:' /report/result.txt || true)
+            DECISION=$(grep -E '^[[:space:]]*DECISION:' /report/result.txt | head -1 \
+              | sed 's/^[[:space:]]*DECISION:[[:space:]]*//' | tr -d '\r' | sed 's/[[:space:]]*$//')
+
+            VALID=0
+            if [ "$DECISION_LINES" = "1" ]; then
+              if [ "$DECISION" = "APPROVE" ] || [ "$DECISION" = "REJECT" ]; then
+                VALID=1
+              fi
+            fi
+
+            if [ "$VALID" != "1" ]; then
+              echo "Unusable verdict (DECISION lines=$DECISION_LINES value='$DECISION')"
+              echo "Falling back to REJECT so $SOURCE_WF does not stay suspended forever"
+              DECISION=REJECT
+            fi
 
             if [ "$DECISION" = "APPROVE" ]; then
               echo "APPROVE: resuming workflow $SOURCE_WF in $SOURCE_NS"
-              WF_JSON=$(kubectl -n "$SOURCE_NS" get wf "$SOURCE_WF" -o json 2>&1)
-              if [ $? -ne 0 ]; then
+              if ! WF_JSON=$(kubectl -n "$SOURCE_NS" get wf "$SOURCE_WF" -o json 2>&1); then
                 echo "Failed to get workflow: $WF_JSON"
-                exit 0
+                exit 1
               fi
               SUSPEND_NODES=$(echo "$WF_JSON" | jq -r '[.status.nodes // {} | to_entries[] | select(.value.type == "Suspend" and .value.phase == "Running")] | length')
               if [ "$SUSPEND_NODES" = "0" ]; then
-                echo "No suspended nodes found in $SOURCE_WF"
+                echo "No suspended nodes found in $SOURCE_WF (already resumed?)"
                 exit 0
               fi
               FINISHED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-              echo "$WF_JSON" | jq --arg fin "$FINISHED" \
+              if ! echo "$WF_JSON" | jq --arg fin "$FINISHED" \
                 '.status.nodes |= with_entries(
                   if .value.type == "Suspend" and .value.phase == "Running"
                   then .value.phase = "Succeeded" | .value.finishedAt = $fin
                   else . end
-                )' | kubectl replace -f - 2>&1
+                )' | kubectl replace -f - 2>&1; then
+                echo "Failed to resume $SOURCE_WF"
+                exit 1
+              fi
               echo "Workflow $SOURCE_WF resumed"
-            elif [ "$DECISION" = "REJECT" ]; then
-              echo "REJECT: stopping workflow $SOURCE_WF in $SOURCE_NS"
-              kubectl -n "$SOURCE_NS" patch wf "$SOURCE_WF" \
-                --type=merge -p '{"spec":{"shutdown":"Stop"}}' 2>&1 || true
-              echo "Workflow $SOURCE_WF stopped"
             else
-              echo "Unknown decision: $DECISION"
+              echo "REJECT: stopping workflow $SOURCE_WF in $SOURCE_NS"
+              if ! kubectl -n "$SOURCE_NS" patch wf "$SOURCE_WF" \
+                --type=merge -p '{"spec":{"shutdown":"Stop"}}' 2>&1; then
+                echo "Failed to stop $SOURCE_WF"
+                exit 1
+              fi
+              echo "Workflow $SOURCE_WF stopped"
             fi
+
+            # A verdict we could not read is a failure worth surfacing, even
+            # though the source workflow was stopped safely above.
+            [ "$VALID" = "1" ] || exit 1
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## 問題

`adjudicator` の `act-on-decision` は判定を

```sh
DECISION=$(grep '^DECISION:' /report/result.txt | head -1 | awk '{print $2}')
```

で読み、`APPROVE` でも `REJECT` でもなければ `echo "Unknown decision"` して **exit 0** していた。

裁定を依頼した側の Workflow は suspend されたまま永久に残り、どこにも異常が出ない。fail-open でも fail-closed でもなく **fail-silent**。

## 変更

- 読めない判定は **REJECT として扱い**、source workflow を停止したうえで **exit 1**。赤くなって Discord 通知が飛ぶ。`result.txt` 自体が無いときの既存フォールバックが REJECT なので、それに揃えた
- 値の一致を厳密にした。`DECISION: APPROVE (条件付き)` は従来 `APPROVE` と解釈され、**条件が落ちたまま resume していた**。条件は `CONDITIONS:` に書くべきもので、余計な文字列を伴う判定は実行可能な判定ではない
  - 先頭の空白は引き続き許容（プロンプトがわざわざ「インデントするな」と書いている＝実際に起きる）
  - `DECISION:` 行が 2 本ある場合は矛盾として読めない扱い
- 周辺の握り潰しも解消。`kubectl get` 失敗・resume 失敗・stop 失敗がいずれも exit 0 だった

## 検証

判定抽出ロジックを切り出して 10 ケース確認（正常 2 / インデント / CRLF / 条件付き / 小文字 / 行なし / 空 / 2 行 / コードフェンス）。`sh -n` と `shellcheck -s sh` も通している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn