### PR TITLE
fix(qdrant): actually apply the manifests that were written for it

### DIFF
--- a/apps/qdrant.yaml
+++ b/apps/qdrant.yaml
@@ -16,6 +16,9 @@ spec:
     - repoURL: https://github.com/Tsuguya/home-cluster.git
       targetRevision: main
       ref: values
+    - repoURL: https://github.com/Tsuguya/home-cluster.git
+      targetRevision: main
+      path: manifests/qdrant
   destination:
     server: https://kubernetes.default.svc
     namespace: qdrant


### PR DESCRIPTION
`apps/qdrant.yaml` はチャートと `$values` 参照しか持っておらず、**`manifests/qdrant/` を指すソースが無い**。リポジトリにある CNP と PSA ラベルは一度も適用されていない。

`manifests/` 配下でどのアプリからも参照されていないディレクトリは **qdrant だけ**（他 29 個は全て対応するアプリがある）。

Application は `Synced` を報告する。チャートしか知らないので。**ポリシーを書き、レビューを通し、マージし、何も強制していない**という一番気づけない壊れ方をしていた。

## 実際に何が起きていたか

qdrant を選択しているのは CCNP `allow-dns` だけ。あれは egress ルールのみを持ち ingress ルールを持たない。Cilium は **ingress ルールで選択されたエンドポイントにしか ingress を強制しない**ので、

- **ingress: 未強制** → クラスタ内のどこからでも qdrant-0 に到達できる
- egress: 強制（DNS のみ）→ 過去 24h で `qdrant-0 → world:443` が 108 件 POLICY_DENIED

ollama が同じ 3 ソース構成を持っているので、それに合わせて欠けているソースを足す。

## 適用しても切れないことの確認

- `manifests/qdrant/netpol.yaml` の ingress は `memory` ns の `app=memory` から 6333/6334 を許可
- `memory/memory` CNP は qdrant への egress を持つ。**クラスタ内で qdrant への egress を許可している CNP はこれだけ**なので、対称であり他に失うものがない
- Hubble では裏が取れない。export の allowList が **DROPPED しか流していない**ため、ingress 未強制の間は拒否が発生せず記録も残らない。よって静的に CNP 側から確認した
- `qdrant-0` の securityContext は namespace マニフェストが設定する `restricted` に既に適合（`runAsNonRoot` / `drop: [ALL]` / `allowPrivilegeEscalation: false` / `seccompProfile: RuntimeDefault`）
- CNP は ingress ルールのみなので egress の強制状態は変わらない（テレメトリ遮断は継続）

## 出どころ

新設した `cnp-check` の初回実行がこの namespace を未カバーとして検出した。ただしエージェントの診断（「ingress が全 DENY で遮断されている」）は逆で、実際は ingress が無防備だった。指摘の起点としては有効だったが、原因と対処はこちらで確認し直している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn