### PR TITLE
Catch values keys that no chart reads, and fix the seven we already had

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -146,6 +146,49 @@ jobs:
             done
           done
 
+  # A key at the wrong nesting level renders exactly like one that was never
+  # written: Helm ignores it, the chart falls back to its default, and nothing
+  # anywhere says so. values.schema.json does not cover this — only 7 of our
+  # charts ship one and only cert-manager sets additionalProperties: false.
+  # That is how `scanJobsConcurrentLimit` sat at the top level of the
+  # trivy-operator values for months while the operator ran on the chart
+  # default of 10 (#547), and how Cilium's WireGuard strict mode switched
+  # itself off when 1.20 split strictMode into egress:/ingress:.
+  #
+  # This renders each chart, changes one leaf of our values at a time, and
+  # renders again: a key no template reads produces byte-identical output.
+  # On a pull request it only examines the values files the PR touches, plus
+  # every values file of a chart whose targetRevision moved — which is exactly
+  # the Renovate bump PR that would otherwise land the rename silently.
+  unread-values:
+    name: unread values
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # the run below diffs against the PR's base commit
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Check for values keys no chart reads
+        env:
+          # Empty on push, which makes the script check every chart. Kept out
+          # of the script body so the ref cannot be interpolated into it.
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASE_SHA}" ]; then
+            python3 scripts/unread-values.py --changed "${BASE_SHA}"
+          else
+            python3 scripts/unread-values.py
+          fi
+
   image-existence:
     name: image existence
     runs-on: ubuntu-latest
@@ -429,7 +472,7 @@ jobs:
       contents: read
   gate:
     name: CI Gate
-    needs: [kubeconform, helm-template, image-existence, mcp, argo-lint, lint-workflows, lint-renovate, lint-aqua]
+    needs: [kubeconform, helm-template, unread-values, image-existence, mcp, argo-lint, lint-workflows, lint-renovate, lint-aqua]
     # `!cancelled()` rather than `always()`: under always(), cancelling a run
     # leaves every leaf reporting `cancelled`, which falls through the case
     # below and records the required check as a failure. A cancelled run has no

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # Node
 node_modules/
+
+# Claude Code worktrees live inside the repo and are untracked, so `git add -A`
+# stages them as an embedded gitlink instead of ignoring them.
+.claude/worktrees/

--- a/helm-values/blackbox-exporter/values.yaml
+++ b/helm-values/blackbox-exporter/values.yaml
@@ -50,8 +50,17 @@ resources:
     memory: 128Mi
 
 # Prometheus の serviceMonitorSelector は release ラベルで絞っているため、
-# extraLabels で付けないと作成されても拾われない。
+# labels で付けないと作成されても拾われない。
+#
+# `serviceMonitor.enabled` + `extraLabels` はこのチャートには無い。前者は
+# `serviceMonitor.targets` に列挙したプローブ対象ごとに ServiceMonitor を
+# 作る側のスイッチで、targets が空なら何も生成しない。exporter 自身の
+# /metrics を拾うのは selfMonitor の方で、そちらが未設定だったため
+# ServiceMonitor は1つも作られていなかった（プローブ結果自体は
+# manifests/monitoring/probe-ipv6.yaml の Probe CRD 経由なので生きている。
+# 見えていなかったのは blackbox-exporter 自身の死活とスクレイプ失敗）。
 serviceMonitor:
-  enabled: true
-  extraLabels:
-    release: kube-prometheus-stack
+  selfMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack

--- a/helm-values/cilium/values.yaml
+++ b/helm-values/cilium/values.yaml
@@ -58,9 +58,19 @@ extraConfig:
 encryption:
   enabled: true
   type: wireguard
+  # 1.20 で strictMode の下が egress:/ingress: に分割された。旧構造
+  # (strictMode.enabled / .cidr を直下) のままだったため、chart bump 以降
+  # strict mode が黙って無効になっていた — WireGuard 自体は張れているので
+  # `cilium-dbg status` は正常に見えるが、cilium-config に
+  # enable-encryption-strict-mode が無く、未暗号化の pod-to-pod egress が
+  # そのまま通っていた。
   strictMode:
-    enabled: true
-    cidr: "10.244.0.0/16"
+    egress:
+      enabled: true
+      cidr: "10.244.0.0/16"
+      # routing-mode=tunnel では必須（chart の values.yaml が明記）。
+      # 無いと remote node identity を解決できず、正規のトラフィックまで落ちる。
+      allowRemoteNodeIdentities: true
 
 gatewayAPI:
   enabled: true

--- a/helm-values/harbor/values.yaml
+++ b/helm-values/harbor/values.yaml
@@ -93,12 +93,24 @@ portal:
       memory: 128Mi
 
 registry:
-  resources:
-    requests:
-      cpu: 50m
-      memory: 128Mi
-    limits:
-      memory: 512Mi
+  # `registry.resources` はチャートが読まないため、registry / registryctl の
+  # 両コンテナが resources: {} （requests も limits も無し）で動いていた。
+  # このチャートはコンテナごとに registry.registry / registry.controller で
+  # 受ける。実測 (2026-08-22) は registry 26Mi / 7m、registryctl 9Mi / 1m。
+  registry:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+  controller:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
   # 起動から 0〜24h のジッタ後に走る upload purger が、SeaweedFS の S3 を
   # walk する途中で必ず panic してプロセスごと落ちる:
   #

--- a/helm-values/kyverno/values.yaml
+++ b/helm-values/kyverno/values.yaml
@@ -1,11 +1,10 @@
 admissionController:
   replicas: 1
-  resources:
-    limits:
-      memory: 384Mi
-    requests:
-      cpu: 50m
-      memory: 128Mi
+  # このコンポーネントだけ resources をコンテナ単位で受ける
+  # (backgroundController などは直下の resources が正しい)。直下にも同じ
+  # ブロックが書かれていたがチャートは読んでおらず、container 側だけが
+  # 効いていた。残しておくと container 側を消したときに気付かず
+  # チャート既定の 256Mi に戻るので、読まれない方を削除する。
   container:
     resources:
       limits:

--- a/helm-values/nextcloud/values.yaml
+++ b/helm-values/nextcloud/values.yaml
@@ -91,6 +91,17 @@ nextcloud:
           name: nextcloud-s3-credentials
           key: password
 
+  # チャートが Pod の securityContext に流すのはここ。トップレベルの
+  # `podSecurityContext:` に書かれていたが、このチャートにそのキーは無く
+  # （非推奨の `securityContext:` はある）、まるごと無視されていた。
+  # fsGroup: 33 が Pod に付いていたのは効いていたからではなく、この値が
+  # 空のときにチャートが nginx 無効時のフォールバックとして焼く定数。
+  # seccompProfile の方はどこにも届いていなかった。
+  podSecurityContext:
+    fsGroup: 33
+    seccompProfile:
+      type: RuntimeDefault
+
 internalDatabase:
   enabled: false
 
@@ -115,11 +126,6 @@ persistence:
   enabled: true
   storageClass: qnap-nfs
   size: 5Gi
-
-podSecurityContext:
-  fsGroup: 33
-  seccompProfile:
-    type: RuntimeDefault
 
 startupProbe:
   enabled: true

--- a/helm-values/qdrant/values.yaml
+++ b/helm-values/qdrant/values.yaml
@@ -25,9 +25,13 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-serviceAccount:
-  create: false
+# `serviceAccount.create: false` はここにあったが、このチャートに create の
+# 概念は無く serviceaccount.yaml は無条件で ServiceAccount を作る。書いて
+# あると「作っていない」と読めてしまうので消す（実際は作られている）。
 
+# チャート側の条件は `updateVolumeFsOwnership and (not image.useUnprivilegedImage)`。
+# 上で useUnprivilegedImage: true にしているので、この値に関わらず
+# fsGroup 付け替えの initContainer は出ない。意図の記録として残す。
 updateVolumeFsOwnership: false
 
 persistence:

--- a/helm-values/trivy-operator/values.yaml
+++ b/helm-values/trivy-operator/values.yaml
@@ -1,5 +1,8 @@
 operator:
-  scanJobNamespace: trivy-system
+  # `scanJobNamespace: trivy-system` がここにあったが、このチャート
+  # (0.35.0) の values にもテンプレートにもそのキーは存在せず、operator の
+  # env にも対応するものが無い。scan job は対象 workload と同じ namespace で
+  # 走る仕様で、集約する設定は用意されていない。
   # SBOMReport が 491件/246MB で etcd の大半を占めていたため無効化 (2026-08-08)
   # ClusterVulnerabilityReport も併せて無効になるが、workload 単位の
   # VulnerabilityReport は影響なし。SBOM が必要なら Harbor 側で保管する

--- a/scripts/unread-values-allow.txt
+++ b/scripts/unread-values-allow.txt
@@ -1,0 +1,57 @@
+# scripts/unread-values.py が「チャートのテンプレートが一度も読まない」と判定した
+# キーのうち、意図して残しているもの。形式は <values ファイル>::<キーのパス>。
+#
+# ここに載せてよいのは「別の設定が理由でそのキーが効かないだけで、意図の記録として
+# 残す価値がある」ものだけ。キー名や階層を間違えているものは直すこと。理由を書けない
+# 行は追加しないこと。
+#
+# 逆に、ここに書いたキーが再現しなくなったら（＝チャート側が読むようになった、
+# あるいは values を直した）検査は失敗する。その時点でこの行を消す。放置すると
+# そのパスで起きた将来の事故を隠してしまう。
+
+# filer はステートレスなので chart ではなく自前 Deployment で動かしている
+# (helm-values/seaweedfs/values.yaml の filer.enabled: false、実体は
+# manifests/seaweedfs/filer-deployment.yaml)。chart 側の filer.* は Deployment を
+# 出さない以上どれも読まれないが、自前 Deployment と設定を突き合わせるときの
+# 参照元として残している。
+helm-values/seaweedfs/values.yaml::filer.replicas
+helm-values/seaweedfs/values.yaml::filer.data.type
+helm-values/seaweedfs/values.yaml::filer.logs.type
+helm-values/seaweedfs/values.yaml::filer.nodeSelector
+helm-values/seaweedfs/values.yaml::filer.tolerations
+helm-values/seaweedfs/values.yaml::filer.extraVolumes
+helm-values/seaweedfs/values.yaml::filer.extraVolumeMounts
+helm-values/seaweedfs/values.yaml::filer.resources.requests.cpu
+helm-values/seaweedfs/values.yaml::filer.resources.requests.memory
+helm-values/seaweedfs/values.yaml::filer.resources.limits.memory
+helm-values/seaweedfs/values.yaml::filer.secretExtraEnvironmentVars.WEED_POSTGRES2_USERNAME.secretKeyRef.name
+helm-values/seaweedfs/values.yaml::filer.secretExtraEnvironmentVars.WEED_POSTGRES2_USERNAME.secretKeyRef.key
+helm-values/seaweedfs/values.yaml::filer.secretExtraEnvironmentVars.WEED_POSTGRES2_PASSWORD.secretKeyRef.name
+helm-values/seaweedfs/values.yaml::filer.secretExtraEnvironmentVars.WEED_POSTGRES2_PASSWORD.secretKeyRef.key
+
+# PDB のテンプレート条件は `podDisruptionBudget.enabled and (replicaCount > 1)`。
+# どれも replicaCount: 1 なので enabled の値に関わらず PDB は出ない。単一
+# レプリカを維持する意思表示として残す（レプリカを増やすときにここを見る）。
+helm-values/oauth2-proxy-hubble/values.yaml::podDisruptionBudget.enabled
+helm-values/oauth2-proxy-rss/values.yaml::podDisruptionBudget.enabled
+helm-values/oauth2-proxy-seaweedfs/values.yaml::podDisruptionBudget.enabled
+
+# registry は S3 (SeaweedFS) 、jobLog は jobLoggers に "file" を含めていないため、
+# どちらも PVC が作られない。storageClass: "-" は PVC を作らせないための保険で、
+# 構成が戻ったときに qnap-nfs を掴まないようにしている。
+helm-values/harbor/values.yaml::persistence.persistentVolumeClaim.registry.storageClass
+helm-values/harbor/values.yaml::persistence.persistentVolumeClaim.jobservice.jobLog.storageClass
+
+# admin バケットは Loki Enterprise 用。deploymentMode: SingleBinary では読まれない
+# が、S3 側にバケットを用意してある3つを揃えて書いておく。
+helm-values/loki/values.yaml::loki.storage.bucketNames.admin
+
+# db-secret は `mariadb.enabled or externalDatabase.enabled or postgresql.enabled`
+# で出るが、認証情報は ExternalSecret 由来の existingSecret を使っているので
+# チャートの Secret は生成させていない。外部 DB を使っている事実の記録として残す。
+helm-values/nextcloud/values.yaml::externalDatabase.enabled
+
+# チャート側の条件は `updateVolumeFsOwnership and (not image.useUnprivilegedImage)`。
+# useUnprivilegedImage: true なのでこの値は効かない。特権イメージに戻したときに
+# fsGroup 付け替えを走らせない意思表示として残す。
+helm-values/qdrant/values.yaml::updateVolumeFsOwnership

--- a/scripts/unread-values.py
+++ b/scripts/unread-values.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Find keys in helm-values/ that the chart's templates never read.
+
+A misplaced key is invisible to Helm: `scanJobsConcurrentLimit` at the top
+level instead of under `operator:` renders exactly like it was never written,
+and the operator runs on the chart default. values.schema.json does not help —
+only 7 of our charts ship one, and only cert-manager sets
+additionalProperties: false, which is what would catch a wrong nesting level.
+
+So decide by rendering. For every leaf in a values file, change the value and
+render again: if the output is byte-identical, no template reads that key.
+Note that this asks a different question than deleting the key would — a value
+that merely repeats the chart default renders identically when deleted, but
+differently when changed, and is correctly reported as live.
+
+Changing the value is not enough on its own. A template that switches on a
+specific string — `if eq .Values.database.type "internal"` — renders the same
+for "external" and for a perturbed "externalzzprobe", both being "not internal",
+which would report a live key as unread. So a key is only reported when it
+survives both probes: perturbing it changes nothing, AND putting the chart's own
+default back (deleting the key, if the chart has no default there) changes
+nothing either. Either probe moving the output proves the key is read.
+
+Ambiguity always resolves to "live" so that this stays quiet unless it is sure:
+a leaf that cannot be perturbed (empty map, null, empty list) is skipped, and a
+probe that makes the chart fail to render counts as proof the key is read.
+"""
+
+import argparse
+import copy
+import os
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+
+import yaml
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ALLOWLIST = os.path.join(ROOT, "scripts", "unread-values-allow.txt")
+CACHE = os.path.join(tempfile.gettempdir(), "unread-values-charts")
+
+PROBE = "zzprobe"
+WORKERS = min(8, (os.cpu_count() or 2) * 2)
+MISSING = object()
+
+
+def sources():
+    apps = os.path.join(ROOT, "apps")
+    for name in sorted(os.listdir(apps)):
+        if not name.endswith(".yaml"):
+            continue
+        path = os.path.join(apps, name)
+        with open(path) as fh:
+            docs = [d for d in yaml.safe_load_all(fh) if d]
+        for doc in docs:
+            spec = doc.get("spec") or {}
+            srcs = spec.get("sources") or ([spec["source"]] if "source" in spec else [])
+            for src in srcs:
+                if not src.get("chart"):
+                    continue
+                helm = src.get("helm") or {}
+                files = [
+                    vf.replace("$values/", "")
+                    for vf in helm.get("valueFiles", [])
+                    if vf and vf != "null"
+                ]
+                if not files:
+                    continue
+                yield {
+                    "app": doc["metadata"]["name"],
+                    "app_file": os.path.join("apps", name),
+                    "chart": src["chart"],
+                    "repo": src["repoURL"],
+                    "version": str(src.get("targetRevision", "")),
+                    "namespace": (spec.get("destination") or {}).get("namespace", "default"),
+                    "release": helm.get("releaseName", doc["metadata"]["name"]),
+                    "files": files,
+                }
+
+
+def pull(src):
+    dest = os.path.join(CACHE, src["app"], src["version"])
+    chart_dir = os.path.join(dest, src["chart"])
+    if os.path.isdir(chart_dir):
+        return chart_dir
+    os.makedirs(dest, exist_ok=True)
+    if src["repo"].startswith("http"):
+        ref, extra = src["chart"], ["--repo", src["repo"]]
+    else:
+        ref, extra = f"oci://{src['repo']}/{src['chart']}", []
+    run = subprocess.run(
+        ["helm", "pull", ref, "--version", src["version"], "--untar", "--untardir", dest] + extra,
+        capture_output=True,
+        text=True,
+    )
+    if run.returncode:
+        raise RuntimeError(f"helm pull {src['chart']}@{src['version']}: {run.stderr.strip()}")
+    return chart_dir
+
+
+def render(chart_dir, src, files):
+    cmd = ["helm", "template", src["release"], chart_dir, "--namespace", src["namespace"]]
+    for f in files:
+        cmd += ["-f", f]
+    run = subprocess.run(cmd, capture_output=True, text=True)
+    return run.stdout.splitlines() if run.returncode == 0 else None
+
+
+def volatile(a, b):
+    """Line numbers that differ between two renders of identical input.
+
+    Several charts mint a self-signed certificate or a random password at
+    template time, so their output is never byte-identical to itself. Those
+    lines carry no signal about our values and are excluded from every
+    comparison below. A chart whose *line count* moves between two identical
+    renders cannot be masked this way and is skipped outright.
+    """
+    if a is None or b is None or len(a) != len(b):
+        return None
+    return {i for i, (x, y) in enumerate(zip(a, b)) if x != y}
+
+
+def same(a, b, mask):
+    if a is None or b is None or len(a) != len(b):
+        return False
+    return all(x == y for i, (x, y) in enumerate(zip(a, b)) if i not in mask)
+
+
+def leaves(node, path=()):
+    for key, value in node.items():
+        if isinstance(value, dict) and value:
+            yield from leaves(value, path + (key,))
+        else:
+            yield path + (key,), value
+
+
+def perturb(value):
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, (int, float)):
+        return value + 7
+    if isinstance(value, str):
+        return value + PROBE
+    if isinstance(value, list) and value and all(isinstance(v, str) for v in value):
+        return value + [PROBE]
+    return None
+
+
+def with_leaf(values, path, new):
+    out = copy.deepcopy(values)
+    node = out
+    for key in path[:-1]:
+        node = node[key]
+    if new is MISSING:
+        del node[path[-1]]
+    else:
+        node[path[-1]] = new
+    return out
+
+
+def default_at(chart_values, path):
+    node = chart_values
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return MISSING
+        node = node[key]
+    return node
+
+
+def check(src, targets):
+    chart_dir = pull(src)
+    abs_files = [os.path.join(ROOT, f) for f in src["files"]]
+
+    base = render(chart_dir, src, abs_files)
+    if base is None:
+        raise RuntimeError(f"{src['app']}: baseline render failed")
+    mask = volatile(base, render(chart_dir, src, abs_files))
+    if mask is None:
+        return None
+
+    with open(os.path.join(chart_dir, "values.yaml")) as fh:
+        chart_values = yaml.safe_load(fh) or {}
+
+    def unchanged(absolute, values, path, new):
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tmp:
+            yaml.safe_dump(with_leaf(values, path, new), tmp)
+            probe_file = tmp.name
+        try:
+            swapped = [probe_file if p == absolute else p for p in abs_files]
+            out = render(chart_dir, src, swapped)
+        finally:
+            os.unlink(probe_file)
+        return out is not None and same(base, out, mask)
+
+    def probe(rel, absolute, values, path, new):
+        if not unchanged(absolute, values, path, new):
+            return None
+        # Second probe: restore the chart's own default (or remove the key when
+        # the chart has none there). This is what separates a genuinely unread
+        # key from one the chart compares against a fixed string.
+        if not unchanged(absolute, values, path, default_at(chart_values, path)):
+            return None
+        return rel, ".".join(str(p) for p in path)
+
+    jobs = []
+    for rel, absolute in zip(src["files"], abs_files):
+        if rel not in targets:
+            continue
+        with open(absolute) as fh:
+            values = yaml.safe_load(fh) or {}
+        for path, value in leaves(values):
+            new = perturb(value)
+            if new is not None:
+                jobs.append((rel, absolute, values, path, new))
+
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        results = pool.map(lambda a: probe(*a), jobs)
+    return [r for r in results if r]
+
+
+def load_allowlist():
+    allowed = {}
+    if not os.path.exists(ALLOWLIST):
+        return allowed
+    with open(ALLOWLIST) as fh:
+        for line in fh:
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            path, _, key = line.partition("::")
+            allowed.setdefault(path.strip(), set()).add(key.strip())
+    return allowed
+
+
+def changed_files(base_ref):
+    run = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    run.check_returncode()
+    return set(run.stdout.split())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--changed", metavar="BASE_REF", help="only charts touched since BASE_REF")
+    args = ap.parse_args()
+
+    touched = changed_files(args.changed) if args.changed else None
+    allowed = load_allowlist()
+
+    unread, skipped = {}, []
+    for src in sources():
+        # A chart bump is exactly when upstream renames or restructures a key,
+        # so a changed apps/ file pulls in all of that chart's values files.
+        if touched is not None:
+            bump = src["app_file"] in touched
+            targets = set(src["files"]) if bump else {f for f in src["files"] if f in touched}
+            if not targets:
+                continue
+        else:
+            targets = set(src["files"])
+
+        found = check(src, targets)
+        if found is None:
+            skipped.append(src["app"])
+            continue
+        for rel in targets:
+            unread.setdefault(rel, set())
+        for rel, key in found:
+            unread[rel].add(key)
+
+    new = sorted(
+        (rel, key)
+        for rel, keys in unread.items()
+        for key in keys
+        if key not in allowed.get(rel, set())
+    )
+    # An allowlist entry that no longer reproduces means the key was fixed (or
+    # the chart started reading it), and the entry is now hiding a future
+    # regression at that exact path. Only files this run examined can say that,
+    # so --changed never reports stale entries for files it skipped.
+    stale = sorted(
+        (rel, key)
+        for rel, keys in unread.items()
+        for key in allowed.get(rel, set())
+        if key not in keys
+    )
+
+    for app in skipped:
+        print(f"::warning::{app}: render is not line-stable, cannot check its values")
+
+    if new:
+        print("Keys no template reads:")
+        for rel, key in new:
+            print(f"::error file={rel}::{key} is never read by the chart")
+        print(
+            "\nEither the key is nested wrong / renamed upstream, or it is a leftover.\n"
+            f"If it is deliberate, add it to {os.path.relpath(ALLOWLIST, ROOT)} with a reason."
+        )
+    if stale:
+        print("\nAllowlist entries that no longer reproduce — delete them:")
+        for rel, key in stale:
+            print(f"::error file={os.path.relpath(ALLOWLIST, ROOT)}::{rel}::{key}")
+    if not new and not stale:
+        print(f"checked {len(unread)} values file(s), no unread keys")
+    return 1 if new or stale else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`values.schema.json` is Helm's own answer to bad values and it does not cover this repo: 7 of 29 charts ship one, and only cert-manager sets `additionalProperties: false` — the part that would catch a key at the wrong nesting level. Every misplacement fixed here passes `helm lint` today.

So this decides by rendering. For each leaf of a values file, change the value and render again; if the output is byte-identical, no template reads that key. It reproduces #547 (`scanJobsConcurrentLimit` at the top level instead of under `operator:`) from the values file as it stood that morning.

Running it over all 30 chart/values pairs found 38 keys, of which 36 survived a second, stricter probe. Seven are real:

| chart | what was wrong | effect |
|---|---|---|
| **cilium** | 1.20 split `encryption.strictMode` into `egress:`/`ingress:`; values kept the flat `strictMode.enabled`/`.cidr` | **WireGuard strict mode off since the bump** — `cilium-config` has no `enable-encryption-strict-mode`, unencrypted pod-to-pod egress passes |
| **harbor** | `registry.resources` is not a key this chart has (`registry.registry` / `registry.controller` are) | both containers ran with `resources: {}` — no requests, no limits |
| **blackbox-exporter** | `serviceMonitor.enabled` drives per-target monitors from `serviceMonitor.targets` (empty); the exporter's own metrics need `selfMonitor` | no ServiceMonitor existed at all |
| **nextcloud** | `podSecurityContext` belongs under `nextcloud:` | `seccompProfile: RuntimeDefault` never reached the pod |
| **kyverno** | `admissionController` takes `resources` under `container:` | duplicate dead block above the live one |
| **qdrant** | chart has no `serviceAccount.create` | ServiceAccount created despite `false` |
| **trivy-operator** | `operator.scanJobNamespace` exists nowhere in 0.35.0 | leftover |

Two of these hid behind a healthy-looking signal. `cilium-dbg status` reports `Wireguard [Peers: 5]` either way — the encryption is real, only the enforcement was missing. And nextcloud's pod does carry `fsGroup: 33`, but from the chart's own fallback constant for the nginx-disabled case, not from our file.

The IPv6 probe is unaffected by the blackbox finding: it runs through the `Probe` CRD in `manifests/monitoring/probe-ipv6.yaml`. What was missing is the exporter's own liveness and scrape failures.

## The check

Perturbing a value alone is not enough. A template that switches on a fixed string — `if eq .Values.database.type "internal"` — renders identically for `"external"` and `"externalzzprobe"`, both being "not internal". So a key is only reported when restoring the chart's own default at that path also changes nothing. That second probe is what keeps harbor's `database.type` and `jobservice.jobLoggers` out of the findings.

Several charts mint a certificate or password at template time and are never byte-identical to themselves. Two baseline renders identify those lines and every comparison ignores them — that is what lets cilium and harbor be checked at all instead of skipped, and both turned out to be carrying findings.

Ambiguity resolves to "live" throughout: a leaf that cannot be perturbed (empty map, null, empty list) is skipped, and a probe that fails to render counts as proof the key is read.

On a pull request it examines the values files the PR touches, **plus every values file of a chart whose `targetRevision` moved** — precisely the Renovate bump PR that would otherwise land a rename silently, as the Cilium 1.20 one did. A push to main checks everything (~45s warm).

`scripts/unread-values-allow.txt` holds the keys that are unread on purpose — a chart-level `enabled: false` upstream of them (seaweedfs's self-managed filer), a replica count that suppresses a PDB, an S3 backend that means no PVC — each with its reason. An entry that stops reproducing fails the check too: by then it is hiding the next accident at that path rather than documenting anything.

## Merging this

**`helm-values/cilium/values.yaml` changes how traffic is enforced, not just what is emitted.** Turning strict egress on drops unencrypted pod-to-pod egress inside `10.244.0.0/16`. `routing-mode=tunnel` requires `allowRemoteNodeIdentities: true`, which is set — without it, legitimate traffic drops. Worth watching the rollout rather than merging and walking away.

harbor-registry restarts (resources changed). Coordinated with the other sessions working in this repo: image builds tolerate it, but avoid merging around 10:00 JST, when `image-digest-audit` runs and reports an unreachable registry as missing digests.

Nothing here touches seaweedfs values, so its pods do not restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RMiotpWxy96TxFfh1MXS5
