### PR TITLE
fix(harbor): raise nginx memory limit to 512Mi

### DIFF
--- a/helm-values/harbor/values.yaml
+++ b/helm-values/harbor/values.yaml
@@ -146,12 +146,14 @@ jobservice:
       memory: 256Mi
 
 nginx:
+  # 全 push/pull の経路。大きい blob の並列アップロードでスパイクし、
+  # 128Mi では OOMKilled した (2026-08-22)
   resources:
     requests:
       cpu: 10m
-      memory: 32Mi
+      memory: 64Mi
     limits:
-      memory: 128Mi
+      memory: 512Mi
 
 exporter:
   resources:


### PR DESCRIPTION
## 何が起きたか

`image-build-9h9xg`（claude-code イメージ）が push 段階で失敗した。

```
#11 pushing layers
  error: ... write tcp 10.244.8.157:33934->10.107.133.63:443: write: connection reset by peer  (×4)
#11 ERROR: failed to push registry.infra.tgy.io/tools/claude-code:b87f766b...
  dial tcp 10.107.133.63:443: connect: connection refused
```

`10.107.133.63` は `svc/harbor`（component=nginx）。同時刻に:

```
harbor-nginx-675d864d44-rb47f  lastReason=OOMKilled  exit=137  at=2026-08-22T13:43:51Z
```

reset → refused の遷移は nginx が落ちてから再起動するまでの窓と一致する。`harbor-registry` は restarts=0 で無関係。

## なぜ

全ての push/pull が nginx を通り、buildkit は blob を並列アップロードする。アイドル 27Mi・平常ピーク 68Mi に対し limit が 128Mi で、ヘッドルームが 2 倍未満だった。claude-code は `exporting layers 146.9s` かかる大きさで、4 並列の blob upload がこれを踏み抜いた。

Prometheus は 5 分刻みなのでスパイク自体は捕捉できていない（記録上の最大は 68Mi）。判定は OOMKilled イベントと buildkit のエラー時刻の一致による。

## 変更

`nginx.resources` の limit 128Mi → 512Mi、request 32Mi → 64Mi。限界値ではなくヘッドルームを取る。

レンダリングでチャートが実際に読むことを確認済み:

```
harbor-nginx nginx {'limits': {'memory': '512Mi'}, 'requests': {'cpu': '10m', 'memory': '64Mi'}}
```

## 残作業

`image-build-9h9xg` の再実行（`tools/claude-code:b87f766b` は未 push）。マージ後に行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyK2G15ZkUH4iQseHPgyiV
