### PR TITLE
chore: keep Claude Code worktrees out of `git add -A`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # Node
 node_modules/
+
+# Claude Code worktrees. These live inside the working tree and are their own
+# git repositories, so `git add -A` stages them as gitlinks.
+.claude/worktrees/


### PR DESCRIPTION
`.claude/worktrees/<name>` はこの作業ツリーの中に作られ、それ自体が git リポジトリなので、素の `git add -A` で **gitlink としてステージされる**。

実際に踏んだ。別セッションが `.claude/worktrees/unread-values` を開いている状態で `git add -A` したところ、

```
warning: adding embedded git repository: .claude/worktrees/unread-values
```

が出て、コミットに submodule 参照が 1 件入った（push 前に amend で除去済み）。clone した側には存在しないパスを指すので、放置すると壊れる。

`.gitignore` に足して恒久的に防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn