### PR TITLE
fix(claude-code): stop cutting reports in the middle of a character

### DIFF
--- a/manifests/claude-code/adjudicator-wft.yaml
+++ b/manifests/claude-code/adjudicator-wft.yaml
@@ -252,7 +252,10 @@ spec:
               COLOR=16711680
             fi
 
-            REPORT=$(printf '%s' '{{workflow.outputs.parameters.adjudication-report}}' | head -c 3800)
+            # Discord の上限は 4096 "文字"。jq の文字列スライスは文字単位。
+            REPORT=$(printf '%s' '{{workflow.outputs.parameters.adjudication-report}}' \
+              | jq -Rsr --argjson max 3900 \
+                  'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end')
             if [ -z "$REPORT" ]; then
               REPORT="裁定結果を取得できませんでした。Argo UI でログを確認してください。"
             fi

--- a/manifests/claude-code/alert-investigate-wft.yaml
+++ b/manifests/claude-code/alert-investigate-wft.yaml
@@ -127,14 +127,15 @@ spec:
               COLOR=16711680
             fi
 
-            REPORT=""
-            if [ -f /report/result.txt ]; then
-              REPORT=$(head -c 3800 /report/result.txt)
+            # Discord の embed description 上限は 4096 "文字"。バイトで切ると
+            # UTF-8 を割るうえ、日本語では送れる量の 1/3 しか使えない。
+            if [ ! -s /report/result.txt ]; then
+              printf '%s' "調査結果を取得できませんでした。Argo UI でログを確認してください。" \
+                > /report/result.txt
             fi
-
-            if [ -z "$REPORT" ]; then
-              REPORT="調査結果を取得できませんでした。Argo UI でログを確認してください。"
-            fi
+            REPORT=$(jq -Rsr --argjson max 3900 \
+              'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end' \
+              < /report/result.txt)
 
             PAYLOAD=$(jq -n \
               --arg title "Alert Investigation ${STATUS}: ${WF_NAME}" \

--- a/manifests/claude-code/cnp-check-cwf.yaml
+++ b/manifests/claude-code/cnp-check-cwf.yaml
@@ -176,12 +176,13 @@ spec:
 
               if [ "$COUNT" = "1" ]; then
                 VERDICT="$FOUND"
-                head -c 3500 "/work/out/$FOUND/report.md" > /work/report.md 2>/dev/null || true
-                # 切り詰めたことを読み手に伝える。黙って落とすと欠けたことに気づけない
-                if [ "$(wc -c < "/work/out/$FOUND/report.md" 2>/dev/null || echo 0)" -gt 3500 ]; then
-                  echo "" >> /work/report.md
-                  echo "_（レポートが 3500 バイトを超えたため以降を省略。全文は Argo UI のログ参照）_" >> /work/report.md
-                fi
+                # 文字単位で切る（jq のスライスは UTF-8 のコードポイントを割らない）。
+                # 切り詰めたことも同時に伝える。黙って落とすと欠けたことに気づけない
+                jq -Rsr --argjson max 3500 \
+                  'if length > $max
+                   then .[0:$max] + "\n\n_（レポートが長いため以降を省略。全文は Argo UI のログ参照）_"
+                   else . end' \
+                  < "/work/out/$FOUND/report.md" > /work/report.md 2>/dev/null || true
               else
                 VERDICT=indeterminate
                 echo "非空のディレクトリが $COUNT 個ありました（ちょうど 1 個であるべき）。" > /work/report.md
@@ -241,7 +242,10 @@ spec:
           args:
             - |
               VERDICT='{{workflow.outputs.parameters.cnp-check-verdict}}'
-              REPORT=$(printf '%s' '{{workflow.outputs.parameters.cnp-check-report}}' | head -c 3800)
+              # Discord の上限は 4096 "文字"。バイトで切ると UTF-8 を割る
+              REPORT=$(printf '%s' '{{workflow.outputs.parameters.cnp-check-report}}' \
+                | jq -Rsr --argjson max 3900 \
+                    'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end')
               WF_NAME="{{workflow.name}}"
               NS="{{workflow.namespace}}"
               URL="https://argo.infra.tgy.io/workflows/${NS}/${WF_NAME}"

--- a/manifests/claude-code/task-executor-wft.yaml
+++ b/manifests/claude-code/task-executor-wft.yaml
@@ -98,18 +98,20 @@ spec:
               --max-turns 30 \
               "$PROMPT" || true
 
-            RESULT=""
-            if [ -f /tmp/result.txt ]; then
-              RESULT=$(head -c 3800 /tmp/result.txt)
-            fi
-            if [ -z "$RESULT" ]; then
-              RESULT="結果ファイルが生成されませんでした。Argo UI でログを確認してください。"
+            # horenso の result は TEXT で上限が無い。ここで切る理由は無いので、
+            # 暴走時の保険としての上限だけ残す。jq の文字列スライスは文字単位なので
+            # UTF-8 のコードポイントを割らない。
+            if [ ! -s /tmp/result.txt ]; then
+              printf '%s' "結果ファイルが生成されませんでした。Argo UI でログを確認してください。" \
+                > /tmp/result.txt
             fi
 
-            PAYLOAD=$(jq -n \
-              --arg status "completed" \
-              --arg result "$RESULT" \
-              '{status:$status,result:$result}')
+            PAYLOAD=$(jq -Rs --arg status "completed" --argjson max 65536 \
+              '{status: $status,
+                result: (if length > $max
+                         then .[0:$max] + "\n\n_(結果が長いため以降を省略。Argo UI のログに全文があります)_"
+                         else . end)}' \
+              < /tmp/result.txt)
             curl -s -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \

--- a/manifests/claude-code/task-executor-write-wft.yaml
+++ b/manifests/claude-code/task-executor-write-wft.yaml
@@ -178,18 +178,20 @@ spec:
               --model sonnet \
               "$PROMPT" || true
 
-            RESULT=""
-            if [ -f /tmp/result.txt ]; then
-              RESULT=$(head -c 3800 /tmp/result.txt)
-            fi
-            if [ -z "$RESULT" ]; then
-              RESULT="結果ファイルが生成されませんでした。Argo UI でログを確認してください。"
+            # horenso の result は TEXT で上限が無い。ここで切る理由は無いので、
+            # 暴走時の保険としての上限だけ残す。jq の文字列スライスは文字単位なので
+            # UTF-8 のコードポイントを割らない。
+            if [ ! -s /tmp/result.txt ]; then
+              printf '%s' "結果ファイルが生成されませんでした。Argo UI でログを確認してください。" \
+                > /tmp/result.txt
             fi
 
-            PAYLOAD=$(jq -n \
-              --arg status "completed" \
-              --arg result "$RESULT" \
-              '{status:$status,result:$result}')
+            PAYLOAD=$(jq -Rs --arg status "completed" --argjson max 65536 \
+              '{status: $status,
+                result: (if length > $max
+                         then .[0:$max] + "\n\n_(結果が長いため以降を省略。Argo UI のログに全文があります)_"
+                         else . end)}' \
+              < /tmp/result.txt)
             curl -s -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \


### PR DESCRIPTION
horenso [#76](https://github.com/Tsuguya/horenso/issues/76) の原因。**horenso のバグではない。**

`result TEXT` に上限は無く、切り詰めているのは home-cluster のワークフローテンプレート側の `head -c 3800`。

## 何が起きていたか

`head -c` は**バイト**を数える。日本語は 1 文字 3 バイトなので、境界が文字の途中に落ちると壊れた UTF-8 が残る。

```
$ head -c 3800 <15000バイトの日本語>
'utf-8' codec can't decode bytes in position 3798-3799: unexpected end of data
末尾 → '。復旧手順を確�'
```

実害は Issue の通り。task #293（kanidm レプリケーション分岐の復旧手順）が「StatefulSet を scale し<fffd>」で切れ、`completed` になったため誰も気づかず、7 週間後の再発時に手順を作り直すことになった。

## 修正

`jq` の文字列スライスに置き換える。**文字単位なのでコードポイントを割れない**し、どのスクリプトにも既に jq が入っている。

```
jq -Rsr --argjson max 3900 'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end'
```

検証（15000 バイトの日本語）:

| | 結果 |
|---|---|
| `head -c 3800` | **デコード失敗**（position 3798） |
| `jq` | 成功、3912 文字、マーカー付き |

## 6 箇所を 2 種類に分けた

**horenso へ書き戻す 2 箇所**（`task-executor` / `task-executor-write`）— 切る理由が無い。`result` は `TEXT` で上限なし。全文を送る。64K の上限だけ**暴走時の保険**として残す（書式上の制約ではない）。

**Discord へ送る 4 箇所** — 上限自体は正当だが、embed description は **4096「文字」**。3800「バイト」で切ると日本語では約 1300 文字にしかならず、**送れる量の 1/3 しか使っていなかった**。3900 文字に変更。

うち 2 箇所は今日追加した `cnp-check`。切り詰め注記は足したのに、カット自体は同じバグを踏んでいた。

## 出どころ

horenso タスク #437 として調査エージェントに投げた結果、`kubectl get workflowtemplate` 経由で原因を特定した。リポジトリを読ませていない。ただし探索範囲を WorkflowTemplate に限ったため、CronWorkflow 側の 2 箇所は取りこぼしている（本 PR では 6 箇所すべてを対象にした）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn