### PR TITLE
fix(rss): make the deployment actually complete — workflows, health, and the schema

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -33,6 +33,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | Workflow pods (talos-build) | SeaweedFS filer (seaweedfs) | 8333 | Artifact/log storage |
 | Workflow pods (image-build) | SeaweedFS filer (seaweedfs) | 8333 | Artifact/log storage |
 | Workflow pods (claude-code) | SeaweedFS filer (seaweedfs) | 8333 | Artifact/log storage |
+| Workflow pods (rss) | SeaweedFS filer (seaweedfs) | 8333 | Artifact/log storage |
 | Workflow pods (claude-code) | Loki gateway (monitoring) | 8080 | Log query (logcli) |
 | PXE sync pods (argo) | SeaweedFS filer (seaweedfs) | 8333 | Artifact/log storage |
 | Etcd backup (argo) | SeaweedFS filer (seaweedfs) | 8333 | Backup storage |
@@ -178,7 +179,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 |---|---|---|
 | **master** | master/volume/filer/bucket-hook → 9333/19333; prometheus (monitoring) → 9327 | master (self):9333/19333, volume:8080/18080, filer:8888/18888 |
 | **volume** | master/filer/volume (self) → 8080/18080; prometheus (monitoring) → 9327 | master:9333/19333, volume (self):8080/18080 |
-| **filer** | loki (monitoring), tempo (monitoring), workflow-pods (argo), workflow-pods (talos-build), workflow-pods (image-build), workflow-pods (claude-code), workflows-server (argo), etcd-backup (argo), pxe-sync (argo), kanidm-backup (argo), kanidm-repl-exchange (argo), nextcloud (nextcloud), harbor-registry (harbor), trading (collector) → 8333; filer/master/bucket-hook/oauth2-proxy-seaweedfs (oauth2-proxy) → 8888/18888; prometheus (monitoring) → 9327 | master:9333/19333, volume:8080/18080, filer (self):8888/18888, shared-pg (database):5432 |
+| **filer** | loki (monitoring), tempo (monitoring), workflow-pods (argo), workflow-pods (talos-build), workflow-pods (image-build), workflow-pods (claude-code), workflow-pods (rss), workflows-server (argo), etcd-backup (argo), pxe-sync (argo), kanidm-backup (argo), kanidm-repl-exchange (argo), nextcloud (nextcloud), harbor-registry (harbor), trading (collector) → 8333; filer/master/bucket-hook/oauth2-proxy-seaweedfs (oauth2-proxy) → 8888/18888; prometheus (monitoring) → 9327 | master:9333/19333, volume:8080/18080, filer (self):8888/18888, shared-pg (database):5432 |
 | **bucket-hook** (Job) | (deny world) | master:9333/19333, filer:8888/18888 |
 
 ## kube-system (6 policies)
@@ -293,7 +294,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **rss-ui** | oauth2-proxy-rss (oauth2-proxy) → 80 | rss-pg:5432 |
 | **rss-fetcher** | rss-cron → 80 | rss-pg:5432, world:443 |
 | **rss-cleaner** | rss-cron → 80 | rss-pg:5432 |
-| **rss-cron** | (none) | rss-fetcher:80, rss-cleaner:80 |
+| **rss-cron** | (none) | rss-fetcher:80, rss-cleaner:80, kube-apiserver:6443, seaweedfs-filer (seaweedfs):8333 |
 | **rss-migration** (Job) | (none) | rss-pg:5432 |
 
 ## horenso (1 policy)

--- a/helm-values/argocd/values.yaml
+++ b/helm-values/argocd/values.yaml
@@ -69,6 +69,31 @@ configs:
       hs.status = "Progressing"
       hs.message = "Waiting for cluster to be ready"
       return hs
+    # Without this a SpinApp is Progressing forever, because ArgoCD cannot read
+    # a CRD it has no rules for. That is not cosmetic: a sync stalls waiting for
+    # the wave to go healthy, so anything in a later wave — the rss schema
+    # migration, for one — never runs. The conditions mirror a Deployment's,
+    # which is what spin-operator creates underneath.
+    resource.customizations.health.core.spinkube.dev_SpinApp: |
+      hs = {}
+      if obj.status ~= nil and obj.status.conditions ~= nil then
+        for _, condition in ipairs(obj.status.conditions) do
+          if condition.type == "Available" then
+            if condition.status == "True" then
+              hs.status = "Healthy"
+              hs.message = condition.message
+              return hs
+            elseif condition.status == "False" then
+              hs.status = "Degraded"
+              hs.message = condition.message
+              return hs
+            end
+          end
+        end
+      end
+      hs.status = "Progressing"
+      hs.message = "Waiting for SpinApp to become available"
+      return hs
     accounts.cluster-bot: apiKey
     url: https://argocd.infra.tgy.io
     oidc.config: |

--- a/manifests/rss/netpol-rss-apps.yaml
+++ b/manifests/rss/netpol-rss-apps.yaml
@@ -134,6 +134,25 @@ spec:
         - ports:
             - port: "80"
               protocol: TCP
+    # The two below are argoexec's, not the container's: the init/wait sidecars
+    # report node status to the API server and archive logs to the artifact
+    # repository. Without them the Pod never leaves Init and the curl above
+    # never runs. Same pair as talos-build and image-build.
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: seaweedfs
+            app.kubernetes.io/component: filer
+            io.kubernetes.pod.namespace: seaweedfs
+      toPorts:
+        - ports:
+            - port: "8333"
+              protocol: TCP
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -3,6 +3,11 @@ kind: SpinApp
 metadata:
   name: rss-cleaner
   namespace: rss
+  annotations:
+    # After the schema migration in wave 1. Starting the components
+    # against an empty database is what left every request returning
+    # `relation "feeds" does not exist`.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.1@sha256:23fdc525221195d3b55cbb40b43d1a7d4b9b9fe0dc173dba738b7030b3bb95ce
   replicas: 1

--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -3,6 +3,11 @@ kind: SpinApp
 metadata:
   name: rss-fetcher
   namespace: rss
+  annotations:
+    # After the schema migration in wave 1. Starting the components
+    # against an empty database is what left every request returning
+    # `relation "feeds" does not exist`.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.1@sha256:3611976453ec439f5b41936fe850f6290d0f9bdcb0696978f86c5055ae379efa
   replicas: 1

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -3,6 +3,11 @@ kind: SpinApp
 metadata:
   name: rss-server
   namespace: rss
+  annotations:
+    # After the schema migration in wave 1. Starting the components
+    # against an empty database is what left every request returning
+    # `relation "feeds" does not exist`.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   image: ghcr.io/tsuguya/home-rss-server:v0.1.1@sha256:32c91fd25b07d0a45201df1d75d912aecf1ab0b66f017bcd6db15a1ab2b527b9
   replicas: 1

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -3,6 +3,11 @@ kind: SpinApp
 metadata:
   name: rss-ui
   namespace: rss
+  annotations:
+    # After the schema migration in wave 1. Starting the components
+    # against an empty database is what left every request returning
+    # `relation "feeds" does not exist`.
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   image: ghcr.io/tsuguya/home-rss-ui:v0.1.1@sha256:18b83df00aee0e78ef26ff2f9c57bde1cac8659a5ed211386dd365b9811cfc94
   replicas: 1

--- a/manifests/seaweedfs/netpol-filer.yaml
+++ b/manifests/seaweedfs/netpol-filer.yaml
@@ -37,6 +37,11 @@ spec:
               operator: Exists
           matchLabels:
             io.kubernetes.pod.namespace: claude-code
+        - matchExpressions:
+            - key: workflows.argoproj.io/workflow
+              operator: Exists
+          matchLabels:
+            io.kubernetes.pod.namespace: rss
         - matchLabels:
             app.kubernetes.io/name: argo-workflows-server
             io.kubernetes.pod.namespace: argo

--- a/manifests/secrets/rss-argo-artifacts.yaml
+++ b/manifests/secrets/rss-argo-artifacts.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argo-artifacts
+  namespace: rss
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: argo-artifacts
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: seaweedfs-argo-s3
+        metadataPolicy: None
+        nullBytePolicy: Ignore


### PR DESCRIPTION
#593 でデプロイした後に踏んだ 3 層。**どれも「上流が動いていなかったので誰も踏めなかった」もの**で、実際にトラフィックを流して初めて出た。

## 1. CronWorkflow がコンテナに到達しない

`argo submit --from cronwf/rss-fetcher` を回すと Pod が `Init:0/1` のまま deadline で死ぬ。

```
MountVolume.SetUp failed for volume "argo-artifacts": secret "argo-artifacts" not found
```

- **`argo-artifacts` secret が rss に無い**。workflow を回す他 4 namespace（argo / talos-build / image-build / claude-code）は全て 1Password から project している。同じ ExternalSecret を追加
- **`rss-cron` の egress が argoexec の分を持っていない**。許可されていたのは 2 つの SpinApp への :80 だけで、init / wait サイドカーが API server に node status を報告し artifact repository にログを archive する経路が無かった。talos-build / image-build と同じペア（kube-apiserver:6443 + seaweedfs-filer:8333）を追加
- **filer の ingress に rss の workflow Pod が無い**。4 namespace 分は列挙済みだったので同じパターンで追加

## 2. SpinApp が永久に Progressing → migration が走らない

ArgoCD は SpinApp の health ルールを持たないので、**全 replica が Ready でも Progressing のまま**。3 月の削除コミットが挙げた理由（"Remove to resolve ArgoCD Progressing health status"）はこれだが、影響は見た目だけではない。

**sync は現在の wave が healthy になるまで次の wave を始めない。したがって wave 1 のスキーマ migration が一度も走らなかった。**

`rss-migration` の completionTime は今も **2026-05-24T12:55:39Z** — rss-pg が作り直された **12:56:32 の 53 秒前**。マイグレーションはその時に消え、以後再適用されていない。今日 API が返していたのはこれ:

```
relation "feeds" does not exist
```

接続そのものは正常。**TLS 検証を通り、認証も通り、クエリを実行した結果**である点は押さえておきたい（#593 の目的は達成できている）。

spin-operator が Deployment から写している `Available` condition を読む health script を追加した。

## 3. SpinApp の sync-wave が未指定 = wave 0

DB と同じ wave、かつ migration より前だった。**空のスキーマに対してコンポーネントが起動する**順序になっていたので wave 2 に移した。

## 検証

- `kubectl apply --dry-run=server` — 全ファイル通過
- `helm template` — argocd values は SpinApp の health script を含めてレンダリング成功
- `docs/network-policies.md` を 3 箇所更新

マージ後: argocd-cm 更新 → rss app が Healthy → wave 1 の migration 実行 → wave 2 で SpinApp 再起動、まで `/dev-watch` で見届ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TothShCHZfaxDJP3VFaRbe