### PR TITLE
feat(monitoring): alert on OOMKilled, scrape argo workflow-controller

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -114,7 +114,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | Component | Ingress | Egress |
 |---|---|---|
 | **workflows-server** | ingress → 2746 (L7 HTTP); sensors (tofu-cloudflare, upgrade-k8s, pxe-sync), workflows-controller → 2746 | kube-apiserver, shared-pg (database):5432, kanidm (kanidm):8443, seaweedfs-filer (seaweedfs):8333 |
-| **workflows-controller** | host → 6060 | kube-apiserver, shared-pg (database):5432, workflows-server:2746 |
+| **workflows-controller** | host → 6060; prometheus (monitoring) → 9090 (metrics, TLS) | kube-apiserver, shared-pg (database):5432, workflows-server:2746 |
 | **eventsource** | cloudflared (argocd) → 12000 | kube-apiserver, eventbus:4222 |
 | **alertmanager-eventsource** | alertmanager (monitoring) → 12001 | kube-apiserver, eventbus:4222 |
 | **argocd-deployed-eventsource** | notifications-controller (argocd) → 12003 | kube-apiserver, eventbus:4222 |
@@ -140,7 +140,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **prometheus** | grafana, tempo, claude-code (claude-code) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
+| **prometheus** | grafana, tempo, claude-code (claude-code) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
 | **alertmanager** | prometheus → 9093/8080 | discord.com:443, discordapp.com:443, alertmanager-eventsource (argo):12001 |
 | **grafana** | ingress → 3000 (L7 HTTP); prometheus → 3000 | kube-apiserver, prometheus:9090, loki-gateway:8080, tempo:3200, shared-pg (database):5432, kanidm (kanidm):8443 |
 | **kube-state-metrics** | prometheus → 8080 | kube-apiserver |

--- a/helm-values/argo-workflows/values.yaml
+++ b/helm-values/argo-workflows/values.yaml
@@ -15,6 +15,20 @@ artifactRepository:
       key: AWS_SECRET_ACCESS_KEY
 
 controller:
+  # Prometheus に取り込まないと、ワークフローの失敗は Argo UI を開いた人しか
+  # 気づけない。9090 は元から開いていて中身も出ているが、scrape 先が無かった。
+  #
+  # secure を明示するのは、この設定を有効にした時点で chart が configmap へ
+  # secure を書き下ろすため。chart のデフォルトは false なので、書かずに
+  # enabled だけ立てると今 TLS で喋っているエンドポイントが平文に落ちる。
+  #
+  # ServiceMonitor は chart 側を使わない（templates に tlsConfig を渡す口が
+  # 無く、自己署名証明書を検証できずに scrape が落ちる）。
+  # manifests/argo/servicemonitor-workflow-controller.yaml が実体。
+  metricsConfig:
+    enabled: true
+    secure: true
+
   links:
     - name: Grafana Logs
       scope: workflow

--- a/manifests/argo/netpol-workflows-controller.yaml
+++ b/manifests/argo/netpol-workflows-controller.yaml
@@ -14,6 +14,14 @@ spec:
         - ports:
             - port: "6060"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prometheus
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
   egress:
     - toEntities:
         - kube-apiserver

--- a/manifests/argo/servicemonitor-workflow-controller.yaml
+++ b/manifests/argo/servicemonitor-workflow-controller.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argo-workflows-workflow-controller
+  namespace: argo
+  labels:
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+    # controller のメトリクスは自己署名証明書の TLS で出ている。chart 同梱の
+    # ServiceMonitor は scheme しか書けず tlsConfig を渡せないため、
+    # helm-values 側では serviceMonitor を有効にせずここで定義する。
+    - port: metrics
+      path: /metrics
+      scheme: https
+      interval: 30s
+      scrapeTimeout: 10s
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-workflows-workflow-controller
+      app.kubernetes.io/instance: argo-workflows

--- a/manifests/monitoring/netpol-prometheus.yaml
+++ b/manifests/monitoring/netpol-prometheus.yaml
@@ -66,6 +66,14 @@ spec:
               protocol: TCP
     - toEndpoints:
         - matchLabels:
+            app.kubernetes.io/name: argo-workflows-workflow-controller
+            io.kubernetes.pod.namespace: argo
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
             app.kubernetes.io/name: tempo
       toPorts:
         - ports:

--- a/manifests/monitoring/prometheusrule-oom.yaml
+++ b/manifests/monitoring/prometheusrule-oom.yaml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oom
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: oom
+      rules:
+        # OOMKilled は「落ちて即座に復帰する」ため、既存のルールを全部すり抜ける。
+        # chart 同梱の KubePodCrashLooping は waiting_reason=CrashLoopBackOff が
+        # 条件なので、1 回落ちてすぐ Running に戻る形では発火しない。
+        #
+        # harbor-nginx はこれで 2 週間に 4 回 OOM していたが誰も気づかず、
+        # 2026-08-22 に大きい image の push と重なって初めて表面化した
+        # （buildkit が connection reset を受けてビルドが失敗した）。
+        # tetragon と harbor-trivy の OOM に至っては、その調査の副産物として
+        # 見つかるまで完全に未知だった。
+        #
+        # last_terminated_reason は「最後の終了理由」で 1 のまま張り付くので、
+        # 単独では新規発生を表さない。restarts_total の増加と組み合わせて
+        # 「今 OOM で再起動した」だけを取る。
+        #
+        # retention 全域 (14日) で range 評価して発火は 7 回。2 日に 1 回なので
+        # warning のまま Discord に流す。critical にすると alert-investigate が
+        # horenso タスクを 2 日に 1 件立て続けることになる。
+        - alert: ContainerOOMKilled
+          expr: |
+            increase(kube_pod_container_status_restarts_total[10m]) > 0
+            and on (namespace, pod, container)
+            kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1
+          labels:
+            severity: warning
+          annotations:
+            summary: "OOMKilled で再起動 ({{ $labels.namespace }}/{{ $labels.pod }} {{ $labels.container }})"
+            description: "{{ $labels.namespace }}/{{ $labels.pod }} の {{ $labels.container }} が memory limit に当たって落ちた。即座に復帰するので気づきにくいが、その瞬間の接続は切れている。limit を見直すか、使用量の跳ね方を調べる。"


### PR DESCRIPTION
#584（harbor-nginx の memory limit）の調査中に、**OOM が起きても何も鳴らない**ことが分かったので塞ぐ。併せて Argo のメトリクスが Prometheus に入っていない件も直す。

## OOMKilled のアラート

OOMKilled は落ちて即座に復帰するため、既存のルールを全部すり抜ける。chart 同梱の `KubePodCrashLooping` は `waiting_reason=CrashLoopBackOff` が条件で、すぐ Running に戻る形では発火しない。

実際、**harbor-nginx は 2 週間で 4 回 OOM していたが誰も気づいていなかった。** 2026-08-22 に大きい image の push と重なって初めて表面化しただけ（buildkit が connection reset を受けてビルドが失敗した）。その調査の副産物として出てきた tetragon と harbor-trivy の OOM は、この瞬間まで完全に未知だった。

### 頻度の実測

retention 全域（14 日）を range 評価した結果：

```
08-10 06:11  harbor/harbor-nginx (前世代)
08-15 16:21  kube-system/tetragon
08-16 15:01  harbor/harbor-nginx
08-20 23:01  harbor/harbor-trivy
08-22 16:11  kube-system/tetragon
08-22 22:46  harbor/harbor-nginx    ← #584 の原因
--- 14日で 7 回発火 ---
```

2 日に 1 回。参考までに同期間の terminated reason 全体は `Error` 149 / `Completed` 28 / `OOMKilled` 9 なので、OOMKilled だけを取れば十分静か。

**severity は warning。** critical にすると `alert-investigate` sensor が拾って horenso タスクを 2 日に 1 件立て続けることになる。

### 繰り返し検出は入れない

当初は「短時間に複数回 OOM」を critical で拾う 2 段構成を考えたが、`increase(restarts_total[24h])` の実値が harbor-nginx で **1.001** で、14 日を range 評価しても発火 0 回だった。クラスタに該当する事象が存在しないルールなので落とした。

### クエリの形

`last_terminated_reason` は「最後の終了理由」で 1 のまま張り付くため、単独では新規発生を表さない。`restarts_total` の増加と `and on (namespace, pod, container)` で組んで「今 OOM で再起動した」だけを取る。#584 の OOM 直後（13:45Z）で評価すると `harbor-nginx` を 1 件返し、修正後の現在は 0 件。

## Argo workflow-controller の scrape

ワークフローの失敗が Argo UI を開いた人にしか見えない状態だった。9090 は元から開いていて中身も出ているが、scrape 先が無かった。

**罠が 2 つあったので書き方が普通と違う：**

1. `metricsConfig.enabled: true` を立てると chart が configmap へ `secure` を書き下ろす。chart のデフォルトは `false` なので、`enabled` だけ立てると**今 TLS で喋っているエンドポイントが平文に落ちる**。`secure: true` を明示している
2. chart 同梱の ServiceMonitor テンプレートは `scheme` しか書けず `tlsConfig` を渡す口が無い。自己署名証明書を検証できず scrape が落ちるため、`manifests/argo/servicemonitor-workflow-controller.yaml` に手書きした

レンダリングで configmap を確認済み：

```
configmap metricsConfig: {'enabled': True, 'path': '/metrics', 'port': 9090, 'ignoreErrors': False, 'secure': True}
```

CNP は両側に追加（prometheus egress → argo:9090、workflows-controller ingress ← prometheus）。`docs/network-policies.md` も同時更新。

## この PR に入れていないもの

**ワークフロー失敗のアラートは入れていない。** メトリクス基盤だけ用意して、ルールは別 PR にする。理由は、今入れると鳴りっぱなしになるため：

```
直近 24 時間の Failed/Error
  37  argo/aqua-checksum          ← 13時間以上ずっと壊れている
   3  argo/tofu-harbor-plan
   2  image-build/image-build
   2  talos-build/talos-secureboot-build
   1  claude-code/cnp-check
   1  argo/image-digest-audit
--- 計 46 件 ---
```

`aqua-checksum` の wait コンテナが kube-apiserver にも SeaweedFS にも届かず、1 回 24 分かけてタイムアウトするのを延々繰り返している。これも今回の調査で初めて見つかった別の障害で、Renovate の aqua checksum 更新が止まっている。先にこちらを潰してからルールを入れる。

## 検証

- `kubeconform -strict`: 4 resources valid
- PromQL: Prometheus に投げて評価成功、現在 0 件
- chart レンダリング: configmap の `secure: True` を確認、chart 版 ServiceMonitor が生成されないことも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyK2G15ZkUH4iQseHPgyiV
