### PR TITLE
fix(tetragon,harbor): raise memory limits for the two remaining OOM sources

### DIFF
--- a/helm-values/harbor/values.yaml
+++ b/helm-values/harbor/values.yaml
@@ -58,12 +58,20 @@ persistence:
 
 trivy:
   enabled: true
+  # working_set は平常 5Mi 前後で、OOM 前後を 1 分刻みで見ても跳ねない。
+  # 効いているのは page cache で、数百 MB の脆弱性 DB を読むと
+  # max_usage_bytes が limit ちょうど (1023Mi / 1024Mi) に張り付く。
+  # 2026-08-20 の OOMKilled はこれで、平常時のグラフを見ている限り
+  # 気づけない類の枯渇。
+  #
+  # page cache は回収可能なので limit を上げても同じだけ埋まるが、
+  # 回収が間に合わずに OOM する余地は減る。根治ではなく緩和。
   resources:
     requests:
       cpu: 50m
       memory: 256Mi
     limits:
-      memory: 1Gi
+      memory: 2Gi
 
 core:
   extraEnvVars:

--- a/helm-values/tetragon/values.yaml
+++ b/helm-values/tetragon/values.yaml
@@ -3,12 +3,16 @@ extraHostPathMounts:
     mountPath: /sys/kernel/tracing
 
 tetragon:
+  # ノードごとに監視対象の pod 数が違うので、DaemonSet 共通の limit は一番重い
+  # ノードに合わせる。wn-03 (64GB、pod 数最多) のピークが 431Mi で 512Mi の 84%
+  # に達しており、実際に 2 回 OOMKilled されている。落ちている間はそのノードの
+  # 観測に穴が開く。requests も実使用 136〜253Mi を下回っていた。
   resources:
     requests:
       cpu: 50m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      memory: 512Mi
+      memory: 1Gi
   exportDenyList: |-
     {"health_check":true}
     {"namespace":["","cilium","kube-system"]}


### PR DESCRIPTION
#584 の調査で見つかった残り 2 件。どちらも #585 で OOMKilled のアラートを入れるまで誰も気づいていなかった。

## tetragon

limit は DaemonSet 共通だが、ノードは対称ではない。wn-03 は RAM も pod 数も最多で、その分監視対象が多い。

```
container_memory_max_usage_bytes / limit 512Mi
  wn-03   431Mi  (84%)   ← OOMKilled 2 回 (08-15, 08-22)
  wn-01   292Mi
  cp-13   243Mi
  wn-02   236Mi
  cp-11   234Mi
  cp-12   226Mi
```

落ちている間はそのノードの観測に穴が開く。全ノードで動くセキュリティ監視なので、静かに落ちるのが一番まずい。

requests も実使用（136〜253Mi）を下回っていたので 256Mi に上げる。

## trivy

working set で見る限り無実に見える。平常 5Mi、OOM 前後を 1 分刻みでサンプリングしても跳ねない：

```
1787154900	6Mi
1787154960	6Mi
1787155020	7Mi   ← OOM 直後
```

効いているのは page cache だった。数百 MB の脆弱性 DB を読むと `max_usage_bytes` が **1023Mi / limit 1024Mi** に張り付く。

```
exitCode: 137, reason: OOMKilled, finishedAt: 2026-08-20T13:57:39Z
```

**page cache は回収可能なので、limit を上げても同じだけ埋まる。** 回収が間に合わずに OOM する余地が減るだけで、根治ではない点は tetragon と違う。再発するようなら DB の持ち方から見直す必要がある。

## 検証

レンダリングで両チャートが値を読むことを確認済み：

```
tetragon: {'limits': {'memory': '1Gi'}, 'requests': {'cpu': '50m', 'memory': '256Mi'}}
trivy:    {'limits': {'cpu': 1, 'memory': '2Gi'}, 'requests': {'cpu': '50m', 'memory': '256Mi'}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyK2G15ZkUH4iQseHPgyiV
