### PR TITLE
Stop the volatile-line mask from reading as "unread"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 # Claude Code worktrees live inside the repo and are untracked, so `git add -A`
 # stages them as an embedded gitlink instead of ignoring them.
 .claude/worktrees/
+
+# Python
+__pycache__/

--- a/scripts/unread-values.py
+++ b/scripts/unread-values.py
@@ -23,7 +23,28 @@ nothing either. Either probe moving the output proves the key is read.
 
 Ambiguity always resolves to "live" so that this stays quiet unless it is sure:
 a leaf that cannot be perturbed (empty map, null, empty list) is skipped, and a
-probe that makes the chart fail to render counts as proof the key is read.
+probe that makes the chart fail to render counts as proof the key is read. That
+direction matters more than it looks: this check's answer is "nobody reads this",
+and what someone does with that answer is delete the key. An unread verdict on a
+live key ends with working configuration removed and a note saying it was
+unnecessary.
+
+The volatile-line mask is the one place that breaks that rule, because it
+compares by line number and never looks at what those lines contain. An effect
+landing only inside masked lines is hidden, and hidden reads as unread.
+
+Searching the whole render for the probe value recovers the cases where the
+perturbed value is emitted verbatim. It does not recover the ones where the
+chart encodes the value first: pointing harbor at `certSource: auto` and
+perturbing `expose.tls.auto.commonName` moves 18 lines, all of them masked, and
+the probe string appears nowhere in the output because the common name is inside
+a base64 certificate. Measured, not assumed.
+
+Nothing distinguishes that from an unread key. Masked lines are regenerated on
+every render, so "only masked lines moved" is exactly what an unread key
+produces too. Rather than guess, charts that render non-deterministically are
+named in a warning: what they can hide is one key whose entire effect is
+confined to those lines.
 """
 
 import argparse
@@ -191,7 +212,15 @@ def check(src, targets):
             out = render(chart_dir, src, swapped)
         finally:
             os.unlink(probe_file)
-        return out is not None and same(base, out, mask)
+        if out is None:
+            return False
+        # same() skips the masked lines outright, so an effect that lands
+        # inside one of them is invisible to it. PROBE cannot appear in a
+        # render that did not read the key, so finding it anywhere is proof
+        # the key is live — whichever line it landed on.
+        if any(PROBE in line for line in out):
+            return False
+        return same(base, out, mask)
 
     def probe(rel, absolute, values, path, new):
         if not unchanged(absolute, values, path, new):
@@ -216,7 +245,7 @@ def check(src, targets):
 
     with ThreadPoolExecutor(max_workers=WORKERS) as pool:
         results = pool.map(lambda a: probe(*a), jobs)
-    return [r for r in results if r]
+    return [r for r in results if r], len(mask)
 
 
 def load_allowlist():
@@ -252,7 +281,7 @@ def main():
     touched = changed_files(args.changed) if args.changed else None
     allowed = load_allowlist()
 
-    unread, skipped = {}, []
+    unread, skipped, masked = {}, [], {}
     for src in sources():
         # A chart bump is exactly when upstream renames or restructures a key,
         # so a changed apps/ file pulls in all of that chart's values files.
@@ -264,10 +293,13 @@ def main():
         else:
             targets = set(src["files"])
 
-        found = check(src, targets)
-        if found is None:
+        result = check(src, targets)
+        if result is None:
             skipped.append(src["app"])
             continue
+        found, mask_size = result
+        if mask_size:
+            masked[src["app"]] = mask_size
         for rel in targets:
             unread.setdefault(rel, set())
         for rel, key in found:
@@ -292,6 +324,11 @@ def main():
 
     for app in skipped:
         print(f"::warning::{app}: render is not line-stable, cannot check its values")
+    for app, lines in sorted(masked.items()):
+        print(
+            f"::warning::{app}: {lines} line(s) are regenerated on every render and are "
+            "excluded from the comparison; a key whose only effect lands in them reads as unread"
+        )
 
     if new:
         print("Keys no template reads:")

--- a/scripts/unread-values.py
+++ b/scripts/unread-values.py
@@ -61,6 +61,8 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ALLOWLIST = os.path.join(ROOT, "scripts", "unread-values-allow.txt")
 CACHE = os.path.join(tempfile.gettempdir(), "unread-values-charts")
 
+SELF = {"scripts/unread-values.py", "scripts/unread-values-allow.txt"}
+
 PROBE = "zzprobe"
 WORKERS = min(8, (os.cpu_count() or 2) * 2)
 MISSING = object()
@@ -279,6 +281,13 @@ def main():
     args = ap.parse_args()
 
     touched = changed_files(args.changed) if args.changed else None
+    # A change to the checker or its allowlist is checked against everything.
+    # Scoping to the touched values files would mean a pull request that edits
+    # this file examines nothing at all and still reports success, which is how
+    # a broken comparison would reach main.
+    if touched is not None and touched & SELF:
+        print("checker changed - examining every chart")
+        touched = None
     allowed = load_allowlist()
 
     unread, skipped, masked = {}, [], {}


### PR DESCRIPTION
`unread-values.py` resolves ambiguity toward "live" everywhere — a leaf that cannot be perturbed is skipped, a probe that fails to render counts as proof the key is read — except in one place. The volatile-line mask compares by line number and never looks at what those lines contain, so an effect landing only inside them is invisible and comes back as *nobody reads this key*.

That direction is the expensive one. This check's answer is consumed by **deleting the key**, so a wrong "unread" ends with working configuration removed and a note saying it was unnecessary. That is the same shape as the accidents the check exists to find (#571).

## What changed

**Search the whole render for the probe string.** If the perturbed value shows up anywhere, the key is live regardless of which line it landed on. Cheap, and it cannot produce the opposite error — the probe cannot occur in a render that did not read the key.

**Name the charts that render non-deterministically**, because the search above does not cover everything:

```
::warning::cilium: 8 line(s) are regenerated on every render and are excluded from
  the comparison; a key whose only effect lands in them reads as unread
::warning::harbor: 14 line(s) are regenerated on every render and are excluded ...
```

**Check every chart when the checker itself changes.** See below — this one was found by watching this pull request pass.

## Why the search is not enough, measured

Charts that encode a value before emitting it defeat a text search. Pointing harbor at `certSource: auto` and perturbing `expose.tls.auto.commonName`:

| | |
|---|---|
| masked lines | 18 |
| lines moved by the perturbation | 18, **all masked** |
| lines containing the probe string | **none** — the common name is inside a base64 certificate |
| verdict before the fix | unread |
| verdict after the fix | unread |

So the search does not rescue this case, and **nothing else can either**. Masked lines are regenerated on every render, which means "only masked lines moved" is exactly what a genuinely unread key produces as well. There is no signal left to separate them. Guessing that it rarely matters would put the guess back in the place the check is supposed to remove it from, so the limit is stated in the module docstring and surfaced per-chart at runtime instead.

## The scope rule had the same problem

The first push of this branch went green in 11 seconds:

```
checked 0 values file(s), no unread keys
```

The scope rule examines the values files a pull request touches, so a pull request that edits only the checker examines nothing and still reports success. **The commit that rewrites how the verdict is reached was verified by a run that did no work.** A change breaking the comparison outright would have reached main the same way.

The script and its allowlist are inputs to every chart, so touching either now checks all of them:

```
checker changed - examining every chart
checked 31 values file(s), no unread keys
```

## Verification

Findings on this tree stay at zero, including the two charts that carry masks. That is the intended result and not the evidence — **the fix was verified against a case built to trip it**, above, rather than against a clean run. A clean run cannot tell "no renames happened" from "a rename hid in the mask", which is the whole reason for the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RMiotpWxy96TxFfh1MXS5
