### PR TITLE
See the digest lose its tag, not lose the digest

### DIFF
--- a/manifests/argo/image-digest-audit.yaml
+++ b/manifests/argo/image-digest-audit.yaml
@@ -236,6 +236,39 @@ spec:
                 continue
               fi
 
+              # digest が在ることと、消されずに在り続けることは別の話。タグを
+              # 失った artifact は retention の件数ルールの保護外で、週次 GC が
+              # 消す。参照している側から見れば「今日は引けるが来週引けない」で、
+              # MISSING と同じ故障を、起きる前の姿で見ていることになる。
+              #
+              # 2026-08-19 の memory も 2026-08-22 の trading も、気付いたのは
+              # 消えた後だった。ここで見えていれば GC までの最大 7 日が猶予になる。
+              proj=${repo%%/*}
+              name=$(printf '%s' "${repo#*/}" | sed 's#/#%2F#g')
+              meta=$(curl -sS --connect-timeout 10 --max-time 30 \
+                --retry 3 --retry-delay 5 --retry-connrefused \
+                -u "$HARBOR_USER:$HARBOR_PASS" \
+                "https://registry.infra.tgy.io/api/v2.0/projects/${proj}/repositories/${name}/artifacts/${digest}?with_tag=true") || meta=""
+
+              # 読めなかったときは黙る。タグが無いことと、権限が無くて分からない
+              # ことを混同すると、この監査が二度目に信用されなくなる。
+              #
+              # 既定を unknown 側に置いているのは、空の応答に jq をかけると何も
+              # 出力されず、それは「タグが空」と見分けが付かないため。curl が
+              # 落ちた回を孤児として報告するのは、直したばかりの誤報と同じ形。
+              tags="unknown"
+              if [ -n "$meta" ]; then
+                tags=$(printf '%s' "$meta" | jq -r 'if type=="object" and has("digest") then ([.tags[]?.name] | join(",")) else "unknown" end' 2>/dev/null) || tags="unknown"
+              fi
+
+              if [ -z "$tags" ]; then
+                echo "ORPHANED  $ref"
+                echo "          the artifact is still here, but nothing tags it any more. The count"
+                echo "          rule cannot retain an untagged artifact and the weekly GC deletes it."
+                echo "          Roll this reference forward before Sunday."
+                FAILED=1
+              fi
+
               # Kyverno と同じ順序で、最初にマッチしたルールが署名の置き場を決める。
               # 行ごとに cut で切り出す。read の IFS をタブにすると、その IFS が
               # ループ本体の $refs の単語分割にも効いてしまい、空白区切りの


### PR DESCRIPTION
`image-digest-audit` に **ORPHANED**（digest は在るがタグが無い）の検知を足す。

## これまで間違った質問をしていた

「この digest はまだ在るか」は、**無くなる瞬間まで「在る」と答え続けます。**実際、今日まで追いかけた 2 件はどちらも消えた後にしか分かりませんでした。

| | 発見の仕方 |
|---|---|
| 2026-08-19 memory | Pod が死んで復帰不能になってから |
| 2026-08-22 trading | CronJob が存在しない digest を指しているのを検出（発火前だが、既に消えた後） |

「まだ何かがタグを付けているか」は**1 週間早く答えが出ます。**タグを失った artifact は retention の件数ルールでは保持できず、週次 GC が消すので、土曜の GC までが猶予になります。1 週間あれば pin を進められる（Renovate の追従は 4 時間）。

## 既定は「黙る」側に置いた

空の応答を jq に通すと**何も出力されず、それは「タグが空」と見分けが付きません**。そのまま書くと、curl が落ちた回を孤児として報告することになります。#572 で直した誤報とまったく同じ形なので、`tags` の初期値を `unknown` にして、**パースできた応答だけがそれを動かす**構造にしました。

ローカル実測:

```
タグあり        -> ok (tags=latest)
タグ空(=孤児)   -> ORPHANED
tags キー無し   -> ORPHANED
403             -> ok (tags=unknown)   ← 黙る
curl 失敗(空)   -> ok (tags=unknown)   ← 黙る
壊れた応答      -> ok (tags=unknown)   ← 黙る
```

## 副産物: `delete_untagged` の判断が要らなくなる

`true` のままにするか `false` にするかは、これまで「孤児が週にいくつ生まれるか」の統計を集めないと決められませんでした。手で 1 週間拾うか、管理者権限のジョブを新設するかの二択です。

タグの有無を監査が見るようになると、**統計を集めて方針を決める問題が、危険な状態そのものを検知する問題に変わります。**参照されている孤児が出たときだけ警告が出るので、設定をどちらに倒しても手当てが間に合う。参照されていない孤児は、そもそも消えて構わない。

依存: Tsuguya/home-harbor#27（マージ済み・apply 済み、`robot$trading+pull` に `artifact: read` を付与。実測で trading が 403 → 200 になったことを確認済み）