### PR TITLE
Fail when the values discovery collapses

### DIFF
--- a/scripts/unread-values.py
+++ b/scripts/unread-values.py
@@ -63,6 +63,13 @@ CACHE = os.path.join(tempfile.gettempdir(), "unread-values-charts")
 
 SELF = {"scripts/unread-values.py", "scripts/unread-values-allow.txt"}
 
+# A full run examines every values file reachable from apps/. If that number
+# collapses, the discovery above broke — a schema change in the Application
+# manifests, a rename under helm-values/, a parse that silently yields nothing —
+# and the check reports "no unread keys" while looking at almost nothing. 31 as
+# of 2026-08-22. Re-baseline deliberately when the real number moves.
+MIN_VALUES_FILES = 25
+
 PROBE = "zzprobe"
 WORKERS = min(8, (os.cpu_count() or 2) * 2)
 MISSING = object()
@@ -351,6 +358,15 @@ def main():
         print("\nAllowlist entries that no longer reproduce — delete them:")
         for rel, key in stale:
             print(f"::error file={os.path.relpath(ALLOWLIST, ROOT)}::{rel}::{key}")
+    # Only meaningful for a full run: when scoped to a pull request, examining
+    # nothing is the ordinary result of a pull request that touches no values.
+    if touched is None and len(unread) < MIN_VALUES_FILES:
+        print(
+            f"::error::only {len(unread)} values file(s) examined, expected at least "
+            f"{MIN_VALUES_FILES} — the discovery in sources() is broken, not the charts"
+        )
+        return 1
+
     if not new and not stale:
         print(f"checked {len(unread)} values file(s), no unread keys")
     return 1 if new or stale else 0


### PR DESCRIPTION
#577 stopped a pull request that edits the checker from examining nothing. It left the other route to zero: **the discovery breaking while the charts stay healthy.**

`sources()` walks `apps/` for Application manifests and pulls `valueFiles` out of them. A schema change upstream, a rename under `helm-values/`, or a parse that quietly yields nothing all end the same way — `no unread keys`, green, having looked at almost nothing.

## Guarding zero alone is not enough

That is the part worth stating, and it came out of a parallel case in home-trading today: a collection sweep guards `if not candidates: fail`, so zero is caught — but a partial master import leaving **50 symbols instead of 5,546** passes, and writes a `write_once` record saying that day had 50 tradable symbols. Nothing distinguished the two magnitudes.

Same here. A partial break is the more likely one and it survives a zero check: discovery that finds one chart instead of 31 reports success just as confidently.

So a full run now requires 25 of the current 31, in the same shape `image-existence` already uses for extracted images (`MIN_IMAGES=60`).

## Verified against breakages, not a clean run

| break | result |
|---|---|
| `valueFiles` moved (schema change) | `only 0 values file(s) examined` → exit 1 |
| `$values/` prefix left unresolved | `baseline render failed` → exit 1 |
| discovery finds one chart | `only 1 values file(s) examined` → exit 1 |

The third is the one a zero check would have missed.

The floor applies only to full runs. Scoped to a pull request, examining nothing is the ordinary result for a pull request that touches no values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RMiotpWxy96TxFfh1MXS5
