### PR TITLE
fix(claude-code): let the CNP check report its own step results

### DIFF
--- a/manifests/claude-code/cnp-check-cwf.yaml
+++ b/manifests/claude-code/cnp-check-cwf.yaml
@@ -35,6 +35,34 @@ subjects:
     name: agent-cnp-reader
     namespace: claude-code
 ---
+# Argo の executor は自分の結果を workflowtaskresults に書く。これが無いと
+# コンテナが何をしたかに関わらず exit 64 で落ちる。既存の SA は ClusterRole
+# argo-workflows-edit に縛られているが、あれは workflow の create/delete まで
+# 含むので、読むだけの点検には過大。executor が要る最小だけを与える。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-executor
+  namespace: claude-code
+rules:
+  - apiGroups: [argoproj.io]
+    resources: [workflowtaskresults]
+    verbs: [create, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-cnp-reader-executor
+  namespace: claude-code
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agent-executor
+subjects:
+  - kind: ServiceAccount
+    name: agent-cnp-reader
+    namespace: claude-code
+---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:


### PR DESCRIPTION
#569 の初回実行がエージェントに到達せず失敗した。

```
analyze  Error  wait: Error (exit code 64): workflowtaskresults.argoproj.io is forbidden:
         User "system:serviceaccount:claude-code:agent-cnp-reader" cannot create resource
         "workflowtaskresults" in API group "argoproj.io" in the namespace "claude-code"
```

Argo の executor はステップの結果を `workflowtaskresults` に書く。コンテナが何をしたかに関わらず、これができないと exit 64 になる。

## 変更

`workflowtaskresults` の `create` / `patch` だけを持つ Role を作って束縛する。

namespace の他の SA（`claude-code-sre` / `claude-code-executor`）は ClusterRole `argo-workflows-edit` 経由でこれを得ているが、あれは

```
workflows, cronworkflows, workflowtemplates, ... × create/delete/update/...
```

まで含む。読むだけであることが存在理由の SA をそこに縛ると、新設した意味が消える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn