### PR TITLE
fix(claude-code): count ingressDeny as ingress enforcement

### DIFF
--- a/manifests/claude-code/agent-prompts.yaml
+++ b/manifests/claude-code/agent-prompts.yaml
@@ -53,9 +53,11 @@ data:
 
     ## Cilium の強制セマンティクス（読み違えやすいので必ず踏まえる）
 
-    - エンドポイントは **ingress ルールを持つポリシーに選択されて初めて ingress が強制**される。
-      egress も同様に、egress ルールを持つポリシーに選択されて初めて強制される
-    - したがって **egress ルールしか持たないポリシー（CCNP `allow-dns` など）にのみ
+    - エンドポイントは **`ingress` または `ingressDeny` を持つポリシーに選択されて初めて
+      ingress が強制**される。`ingressDeny` しか持たないポリシー（`fromEntities: [world]` だけ、など）
+      でも強制は有効になる。**`ingress` の有無だけで判定しないこと**
+    - egress も同様に、`egress` または `egressDeny` を持つポリシーに選択されて初めて強制される
+    - したがって **egress 系のルールしか持たないポリシー（CCNP `allow-dns` など）にのみ
       選択されているエンドポイントは、egress は絞られるが ingress は無防備**（全許可）になる
     - これを「ingress が全 DENY」と読むと**危険度の評価が反転する**。
       遮断されているのではなく、誰からでも到達できる状態である
@@ -66,7 +68,8 @@ data:
     1. `kubectl get cnp -A -o json` と `kubectl get ccnp -o json` で全ポリシーを取得
     2. `kubectl get pods -A -o json` で全 Pod とラベルを取得
     3. 各 Pod について、**どのポリシーの `endpointSelector` に一致するか**を判定する。
-       一致したポリシーが ingress ルールを持つか / egress ルールを持つかを**分けて**記録する
+       一致したポリシーが `ingress` / `ingressDeny` / `egress` / `egressDeny` のどれを持つかを
+       **キーごとに**記録する。`ingress` が空でも `ingressDeny` があれば ingress は強制される
     4. 直近 24 時間の `POLICY_DENIED` を Loki で確認する
 
     ## Loki
@@ -94,7 +97,7 @@ data:
     | 主張 | 併記する根拠 |
     |---|---|
     | Pod X は未カバー | X のラベルと、照合したポリシー名（一致が無いなら「一致なし」と明記） |
-    | X は ingress が強制されていない | X を選択しているポリシー名と、それが ingress ルールを持たないこと |
+    | X は ingress が強制されていない | X を選択している全ポリシー名と、**そのいずれもが `ingress` と `ingressDeny` の両方を持たない**こと |
     | Y が原因で DENIED になっている | Y を実際に確認したコマンドと結果。ラベル不一致を疑うなら**その Pod のラベルを見る** |
 
     裏が取れなかった主張は、書かないか「未確認の推測」と明記する。
@@ -107,5 +110,7 @@ data:
 
     ## レポート
 
+    **重要な指摘から先に書く。** レポートは 3000 字で打ち切られるため、後ろに置いた内容は
+    人間に届かない。冒頭に結論の箇条書きを置き、詳細をその後に続ける。
+
     namespace ごとの未カバー Pod、`POLICY_DENIED` の送信元・宛先・理由、対処案を簡潔に。
-    3000 字以内。

--- a/manifests/claude-code/cnp-check-cwf.yaml
+++ b/manifests/claude-code/cnp-check-cwf.yaml
@@ -177,6 +177,11 @@ spec:
               if [ "$COUNT" = "1" ]; then
                 VERDICT="$FOUND"
                 head -c 3500 "/work/out/$FOUND/report.md" > /work/report.md 2>/dev/null || true
+                # 切り詰めたことを読み手に伝える。黙って落とすと欠けたことに気づけない
+                if [ "$(wc -c < "/work/out/$FOUND/report.md" 2>/dev/null || echo 0)" -gt 3500 ]; then
+                  echo "" >> /work/report.md
+                  echo "_（レポートが 3500 バイトを超えたため以降を省略。全文は Argo UI のログ参照）_" >> /work/report.md
+                fi
               else
                 VERDICT=indeterminate
                 echo "非空のディレクトリが $COUNT 個ありました（ちょうど 1 個であるべき）。" > /work/report.md


### PR DESCRIPTION
#578 で書いた指示に誤りがあった。

> エンドポイントは **ingress ルールを持つポリシーに選択されて初めて ingress が強制**される

**`ingressDeny` でも強制は有効になる。** argo の `sensor` CNP は

```yaml
ingress: null
ingressDeny: [{fromEntities: [world]}]
```

で `ingress` を一切持たないが、選択されている Pod は `policy-enabled = both`。

```
k8s:sensor-name=aqua-checksum      policy-enabled= both
k8s:sensor-name=single-repo-build  policy-enabled= both
k8s:sensor-name=task-status-sync   policy-enabled= egress   ← こちらは本当に未強制
```

結果、点検は sensor Pod 3 件を「クラスタ内のどこからでも到達可能」と報告した。実際は強制されている。**エージェントは指示どおりに動いており、間違っていたのは指示**。

## 変更

- 判定条件を `ingress` **または** `ingressDeny` に修正
- 「ingress が強制されていない」と述べる条件を、**選択している全ポリシーがどちらのキーも持たないこと**に厳格化
- 手順を「方向ごと」ではなく**キーごとに記録**するよう変更（`ingress` が空でも `ingressDeny` があれば強制される、と明記）

指摘の類型自体は本物で、`task-status-sync-eventsource` と `talos-extension-bump-sensor` は実際に ingress 未強制だった。そちらは別途対応する。

## 切り詰めの可視化

レポートは 3500 バイトで打ち切られる。今回の実行は**未強制 Pod の一覧の途中で切れており**、一番行動に繋がる部分が Discord に届かず、しかも切れたことがどこにも出ていなかった。

- 回収側が切り詰め時に注記を追記する
- 指示側で「重要な指摘から先に書く」を明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn