### PR TITLE
feat(rss): deploy the RSS reader now that PostgreSQL TLS works

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -212,6 +212,13 @@ jobs:
     name: image existence
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      # The home-rss images are private packages; GHCR grants this repository
+      # read access to them. Without this the check would have to skip them
+      # the way it skips the internal Harbor, and a mistyped digest on our own
+      # images would sail through.
+      packages: read # crane auth login ghcr.io
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -220,6 +227,12 @@ jobs:
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:
           aqua_version: v2.62.3
+
+      - name: Log in to GHCR
+        env:
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: crane auth login ghcr.io -u "${GHCR_USER}" -p "${GHCR_TOKEN}"
 
       - name: Check image existence
         run: |

--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -48,7 +48,8 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | oauth2-proxy-hubble (oauth2-proxy) | Kanidm (kanidm) | 8443 | OIDC token exchange |
 | oauth2-proxy-seaweedfs (oauth2-proxy) | SeaweedFS filer (seaweedfs) | 8888 | Reverse proxy upstream |
 | oauth2-proxy-seaweedfs (oauth2-proxy) | Kanidm (kanidm) | 8443 | OIDC token exchange |
-| oauth2-proxy-rss (oauth2-proxy) | rss-ui (rss) | 80 | Reverse proxy upstream |
+| oauth2-proxy-rss (oauth2-proxy) | rss-ui (rss) | 80 | Reverse proxy upstream (static UI) |
+| oauth2-proxy-rss (oauth2-proxy) | rss-server (rss) | 80 | Reverse proxy upstream (/api) |
 | oauth2-proxy-rss (oauth2-proxy) | Kanidm (kanidm) | 8443 | OIDC token exchange |
 | Nextcloud (nextcloud) | shared-pg (database) | 5432 | Database |
 | Nextcloud (nextcloud) | SeaweedFS filer (seaweedfs) | 8333 | S3 object storage |
@@ -107,7 +108,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **applicationset-controller** | (deny world) | kube-apiserver |
 | **notifications-controller** | (deny world) | kube-apiserver, discord.com:443, horenso (horenso):3000, argocd-deployed-eventsource (argo):12003 |
 | **redis-secret-init** (Job) | (deny world) | kube-apiserver |
-| **cloudflared** | (deny world) | *.v2.argotunnel.com + cftunnel.com + h2.cftunnel.com + quic.cftunnel.com:443/7844 (7844 TCP+UDP), server:8080, eventsource (argo):12000, kanidm (kanidm):8443, nextcloud (nextcloud):80, harbor-nginx (harbor):8443 |
+| **cloudflared** | (deny world) | *.v2.argotunnel.com + cftunnel.com + h2.cftunnel.com + quic.cftunnel.com:443/7844 (7844 TCP+UDP), server:8080, eventsource (argo):12000, kanidm (kanidm):8443, nextcloud (nextcloud):80, harbor-nginx (harbor):8443, oauth2-proxy-rss (oauth2-proxy):4180 |
 
 ## argo (22 policies)
 
@@ -247,7 +248,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 |---|---|---|
 | **oauth2-proxy-hubble** | ingress → 4180 (L7 HTTP) | hubble-ui (kube-system):8081, kanidm (kanidm):8443 |
 | **oauth2-proxy-seaweedfs** | ingress → 4180 (L7 HTTP) | seaweedfs-filer (seaweedfs):8888, kanidm (kanidm):8443 |
-| **oauth2-proxy-rss** | ingress → 4180 (L7 HTTP) | rss-ui (rss):80, kanidm (kanidm):8443 |
+| **oauth2-proxy-rss** | ingress, cloudflared (argocd) → 4180 (L7 HTTP) | rss-ui (rss):80, rss-server (rss):80, kanidm (kanidm):8443 |
 
 ## trivy-system (3 policies)
 

--- a/helm-values/oauth2-proxy-rss/values.yaml
+++ b/helm-values/oauth2-proxy-rss/values.yaml
@@ -3,15 +3,20 @@ config:
   cookieName: "_oauth2_proxy_rss"
   configFile: ""
 
+# List form, not the map form the other two proxies use: two `--upstream` flags
+# are needed and a map can only hold one. oauth2-proxy routes by longest path
+# prefix, so /api reaches the REST API and everything else falls through to the
+# static UI.
 extraArgs:
-  provider: oidc
-  oidc-issuer-url: "https://idm.tgy.io/oauth2/openid/oauth2-proxy-rss"
-  redirect-url: "https://reader.tgy.io/oauth2/callback"
-  upstream: "http://rss-ui.rss.svc.cluster.local:80"
-  email-domain: "*"
-  skip-provider-button: "true"
-  code-challenge-method: S256
-  reverse-proxy: "true"
+  - --provider=oidc
+  - --oidc-issuer-url=https://idm.tgy.io/oauth2/openid/oauth2-proxy-rss
+  - --redirect-url=https://reader.tgy.io/oauth2/callback
+  - --upstream=http://rss-server.rss.svc.cluster.local:80/api
+  - --upstream=http://rss-ui.rss.svc.cluster.local:80
+  - --email-domain=*
+  - --skip-provider-button=true
+  - --code-challenge-method=S256
+  - --reverse-proxy=true
 
 service:
   portNumber: 4180

--- a/manifests/argocd/netpol-cloudflared.yaml
+++ b/manifests/argocd/netpol-cloudflared.yaml
@@ -64,3 +64,11 @@ spec:
         - ports:
             - port: "8443"
               protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/instance: oauth2-proxy-rss
+            io.kubernetes.pod.namespace: oauth2-proxy
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP

--- a/manifests/oauth2-proxy/netpol-oauth2-proxy-rss.yaml
+++ b/manifests/oauth2-proxy/netpol-oauth2-proxy-rss.yaml
@@ -8,6 +8,10 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: oauth2-proxy-rss
   ingress:
+    # reader.tgy.io resolves to the Gateway inside the house and reaches
+    # Cloudflare from outside, so both paths have to be allowed. The tunnel
+    # config has pointed at this Service since March, but nothing could use it
+    # while the upstream did not exist.
     - fromEntities:
         - ingress
       toPorts:
@@ -17,10 +21,27 @@ spec:
           rules:
             http:
               - {}
+    - fromEndpoints:
+        - matchLabels:
+            app: cloudflared
+            io.kubernetes.pod.namespace: argocd
+      toPorts:
+        - ports:
+            - port: "4180"
+              protocol: TCP
+          rules:
+            http:
+              - {}
   egress:
+    # spin-operator labels the Pods it creates with core.spinkube.dev/app-name;
+    # `app: rss-ui` never matched anything. It went unnoticed because the
+    # SpinApps were removed before either side was ever exercised.
     - toEndpoints:
         - matchLabels:
-            app: rss-ui
+            core.spinkube.dev/app-name: rss-ui
+            io.kubernetes.pod.namespace: rss
+        - matchLabels:
+            core.spinkube.dev/app-name: rss-server
             io.kubernetes.pod.namespace: rss
       toPorts:
         - ports:

--- a/manifests/rss/cronworkflow.yaml
+++ b/manifests/rss/cronworkflow.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workflow-executor
+  namespace: rss
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflow-executor
+  namespace: rss
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-edit
+subjects:
+  - kind: ServiceAccount
+    name: workflow-executor
+    namespace: rss
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: rss-fetcher
+  namespace: rss
+spec:
+  activeDeadlineSeconds: 300
+  serviceAccountName: workflow-executor
+  entrypoint: main
+  templates:
+    - name: main
+      metadata:
+        labels:
+          rss-cron: "true"
+      container:
+        image: curlimages/curl:8.18.0@sha256:d94d07ba9e7d6de898b6d96c1a072f6f8266c687af78a74f380087a0addf5d17
+        command: [sh, -c]
+        args:
+          - curl -fsS -X POST http://rss-fetcher:80/fetch
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: rss-fetcher
+  namespace: rss
+spec:
+  schedule: "*/15 * * * *"
+  timezone: Asia/Tokyo
+  concurrencyPolicy: Forbid
+  workflowSpec:
+    workflowTemplateRef:
+      name: rss-fetcher
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: rss-cleaner
+  namespace: rss
+spec:
+  activeDeadlineSeconds: 300
+  serviceAccountName: workflow-executor
+  entrypoint: main
+  templates:
+    - name: main
+      metadata:
+        labels:
+          rss-cron: "true"
+      container:
+        image: curlimages/curl:8.18.0@sha256:d94d07ba9e7d6de898b6d96c1a072f6f8266c687af78a74f380087a0addf5d17
+        command: [sh, -c]
+        args:
+          - curl -fsS -X POST http://rss-cleaner:80/clean
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: rss-cleaner
+  namespace: rss
+spec:
+  schedule: "0 3 * * *"
+  timezone: Asia/Tokyo
+  concurrencyPolicy: Forbid
+  workflowSpec:
+    workflowTemplateRef:
+      name: rss-cleaner

--- a/manifests/rss/cronworkflow.yaml
+++ b/manifests/rss/cronworkflow.yaml
@@ -50,7 +50,8 @@ metadata:
   name: rss-fetcher
   namespace: rss
 spec:
-  schedule: "*/15 * * * *"
+  schedules:
+    - "*/15 * * * *"
   timezone: Asia/Tokyo
   concurrencyPolicy: Forbid
   workflowSpec:
@@ -89,7 +90,8 @@ metadata:
   name: rss-cleaner
   namespace: rss
 spec:
-  schedule: "0 3 * * *"
+  schedules:
+    - "0 3 * * *"
   timezone: Asia/Tokyo
   concurrencyPolicy: Forbid
   workflowSpec:

--- a/manifests/rss/shim-executor.yaml
+++ b/manifests/rss/shim-executor.yaml
@@ -1,0 +1,11 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinAppExecutor
+metadata:
+  name: containerd-shim-spin
+  namespace: rss
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  createDeployment: true
+  deploymentConfig:
+    runtimeClassName: wasmtime-spin-v2

--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -1,0 +1,32 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: rss-cleaner
+  namespace: rss
+spec:
+  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.0@sha256:97d65e86f054ebad6135737df74e0c8258852069a0f272e91fa1911cf5167a2b
+  replicas: 1
+  executor: containerd-shim-spin
+  imagePullSecrets:
+    - name: ghcr-pull
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+  variables:
+    - name: db_url
+      valueFrom:
+        secretKeyRef:
+          name: rss-pg-credentials
+          key: uri
+    # The component refuses to connect in the clear once this is set, so the
+    # CA is what actually enforces TLS — not the URL, which CNPG generates
+    # without an sslmode at all. Comes from the CNPG-managed CA secret so a
+    # rotation does not need a rebuild.
+    - name: db_ca_root
+      valueFrom:
+        secretKeyRef:
+          name: rss-pg-ca
+          key: ca.crt

--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rss-cleaner
   namespace: rss
 spec:
-  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.0@sha256:97d65e86f054ebad6135737df74e0c8258852069a0f272e91fa1911cf5167a2b
+  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.1@sha256:23fdc525221195d3b55cbb40b43d1a7d4b9b9fe0dc173dba738b7030b3bb95ce
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -1,0 +1,32 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: rss-fetcher
+  namespace: rss
+spec:
+  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.0@sha256:18de9013de3acb628e9b8f3cea1a9052c9a90e5e931a5656153ea0977640a317
+  replicas: 1
+  executor: containerd-shim-spin
+  imagePullSecrets:
+    - name: ghcr-pull
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+  variables:
+    - name: db_url
+      valueFrom:
+        secretKeyRef:
+          name: rss-pg-credentials
+          key: uri
+    # The component refuses to connect in the clear once this is set, so the
+    # CA is what actually enforces TLS — not the URL, which CNPG generates
+    # without an sslmode at all. Comes from the CNPG-managed CA secret so a
+    # rotation does not need a rebuild.
+    - name: db_ca_root
+      valueFrom:
+        secretKeyRef:
+          name: rss-pg-ca
+          key: ca.crt

--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rss-fetcher
   namespace: rss
 spec:
-  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.0@sha256:18de9013de3acb628e9b8f3cea1a9052c9a90e5e931a5656153ea0977640a317
+  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.1@sha256:3611976453ec439f5b41936fe850f6290d0f9bdcb0696978f86c5055ae379efa
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -1,0 +1,32 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: rss-server
+  namespace: rss
+spec:
+  image: ghcr.io/tsuguya/home-rss-server:v0.1.0@sha256:aafee1831effaddc3b92d4c2d34881d9a4c19e0fd7d51672751f6ca442654e77
+  replicas: 1
+  executor: containerd-shim-spin
+  imagePullSecrets:
+    - name: ghcr-pull
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+  variables:
+    - name: db_url
+      valueFrom:
+        secretKeyRef:
+          name: rss-pg-credentials
+          key: uri
+    # The component refuses to connect in the clear once this is set, so the
+    # CA is what actually enforces TLS — not the URL, which CNPG generates
+    # without an sslmode at all. Comes from the CNPG-managed CA secret so a
+    # rotation does not need a rebuild.
+    - name: db_ca_root
+      valueFrom:
+        secretKeyRef:
+          name: rss-pg-ca
+          key: ca.crt

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rss-server
   namespace: rss
 spec:
-  image: ghcr.io/tsuguya/home-rss-server:v0.1.0@sha256:aafee1831effaddc3b92d4c2d34881d9a4c19e0fd7d51672751f6ca442654e77
+  image: ghcr.io/tsuguya/home-rss-server:v0.1.1@sha256:32c91fd25b07d0a45201df1d75d912aecf1ab0b66f017bcd6db15a1ab2b527b9
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: core.spinkube.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: rss-ui
+  namespace: rss
+spec:
+  image: ghcr.io/tsuguya/home-rss-ui:v0.1.0@sha256:72463b6b37bab784d9f62ec9c13aa504502bab0ff377114abf084f41338f4178
+  replicas: 1
+  executor: containerd-shim-spin
+  imagePullSecrets:
+    - name: ghcr-pull
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rss-ui
   namespace: rss
 spec:
-  image: ghcr.io/tsuguya/home-rss-ui:v0.1.0@sha256:72463b6b37bab784d9f62ec9c13aa504502bab0ff377114abf084f41338f4178
+  image: ghcr.io/tsuguya/home-rss-ui:v0.1.1@sha256:18b83df00aee0e78ef26ff2f9c57bde1cac8659a5ed211386dd365b9811cfc94
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:


### PR DESCRIPTION
SpinApp は 3 月に削除された（`d7f056b`）。Spin SDK が rss-pg のサーバー証明書を検証できず、起動しても DB に繋げなかったため。以来 `rss` namespace には DB と migration Job と CNP 5 本だけが残り、**ArgoCD はずっと Synced / Healthy と報告していた**（残っているものは全部正常だったので）。

home-rss v0.1.0 (Tsuguya/home-rss#82) でこれが解けた。各コンポーネントは CNPG の CA を `db_ca_root` 変数で受け取り、**CA が設定されている限り平文接続を拒否する**。マニフェストはその変数を足して復活させ、イメージは digest ピン、CronWorkflow の curl も同様にピンした。

## トラフィックが流れて初めて見えた 2 つの穴

どちらも「上流が存在しないので誰も通らなかった」ため、これまで検出しようがなかった層。

1. **oauth2-proxy-rss の egress が空振りしていた**
   `app: rss-ui` を許可していたが、spin-operator が Pod に付けるのは `core.spinkube.dev/app-name`。**このラベルは誰にも当たらない**。修正のうえ、`/api` 用に rss-server も追加。

2. **Cloudflare Tunnel の経路が CNP で塞がっていた**
   `reader.tgy.io` → `oauth2-proxy-rss:4180` は 3 月から tunnel.tf にあるが、cloudflared 側に egress が無く、proxy 側も `fromEntities: ingress`（= Gateway 経由）しか受け付けていなかった。両方向を開けた。

## oauth2-proxy の extraArgs をリスト形式に

`/api` を REST API に、それ以外を静的 UI に振るには `--upstream` が 2 つ要る。map 形式ではキーが 1 つしか持てないので、この values だけリスト形式にした（他 2 つの proxy は map のまま）。oauth2-proxy は最長パス前方一致でルーティングする。

## 検証

- `kubectl apply --dry-run=server` — 全ファイル通過（SpinApp 4 件は SpinAppExecutor 未適用による順序エラーのみ。`sync-wave: -1` で解決する）
- `helm template` で oauth2-proxy の args が意図どおり 2 upstream になることを確認
- `/lint` — Critical / Important ともに指摘なし
- `docs/network-policies.md` を同時更新

マージ後は ArgoCD sync → Pod 起動 → TLS 接続 → reader.tgy.io 疎通まで `/dev-watch` で見届ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TothShCHZfaxDJP3VFaRbe