### PR TITLE
fix(rss): cover the workflow exit hook

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -285,7 +285,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **nextcloud** | ingress, cloudflared (argocd) → 80 | kube-apiserver, shared-pg (database):5432, seaweedfs-filer (seaweedfs):8333, kanidm (kanidm):8443, valkey:6379, *.nextcloud.com:443 (app store/updates), github.com:443 + *.githubusercontent.com:443 + *.github.com:443 (app store downloads) |
 | **valkey** | nextcloud → 6379 | (none) |
 
-## rss (7 policies)
+## rss (8 policies)
 
 | Component | Ingress | Egress |
 |---|---|---|
@@ -295,6 +295,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **rss-fetcher** | rss-cron → 80 | rss-pg:5432, world:443 |
 | **rss-cleaner** | rss-cron → 80 | rss-pg:5432 |
 | **rss-cron** | (none) | rss-fetcher:80, rss-cleaner:80, kube-apiserver:6443, seaweedfs-filer (seaweedfs):8333 |
+| **rss-workflow-exit** (workflows.argoproj.io/on-exit=true) | (none) | kube-apiserver:6443, seaweedfs-filer (seaweedfs):8333, discord.com:443 |
 | **rss-migration** (Job) | (none) | rss-pg:5432 |
 
 ## horenso (1 policy)

--- a/manifests/rss/netpol-rss-apps.yaml
+++ b/manifests/rss/netpol-rss-apps.yaml
@@ -154,6 +154,43 @@ spec:
             - port: "8333"
               protocol: TCP
 ---
+# argo's workflowDefaults attach a discord-notify exit hook to every workflow,
+# and the Pod it creates carries none of the labels the template sets — so
+# `rss-cron` above does not select it. It needs the API server to report its
+# own status, the artifact repository for its logs, and Discord to deliver the
+# notification.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: rss-workflow-exit
+  namespace: rss
+spec:
+  endpointSelector:
+    matchLabels:
+      workflows.argoproj.io/on-exit: "true"
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: seaweedfs
+            app.kubernetes.io/component: filer
+            io.kubernetes.pod.namespace: seaweedfs
+      toPorts:
+        - ports:
+            - port: "8333"
+              protocol: TCP
+    - toFQDNs:
+        - matchName: "discord.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:

--- a/manifests/secrets/discord-webhook-argo.yaml
+++ b/manifests/secrets/discord-webhook-argo.yaml
@@ -13,6 +13,7 @@ spec:
           - image-build
           - claude-code
           - horenso
+          - rss
   externalSecretSpec:
     refreshInterval: 1h
     secretStoreRef:


### PR DESCRIPTION
#595 で CronWorkflow 本体は動くようになったが、**exit hook の Pod が別の理由で詰まる**。

argo の `workflowDefaults.hooks.exit` が全 workflow に discord-notify を付けるので、fetcher の CronWorkflow は終了時にもう 1 つ Pod を作る。それが rss では起動できない:

```
Error: secret "discord-webhook-argo" not found
```

`discord-webhook-argo` は ClusterExternalSecret で 5 つの namespace に配られているが、**書かれた当時に workflow を回していた namespace のリスト**であって rss は入っていない。そして retry している間、argoexec サイドカーが API server を叩き続けて CNP に落とされる（hubble で実測）:

```
rss/rss-fetcher-...-send-...:57996 <> 192.168.10.231:6443 (kube-apiserver) Policy denied DROPPED
```

exit Pod は**テンプレートが付けるラベルを一切持たない**（`workflows.argoproj.io/on-exit=true` と `workflows.argoproj.io/workflow=...` だけ）ので `rss-cron` の selector に当たらない。on-exit ラベルで選択する専用ポリシーを追加し、hook が実際に必要とする 3 つだけを許可した:

| 宛先 | 用途 |
|---|---|
| kube-apiserver:6443 | argoexec が自身の status を報告 |
| seaweedfs-filer:8333 | ログの archive |
| discord.com:443 | 通知の送信 |

## 横展開の疑い

他の workflow namespace（argo / talos-build / image-build / claude-code / horenso）のポリシーも**テンプレートが付けるラベル**（`talos-build: "true"` 等）で書かれており、exit Pod はそれを持たない。同じ穴が空いている可能性がある。

ただし **通知に失敗する hook は構造的に無音**なので、空いていても何も報告されない。この PR とは別に確認する価値がある。

## 現時点のデプロイ状況

- rss app: `Synced / Healthy`
- スキーマ適用済み（articles / feeds / read_status / schema_migrations）
- `GET /api/stats` → `{"feeds":0,"unread":0}` (HTTP 200)、`GET /api/feeds` → `[]` (HTTP 200)

つまり **spin-sdk 6 移行と PostgreSQL の TLS 検証は動作確認済み**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TothShCHZfaxDJP3VFaRbe