### PR TITLE
Notice when the tag check has gone blind

### DIFF
--- a/manifests/argo/image-digest-audit.yaml
+++ b/manifests/argo/image-digest-audit.yaml
@@ -189,6 +189,10 @@ spec:
             echo
 
             FAILED=0
+            # タグ判定が何件成立したか。0 件のまま終わるなら、この監査は
+            # 「孤児はいない」ではなく「孤児を見る目を失っている」。
+            TAGSEEN=0
+            TAGBLIND=0
             while IFS= read -r ref; do
               [ -n "$ref" ] || continue
 
@@ -261,6 +265,12 @@ spec:
                 tags=$(printf '%s' "$meta" | jq -r 'if type=="object" and has("digest") then ([.tags[]?.name] | join(",")) else "unknown" end' 2>/dev/null) || tags="unknown"
               fi
 
+              if [ "$tags" = "unknown" ]; then
+                TAGBLIND=$((TAGBLIND + 1))
+              else
+                TAGSEEN=$((TAGSEEN + 1))
+              fi
+
               if [ -z "$tags" ]; then
                 echo "ORPHANED  $ref"
                 echo "          the artifact is still here, but nothing tags it any more. The count"
@@ -325,6 +335,19 @@ spec:
             done < /tmp/images.txt
 
             echo
+            # 一件も読めなかったなら、ORPHANED は一度も判定されていない。
+            # 権限を失った監査は「孤児 0 件」を静かに報告し続けるので、
+            # 見えていないこと自体を失敗として言う。個別の unknown は
+            # 一過性でありうるので、全滅したときだけ。
+            if [ "$TAGSEEN" = 0 ] && [ "$TAGBLIND" -gt 0 ]; then
+              echo "TAGBLIND  could not read tag state for any of the $TAGBLIND reference(s)."
+              echo "          ORPHANED was never evaluated, so nothing above rules out an orphan."
+              echo "          Check that the robot still has artifact:read on these projects."
+              FAILED=1
+            elif [ "$TAGBLIND" -gt 0 ]; then
+              echo "note: tag state unreadable for $TAGBLIND of $((TAGSEEN + TAGBLIND)) reference(s)."
+            fi
+
             if [ "$FAILED" = 0 ]; then
               echo "everything that could start right now can still pull and verify what it references"
             else


### PR DESCRIPTION
#591 の ORPHANED 判定は、Harbor が答えを拒んだとき**意図的に黙ります**（「タグが無い」と「見る権限が無い」を混同したら、この監査は二度目に信用されないため）。

ただし黙ることにも固有の故障モードがあります。**権限を失うと全参照が読めなくなり、ORPHANED は一度も判定されないまま「異常なし」を報告し続けます。**誤報より悪い — 監視をやめた監視が ok と言っている状態です。

なので:

| 状況 | 挙動 |
|---|---|
| 全部読めた | 通常判定 |
| 1 件だけ読めない | `note:` 行のみ、失敗しない（一過性でありうる） |
| **全部読めない** | **`TAGBLIND` で失敗**。「上の行は孤児がいないことを何も示していない」と明示 |

レジストリ本体に対して `UNREACHABLE` で引いた線と同じです。**知らないことは所見であって、異常がないと知っていることとは別の所見**。

ローカル実測:

```
全部読めた           -> 全件判定済み FAILED=0
全部 403(権限喪失)   -> TAGBLIND (失敗) blind=3
1件だけ読めない      -> note: 1/3 unreadable, FAILED=0
孤児あり             -> 全件判定済み FAILED=1
孤児+一部読めない    -> note: 1/3 unreadable, FAILED=1
```

## 経緯

p-d2 が「artifact API が 403 だ」と報告してきて測定が食い違いました。原因は**エンドポイントの違い**で、権限は正しく付いています:

```
GET .../artifacts            (list)  → 403   ← p-d2 が叩いた
GET .../artifacts/{digest}   (read)  → 200   ← 監査が使う
```

`artifact: read` が許すのは digest 指定の読み取りだけで、一覧は `artifact: list` という別権限でした。認証情報も ESO 同期分と 1Password の値が一致していることを確認済み（ドリフト無し）。

ただし向こうが投げた「**その 403 が read 側で起きたらどうなるのか**」という問いは正しく、実際そのときは黙って「孤児 0 件」を報告し続けます。それがこの PR です。