### PR TITLE
chore(rss): move the SpinApps to v0.1.3

### DIFF
--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.2@sha256:f8586590b69f0d7f10ff3fcaf1f9f2bab802d329fc781435014f1b5049944054
+  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.3@sha256:4e4145575aecbaef885eea0987b4d50ba7e532320df27ab4bef9d7a3f078d947
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.2@sha256:31d17567bd1cbfbce41fa10c88fe51c8c7f0c92f8544d0fb5250fe801c3aae6c
+  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.3@sha256:7e0c30d1c3347a3cf3168691ae401bb24d05bc23abc8eca1db55006477752be4
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-server:v0.1.2@sha256:9a866c6acac1741484b54b5ff5e60fde40e7412ebf8d29ed8b8297ff5205b8cc
+  image: ghcr.io/tsuguya/home-rss-server:v0.1.3@sha256:edd3d9c796d57cd59c55db908e6d3fc966642c9c9c8c119203da0b7487a09a86
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-ui:v0.1.2@sha256:c0bcb5602bb5f6ee3063c6e10ecb81141da5d2d8af89b50717b78b27f656df66
+  image: ghcr.io/tsuguya/home-rss-ui:v0.1.3@sha256:1ac83bca17b753f14a2105edb405240d29b078b474feb9a5f47086d9cd85ad3b
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:


### PR DESCRIPTION
`v0.1.3` は timestamptz / interval のパラメータを text 経由でバインドする（Tsuguya/home-rss#86）。#85 が uuid で直したのと同じ問題の後半で、**パラメータに書いたキャストがそのパラメータの型を決めてしまい、SDK が送る型と食い違う**。

## 今回はタグを打つ前に実物で全部流した

同じ往復を繰り返さないため、port-forward 経由でローカルから実 DB に対して全パスを実行した:

| 対象 | 結果 |
|---|---|
| `GET /api/stats` `/api/feeds` `/api/articles`（feed_id / unread の 4 組合せ） | 200 |
| `POST /api/feeds` | 201 |
| `POST /api/articles/:id/read` | 204、`unread: 10 → 9` を確認 |
| `POST /api/articles/read-all` | 204 |
| `POST /api/import/opml` | 200 `{"imported":1}` |
| `DELETE /api/feeds/:id` / 存在しない id | 204 / 404 |
| fetcher | 実フィードから **記事 10 件を保存**、`published_at` も TIMESTAMPTZ で正しく格納 |
| cleaner | 200 `deleted 0 read article(s) older than 30 day(s)` |

server 側のエラーログはゼロ。テスト用のフィードと read_status は掃除済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TothShCHZfaxDJP3VFaRbe