### PR TITLE
feat(monitoring): alert when an argo workflow fails

### DIFF
--- a/manifests/monitoring/prometheusrule-argo-workflows.yaml
+++ b/manifests/monitoring/prometheusrule-argo-workflows.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: argo-workflows
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: argo-workflows
+      rules:
+        # ワークフローの失敗は Argo UI を開いた人にしか見えなかった。
+        # 2026-08-22 の image-build の失敗（Harbor への push 中に
+        # harbor-nginx が OOMKilled され buildkit が connection reset を
+        # 受けた）は、たまたま UI を見たから気づいただけで、アラートは
+        # 1 本も鳴っていない。
+        #
+        # 失敗頻度は記録のある 186 日で 84 件 = 0.4 件/日。うち半分は
+        # 同日中に解消した aqua-checksum の CNP 不足によるもので、それを
+        # 除くと 0.2 件/日（5 日に 1 件）。warning で流して問題ない量。
+        #
+        # namespace ラベルは scrape 元の argo に潰されるため、実際に
+        # ワークフローが動いた namespace は exported_namespace に入る
+        # （ServiceMonitor が honorLabels: false のため）。
+        - alert: ArgoWorkflowFailed
+          expr: |
+            sum by (exported_namespace, phase) (
+              increase(argo_workflows_total_count{phase=~"Failed|Error"}[10m])
+            ) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "ワークフローが {{ $labels.phase }} で終了 ({{ $labels.exported_namespace }})"
+            description: "{{ $labels.exported_namespace }} で直近 10 分に {{ $value | humanize }} 件のワークフローが {{ $labels.phase }} になった。Failed はステップ自体の失敗、Error は executor やインフラ側の異常。https://argo.infra.tgy.io/workflows/{{ $labels.exported_namespace }}"


### PR DESCRIPTION
#585 で入れたメトリクス基盤の上に、ワークフロー失敗のアラートを載せる。

## 経緯

#584（harbor-nginx の memory limit）の失敗は、Harbor への push 中に nginx が OOMKilled され buildkit が connection reset を受けたもの。**その間アラートは 1 本も鳴っておらず**、たまたま Argo UI を開いたから気づいただけだった。

## 頻度の実測

当初「直近 24 時間で 46 件失敗しているので、今入れると鳴りっぱなしになる」と判断して #585 から外したが、**これは読み違いだった**。37 件を占めていた `aqua-checksum` は同日中に #551 / #554 / #559 で修正済みで、19:59 JST 以降は連続成功している。失敗の一覧は「今壊れている」ことを意味しない。

記録のある全期間で数え直すと：

```
記録範囲: 02-17 00:59 〜 08-22 22:44 (186.9 日)
総 Failed/Error: 84 件 → 0.4 件/日
aqua-checksum を除く: 40 件 → 0.2 件/日   ← 5 日に 1 件
```

warning で流して問題ない量。ブロッカーは存在しなかった。

## ラベルの注意

`namespace` は scrape 元（argo）に潰され、ワークフローが実際に動いた namespace は **`exported_namespace`** に入る。#585 で入れた ServiceMonitor が `honorLabels: false` のため。式はそちらで書いている。

## 検証

対象 0 件のまま「構文 OK」で済ませないよう、意図的に `exit 1` するワークフローを実際に流した：

```
submitted: alert-probe-j9zlj
[3] Failed

=== アラート式の評価 ===
[1] 発火なし
[2] argo   Failed   1.05     ← 次の scrape で発火
```

確認後にテストワークフローは削除済み。`kubeconform -strict` は 1/1 valid。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyK2G15ZkUH4iQseHPgyiV
