### PR TITLE
ci: sign the commits ai-fix-ci makes

### DIFF
--- a/.github/workflows/claude-fix-ci.yml
+++ b/.github/workflows/claude-fix-ci.yml
@@ -123,6 +123,19 @@ jobs:
           # line below, the `gh run view --log-failed` in the prompt is a 403.
           additional_permissions: |
             actions: read
+          # Claude commits with plain `git` unless this is set, and a runner-side
+          # git commit is unsigned. With it, the action registers its
+          # github_file_ops MCP server and the commit goes through the Git Data
+          # API instead, which GitHub signs — the same path the cluster-side
+          # aqua-checksum workflow already uses.
+          #
+          # This is the last unsigned push path in the fleet, and closing it is
+          # what lets required_signatures widen from the default branch to all
+          # branches. Unverified in practice: this job has never once reached
+          # the agent step (every run so far ends at the proceed guard because
+          # CI was green), so the first real fix it attempts is also the first
+          # test of this.
+          use_commit_signing: "true"
           # Match the reviewer's posture: no web access, and a turn budget so a
           # confused run ends before the job timeout does.
           claude_args: "--model claude-sonnet-5 --max-turns 40 --disallowedTools WebFetch,WebSearch,NotebookEdit"


### PR DESCRIPTION
Prerequisite for widening `required_signatures` from the default branch to **all branches**.

## The mechanism

`use_commit_signing` changes which path Claude commits through (v1.0.99 source):

| | commit path | signed |
|---|---|---|
| `false` (default) | Claude runs plain `git commit` in Bash | **no** |
| `true` | the action registers its `github_file_ops` MCP server; commits go through the Git Data API | **yes** |

The action itself does not commit here. `branch-cleanup.ts` has a `git add -A` / `git commit` / `git push` fallback, but it only runs when `claudeBranch` is set — the tag-mode path for issues and closed PRs, not this job. What commits is Claude, because instruction 4 of the prompt tells it to.

## Why this is the only one

Every other path that writes to a branch across the thirteen repos is already signed — checked, not assumed:

- local commits: `commit.gpgsign=true` with SSH signing
- both Renovate identities (`tsuguya-home-cluster[bot]`, `renovate[bot]`): commit through the API
- cluster-side `aqua-checksum`: uses `github-signed-commit.sh` (Git Data API)
- no workflow YAML in any repo runs `git push` or `git commit` directly
- every open PR head across all thirteen repos verifies as signed

## Caveat

**This is unverified in practice.** `claude-fix-ci` has never once reached the agent step — all 30 most recent runs end at the `proceed` guard because CI was green, and the workflow's own comment records an earlier stretch where a `direct_prompt` typo meant it never ran at all. So the first real fix it attempts will also be the first test of this setting.

That argues for landing it *before* the signature rule widens, not after: if it were the other way round, the job's first ever run would fail on a rejected push, in the one situation where CI is already broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoQkgisfTG4AUatvnHNVxB