### PR TITLE
feat(claude-code): make the CNP check show its work

### DIFF
--- a/manifests/claude-code/agent-prompts.yaml
+++ b/manifests/claude-code/agent-prompts.yaml
@@ -1,0 +1,111 @@
+# エージェントに渡す指示。マニフェストのヒアドキュメントから出して、プロンプトだけを
+# 単独で直せるようにする。verdict-protocol は全タスク共通、タスク固有の手順とは分ける。
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-verdict-protocol
+  namespace: claude-code
+data:
+  verdict-protocol.md: |
+    # 判定の出し方（全タスク共通）
+
+    結論は文章ではなく **置き場所** で表す。回収側はディレクトリしか見ず、
+    あなたの発話は一切読まない。
+
+    | 結論 | 置き場所 |
+    |---|---|
+    | 問題なし | `/work/out/pass/report.md` |
+    | 対処すべき指摘がある | `/work/out/attention/report.md` |
+    | 判定できない | `/work/out/escalate/report.md` |
+
+    ## 規則
+
+    - **3 つのうち必ず 1 つだけ**に書く。2 つ以上に置くと判定不能として扱われ、
+      内容に関係なく人間に差し戻される
+    - ファイル名は `report.md` 固定
+    - `/work/out/` に新しいディレクトリは作れない。作れなくても異常ではないので、
+      回避しようとしないこと
+    - 判断に足る材料が無いときは、無理に pass / attention を選ばず **escalate** を選ぶ。
+      判定できないと述べることは失敗ではない
+
+    ## 報告に必ず含めるもの
+
+    - **主張と、それを確かめた手順を対にして書く。** 確かめていないものは
+      「未確認の推測」と明記する。確かめられるのに確かめていない主張は書かない
+    - 対処案は、現状より権限や到達範囲を広げないものに限る
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cnp-check-prompt
+  namespace: claude-code
+data:
+  cnp-check.md: |
+    # CiliumNetworkPolicy カバレッジ点検
+
+    全 namespace の Pod がポリシーに覆われているかを点検し、報告する。
+
+    ## 与えられている権限
+
+    読み取り専用。`pods` / `namespaces` / `ciliumnetworkpolicies` /
+    `ciliumclusterwidenetworkpolicies` の get・list のみ。
+    `kubectl exec` も書き込みもできない。できないことを迂回しようとしないこと。
+
+    ## Cilium の強制セマンティクス（読み違えやすいので必ず踏まえる）
+
+    - エンドポイントは **ingress ルールを持つポリシーに選択されて初めて ingress が強制**される。
+      egress も同様に、egress ルールを持つポリシーに選択されて初めて強制される
+    - したがって **egress ルールしか持たないポリシー（CCNP `allow-dns` など）にのみ
+      選択されているエンドポイントは、egress は絞られるが ingress は無防備**（全許可）になる
+    - これを「ingress が全 DENY」と読むと**危険度の評価が反転する**。
+      遮断されているのではなく、誰からでも到達できる状態である
+    - `ingress: []`（空リスト）は no-op で何も強制しない
+
+    ## 手順
+
+    1. `kubectl get cnp -A -o json` と `kubectl get ccnp -o json` で全ポリシーを取得
+    2. `kubectl get pods -A -o json` で全 Pod とラベルを取得
+    3. 各 Pod について、**どのポリシーの `endpointSelector` に一致するか**を判定する。
+       一致したポリシーが ingress ルールを持つか / egress ルールを持つかを**分けて**記録する
+    4. 直近 24 時間の `POLICY_DENIED` を Loki で確認する
+
+    ## Loki
+
+    ```
+    curl -sG 'http://loki-gateway.monitoring.svc.cluster.local:80/loki/api/v1/query_range' \
+      --data-urlencode 'query={job="hubble"}' \
+      --data-urlencode 'limit=300' \
+      --data-urlencode "start=$(date -u -d '24 hours ago' +%s)000000000"
+    ```
+
+    取得できない場合はその旨を書いて次に進む。
+
+    **Hubble の export は DROPPED しか流していない。** よって「宛先 X のフローが無い」は
+    「誰も X と通信していない」の証拠にならない。許可された通信は記録に残らないので、
+    フローの不在から通信の不在を結論しないこと。
+
+    ## 対象外
+
+    - `hostNetwork: true` の Pod（ポリシーの対象外）
+    - `Completed` / `Succeeded` の Pod
+
+    ## 主張ごとに要求される裏取り
+
+    | 主張 | 併記する根拠 |
+    |---|---|
+    | Pod X は未カバー | X のラベルと、照合したポリシー名（一致が無いなら「一致なし」と明記） |
+    | X は ingress が強制されていない | X を選択しているポリシー名と、それが ingress ルールを持たないこと |
+    | Y が原因で DENIED になっている | Y を実際に確認したコマンドと結果。ラベル不一致を疑うなら**その Pod のラベルを見る** |
+
+    裏が取れなかった主張は、書かないか「未確認の推測」と明記する。
+
+    ## 対処案の制約
+
+    - `toCIDR: 0.0.0.0/0` は使わない。外部 HTTPS は `toFQDNs` でドメイン単位に絞る
+    - 現状より到達範囲を広げる案を出さない
+    - DNS egress は CCNP で全 Pod に共通適用済みなので、個別 CNP には書かない
+
+    ## レポート
+
+    namespace ごとの未カバー Pod、`POLICY_DENIED` の送信元・宛先・理由、対処案を簡潔に。
+    3000 字以内。

--- a/manifests/claude-code/cnp-check-cwf.yaml
+++ b/manifests/claude-code/cnp-check-cwf.yaml
@@ -89,6 +89,13 @@ spec:
     volumes:
       - name: work
         emptyDir: {}
+      - name: prompt
+        projected:
+          sources:
+            - configMap:
+                name: agent-verdict-protocol
+            - configMap:
+                name: cnp-check-prompt
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
@@ -145,37 +152,8 @@ spec:
           workingDir: /work
           args:
             - |
-              PROMPT="あなたは Kubernetes クラスタの CiliumNetworkPolicy カバレッジ点検員です。
-
-              ## タスク
-              全 namespace の Pod が CNP/CCNP に覆われているかを点検し、結果を報告してください。
-
-              ## 手順
-              1. kubectl get ciliumnetworkpolicies -A -o json と kubectl get ciliumclusterwidenetworkpolicies -o json で全ポリシーを取得する
-              2. kubectl get pods -A -o json で全 Pod とそのラベルを取得する
-              3. 各 Pod が、どのポリシーの endpointSelector にも一致しないかを判定する
-              4. 直近 24 時間の POLICY_DENIED を Loki で確認する:
-                 curl -sG 'http://loki-gateway.monitoring.svc.cluster.local:80/loki/api/v1/query_range' \\
-                   --data-urlencode 'query={job=\"hubble\"}' --data-urlencode 'limit=300' \\
-                   --data-urlencode \"start=\$(date -u -d '24 hours ago' +%s)000000000\"
-                 取得できない場合はその旨を書いて次に進む
-
-              ## 除外
-              hostNetwork: true の Pod は CNP の対象外なので未カバー扱いにしない。
-              Completed/Succeeded の Pod も対象外。
-
-              ## 出力（重要）
-              判定に応じて置き場所を変えること。ファイル名は report.md 固定。
-
-              - 未カバー Pod も POLICY_DENIED も無い  -> /work/out/pass/report.md
-              - 対処すべき指摘がある                  -> /work/out/attention/report.md
-              - 情報が足りず判定できない              -> /work/out/escalate/report.md
-
-              **3 つのうち必ず 1 つだけに書くこと。** 複数に書いてはいけない。
-              /work/out/ に新しいディレクトリを作ることはできない（作れなくても正常）。
-
-              report.md の中身は自由。namespace ごとの未カバー Pod、POLICY_DENIED の
-              送信元/宛先と理由、対処案を簡潔に。長くても 3000 字以内。"
+              # 指示は ConfigMap から読む。ここでは組み立てない。
+              PROMPT="$(cat /prompt/cnp-check.md; echo; cat /prompt/verdict-protocol.md)"
 
               claude -p \
                 --verbose \
@@ -226,6 +204,9 @@ spec:
           volumeMounts:
             - name: work
               mountPath: /work
+            - name: prompt
+              mountPath: /prompt
+              readOnly: true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
#569 の初回実行は**検出は当たっていたが、診断は 2 箇所とも外していた**。

| 主張 | 実際 |
|---|---|
| claude-code の workflow Pod は `claude-code=true` を持たないので CNP に選択されない | Pod は持っている。真因は CNP の `toFQDNs` が 9 ドメインしか許可していないこと |
| qdrant は ingress 全 DENY で遮断されている | **逆。** 唯一選択している CCNP `allow-dns` は egress ルールのみなので ingress は未強制＝どこからでも到達可能だった |

しかも対処案が `toCIDR: 0.0.0.0/0` の 443 全開放で、FQDN 許可リストを任意 HTTPS に置き換える改悪だった。

どれも**「確かめれば決着する問いを、確かめずに断定した」**結果なので、指示側で裏取りを要求する。

## 変更

**1. 主張ごとに根拠の併記を必須にした**

| 主張 | 併記する根拠 |
|---|---|
| Pod X は未カバー | X のラベルと、照合したポリシー名 |
| X は ingress が強制されていない | X を選択しているポリシー名と、それが ingress ルールを持たないこと |
| Y が原因で DENIED | Y を確認したコマンドと結果。ラベル不一致を疑うならそのラベルを見る |

裏が取れないものは書かないか「未確認の推測」と明記する。

**2. 読み違えたセマンティクスを明示した**

ingress ルールを持つポリシーに選択されて初めて ingress が強制される。egress ルールだけのポリシーに選択されているエンドポイントは **ingress が無防備**であって遮断ではない。方向を逆に読むと危険度の評価が反転する。

**3. Hubble の性質を明示した**

export は DROPPED しか流していないので、「フローが無い」は「通信が無い」の証拠にならない。

**4. 対処案の制約**

`toCIDR: 0.0.0.0/0` を名指しで禁止（実際にこれを出したため）。到達範囲を広げる案を出さない。

**5. 指示を ConfigMap に出した**

プロンプトが YAML の中のシェルの中のヒアドキュメントで、クォートが 3 重だった。調整のたびに Workflow を編集することになる。

- `agent-verdict-protocol` — **全タスク共通**の出力契約（3 分類・1 つだけ・迷ったら escalate）
- `cnp-check-prompt` — この点検固有の手順

タスクを増やすときに出力契約を書き直さなくて済む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn