### PR TITLE
docs(harbor): correct why trivy runs out of memory

### DIFF
--- a/helm-values/harbor/values.yaml
+++ b/helm-values/harbor/values.yaml
@@ -58,14 +58,21 @@ persistence:
 
 trivy:
   enabled: true
-  # working_set は平常 5Mi 前後で、OOM 前後を 1 分刻みで見ても跳ねない。
-  # 効いているのは page cache で、数百 MB の脆弱性 DB を読むと
-  # max_usage_bytes が limit ちょうど (1023Mi / 1024Mi) に張り付く。
-  # 2026-08-20 の OOMKilled はこれで、平常時のグラフを見ている限り
-  # 気づけない類の枯渇。
+  # 平常時は API サーバとして待つだけで rss 5Mi 前後。メモリを食うのは
+  # スキャン実行中だけで、そのスパイクは cAdvisor の 30 秒間隔に写らない
+  # ほど短い。2026-08-20 の OOMKilled はスキャン要求の 10 秒後に起きた:
   #
-  # page cache は回収可能なので limit を上げても同じだけ埋まるが、
-  # 回収が間に合わずに OOM する余地は減る。根治ではなく緩和。
+  #   13:57:22Z jobservice: Job incoming: IMAGE_SCAN
+  #   13:57:32Z jobservice: exit with error: ... connect: connection refused
+  #   13:57:39Z trivy: OOMKilled (exitCode 137)
+  #
+  # コンテナが落ちるのでスキャン自体も失敗するが、Harbor UI 上は該当
+  # イメージの結果が欠けるだけで、それ以外に痕跡が残らない。
+  #
+  # 直近 7 日で incoming 40 件に対し失敗 1 件。常時足りないのではなく、
+  # 大きいイメージを引いたときだけ超える。所要はスキャン対象のサイズに
+  # 依存するので、2Gi で足りるかは次に大きいイメージが来たとき分かる
+  # （ContainerOOMKilled が拾う）。
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
#588 で書いた trivy の OOM 原因が誤りだったので直す。**limit の値 (2Gi) は変えない、コメントのみ。**

## 何を間違えたか

#588 には「page cache が limit を埋めている」「page cache は回収可能なので limit を上げても緩和にすぎない」と書いた。どちらも誤り。

```
OOM 前後の内訳（2026-08-20 13:57Z）
  container_memory_cache   0〜1Mi     ← page cache は無関係
  container_memory_rss     28Mi → 6Mi
```

根拠にした `max_usage_bytes = 1023Mi` は、**既に死んだコンテナの生涯最大値**だった。現在のコンテナは 4Mi を返す。working set と max_usage の差だけを見て page cache と決めつけたのが誤りの出所。

## 実際の原因

cAdvisor の 30 秒間隔に写らないほど短いスパイク。jobservice のログが時刻を確定させる：

```
13:57:22Z  jobservice: Job incoming: IMAGE_SCAN
13:57:32Z  jobservice: exit with error: ... connect: connection refused
13:57:39Z  trivy: OOMKilled (exitCode 137)
13:57:40Z  trivy: Starting harbor-scanner-trivy
```

スキャン要求の 10 秒後に落ちている。**その scan 自体も失敗している**が、Harbor UI 上は該当イメージのスキャン結果が欠けるだけで他に痕跡が残らない。

## 対処の意味が変わる

```
直近 7 日の IMAGE_SCAN   incoming=40  failed=1
```

常時足りないのではなく、大きいイメージを引いたときだけ超える。所要はスキャン対象のサイズに依存するので、「回収の余地を広げる」のではなく「最大のイメージに耐える limit」の問題。2Gi で足りるかは次に大きいイメージが来たとき分かる（#585 で入れた `ContainerOOMKilled` が拾う）。

根拠が違うと次に読む人が誤った対処をするので、値ではなくコメントを直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyK2G15ZkUH4iQseHPgyiV
