### PR TITLE
ci: pin helm through aqua instead of taking latest

### DIFF
--- a/.github/workflows/_claude-review.yml
+++ b/.github/workflows/_claude-review.yml
@@ -173,8 +173,10 @@ jobs:
         run: npm ci
         working-directory: .github/mcp/pr-review
 
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         if: steps.ci.outputs.proceed == 'true'
+        with:
+          aqua_version: v2.62.3
 
       # Pinned to v1.0.99 — v1.0.100+ has a regression where install.sh
       # silently fails and the SDK can't fall back to its bundled binary.

--- a/.github/workflows/claude-fix-ci.yml
+++ b/.github/workflows/claude-fix-ci.yml
@@ -102,9 +102,6 @@ jobs:
           PR: ${{ github.event.workflow_run.pull_requests[0].number }}
           REPO: ${{ github.repository }}
 
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-        if: steps.failed.outputs.proceed == 'true'
-
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         if: steps.failed.outputs.proceed == 'true'
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -129,13 +129,24 @@ jobs:
               done < <(yq ".spec.sources[$i].helm.valueFiles[]" "$app_file" 2>/dev/null || true)
               echo ">>> $app_name: $chart@$revision"
               if is_oci "$repo_url"; then
-                chart_ref="oci://${repo_url}/${chart}"
+                # helm 4 prints the OCI pull result ("Pulled:" / "Digest:") on
+                # stdout, so rendering straight from an oci:// ref puts two
+                # non-manifest lines at the head of the stream and kubeconform
+                # reads them as a document with no kind. helm 3 did not do this,
+                # which is why it only surfaced once the version was pinned.
+                # Pull first with that output discarded, then render the copy.
+                oci_dir=$(mktemp -d)
+                helm pull "oci://${repo_url}/${chart}" \
+                  --version "$revision" --untar --untardir "$oci_dir" >/dev/null
+                chart_ref="$oci_dir/$chart"
+                version_args=()
               else
                 alias="r$(echo "$repo_url" | sha256sum | cut -c1-8)"
                 chart_ref="$alias/$chart"
+                version_args=(--version "$revision")
               fi
               helm template "$release_name" "$chart_ref" \
-                --version "$revision" \
+                "${version_args[@]}" \
                 --namespace "$namespace" \
                 "${values_args[@]}" \
                 | kubeconform -strict -ignore-missing-schemas \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -171,7 +171,15 @@ jobs:
           # the run below diffs against the PR's base commit
           fetch-depth: 0
 
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.3
+
+      # This job's verdict is "render, change one leaf, render again, compare",
+      # so the renderer is the measuring instrument. Record which one produced
+      # the result.
+      - name: helm version
+        run: helm version --short
 
       - name: Install PyYAML
         run: pip install --quiet pyyaml
@@ -201,8 +209,6 @@ jobs:
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:
           aqua_version: v2.62.3
-
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Check image existence
         run: |
@@ -341,8 +347,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -16,6 +16,11 @@
       "algorithm": "sha256"
     },
     {
+      "id": "http/get.helm.sh/helm-v4.2.4-linux-amd64.tar.gz",
+      "checksum": "C306B46F719B0A4DA32D0F78EE21BF90CE8D602F15B22AB753F0674D1670A7F3",
+      "algorithm": "sha256"
+    },
+    {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.553.0/registry.yaml",
       "checksum": "A0610103BC291509498CA448B8E9FB09588A1999FD0E391D1BEBEA8E596348A0",
       "algorithm": "sha256"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -28,3 +28,6 @@ packages:
   - name: mikefarah/yq@v4.53.4
   # provides `crane`
   - name: google/go-containerregistry@v0.21.9
+  # The registry entry verifies the tarball against get.helm.sh's published
+  # .sha256sum, which azure/setup-helm did not do at all.
+  - name: helm/helm@v4.2.4


### PR DESCRIPTION
The last unpinned tool. Every `azure/setup-helm` call here ran with no `version` input, so it resolved `latest` — measured on run 32570385974:

```
version: latest
Downloading 'v4.2.4' from 'https://get.helm.sh'
```

## Two separate problems

**Unverified.** `azure/setup-helm` v5.0.1 does not check what it downloads. (The `sha256` hits in its bundled `lib/index.js` are a vendored fetch library's subresource-integrity parser, not helm verification.) This is the same shape as the `releases/latest/download | tar xz` installs aqua already replaced. aqua's `helm/helm` registry entry verifies the tarball against the `.sha256sum` published beside it on `get.helm.sh`, and `aqua-checksums.json` pins that hash.

**`helm-template` was not even using setup-helm.** It installs nothing and calls `helm repo add` / `helm template` directly, so it ran on whatever helm the runner image ships — a *different* version from the other jobs, and one that appears in no log. The job that renders every chart for kubeconform was the least controlled of the six.

## Changes

| Where | Before | After |
|---|---|---|
| `lint.yaml` helm-template | runner image's helm (unlogged) | aqua (already had aqua-installer) |
| `lint.yaml` unread-values | setup-helm | aqua-installer |
| `lint.yaml` image-existence | setup-helm + aqua-installer | aqua-installer |
| `lint.yaml` argo-lint | setup-helm + aqua-installer | aqua-installer |
| `claude-fix-ci.yml` | setup-helm + aqua-installer | aqua-installer |
| `_claude-review.yml` | setup-helm | aqua-installer |

Pinned to `helm/helm@v4.2.4` — the version the other jobs were already resolving, so this is not a version bump. It does align `helm-template` with the rest, which is the one place output could shift; watch that job.

`helm version --short` is now logged in `unread-values` at that job author's request: its verdict is "render, change one leaf, render again, compare", so the renderer is the measuring instrument.

## Verification

`actionlint` and `zizmor` clean. `aqua i` installs helm v4.2.4 locally and leaves `aqua-checksums.json` byte-identical afterwards, which is what the `lint-aqua` shared workflow checks. No `setup-helm` left in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoQkgisfTG4AUatvnHNVxB