### PR TITLE
chore(rss): move the SpinApps to v0.1.2

### DIFF
--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.1@sha256:23fdc525221195d3b55cbb40b43d1a7d4b9b9fe0dc173dba738b7030b3bb95ce
+  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.2@sha256:f8586590b69f0d7f10ff3fcaf1f9f2bab802d329fc781435014f1b5049944054
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.1@sha256:3611976453ec439f5b41936fe850f6290d0f9bdcb0696978f86c5055ae379efa
+  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.2@sha256:31d17567bd1cbfbce41fa10c88fe51c8c7f0c92f8544d0fb5250fe801c3aae6c
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-server:v0.1.1@sha256:32c91fd25b07d0a45201df1d75d912aecf1ab0b66f017bcd6db15a1ab2b527b9
+  image: ghcr.io/tsuguya/home-rss-server:v0.1.2@sha256:9a866c6acac1741484b54b5ff5e60fde40e7412ebf8d29ed8b8297ff5205b8cc
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-ui:v0.1.1@sha256:18b83df00aee0e78ef26ff2f9c57bde1cac8659a5ed211386dd365b9811cfc94
+  image: ghcr.io/tsuguya/home-rss-ui:v0.1.2@sha256:c0bcb5602bb5f6ee3063c6e10ecb81141da5d2d8af89b50717b78b27f656df66
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:


### PR DESCRIPTION
`v0.1.2` は uuid 列を `ParameterValue::Uuid` でバインドする（Tsuguya/home-rss#85）。

`v0.1.1` では `$1::uuid` キャストに文字列を渡していたため、**フィード取得は成功するのに記事の insert が全部型エラーで落ち、workflow は Succeeded を返し、DB には何も入らない**状態だった。デプロイ後に実物のフィードを流して判明した。

マージ後に E2E（フィード登録 → 収集 → 記事取得）を回して締める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TothShCHZfaxDJP3VFaRbe