### PR TITLE
feat(gateway): terminate reader.tgy.io inside the house

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -15,6 +15,7 @@ ArgoCD のみ TLS Passthrough（専用 argocd-gateway、ArgoCD 自身が TLS 終
 | SeaweedFS UI | https://seaweedfs.infra.tgy.io | oauth2-proxy-seaweedfs:4180 (oauth2-proxy) → seaweedfs-filer:8888 | Terminate (main-gateway) |
 | Nextcloud | https://nc.tgy.io | nextcloud:80 (nextcloud) | Cloudflare Tunnel (cloudflared) |
 | Harbor | https://registry.infra.tgy.io | harbor-nginx:8080 (harbor) | Cloudflare Tunnel (cloudflared) |
+| RSS Reader | https://reader.tgy.io | oauth2-proxy-rss:4180 (oauth2-proxy) → rss-ui:80 / rss-server:80 (/api) | Terminate (main-gateway) + Cloudflare Tunnel (cloudflared) |
 
 ## 内部サービス
 

--- a/manifests/infra/gateway.yaml
+++ b/manifests/infra/gateway.yaml
@@ -60,3 +60,33 @@ spec:
           selector:
             matchLabels:
               gateway-access: "true"
+    # reader.tgy.io reaches Cloudflare from outside, but CoreDNS has answered
+    # with this Gateway's address since March and nothing terminated it here.
+    # The certificate comes from the cluster-issuer annotation above, the same
+    # way nc-tgy-io-tls does.
+    - name: https-reader
+      hostname: "reader.tgy.io"
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: reader-tgy-io-tls
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              gateway-access: "true"
+    - name: http-reader
+      hostname: "reader.tgy.io"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              gateway-access: "true"

--- a/manifests/infra/rss-route.yaml
+++ b/manifests/infra/rss-route.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rss
+  namespace: oauth2-proxy
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: main-gateway
+      namespace: gateway
+      sectionName: https-reader
+  hostnames:
+    - reader.tgy.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: oauth2-proxy-rss
+          port: 4180
+          weight: 1


### PR DESCRIPTION
`reader.tgy.io` は **3 月から CoreDNS が Gateway (192.168.10.190) を返していた**が、Gateway 側にその hostname の listener が無く、**答えの先に何も無い**状態だった。

- 外から: Cloudflare Tunnel が oauth2-proxy に直接届くので動く
- 中から: 名前は引けて、接続は拒否される

`*.infra.tgy.io` の listener は hostname が一致しないので拾わない。apex ドメインのもう 1 つのサービス `nc.tgy.io` と同じ形で listener を 2 本足した。

## 証明書のマニフェストは要らない

`main-gateway` に `cert-manager.io/cluster-issuer: letsencrypt-prod` が付いており、**cert-manager の gateway-shim が listener ごとに Certificate を生成する**（`nc-tgy-io-tls` も Gateway が owner で git には存在しない）。

ACME solver は **DNS-01 (Cloudflare) で tgy.io ゾーン全体**が対象なので、認証プロキシの背後にある hostname でも発行できる。HTTP-01 なら oauth2-proxy がチャレンジを飲み込んで失敗するところだった。

## CNP は変更なし

`oauth2-proxy-rss` の ingress は既に `fromEntities: ingress` を持っている（Cilium LB 経由のトラフィックはこの entity にマッチする）。#593 で cloudflared 側を足したときに、Gateway 経由の分は元から通っていた。

`kubectl apply --dry-run=server` 通過。`docs/services.md` に 1 行追加。

マージ後、証明書が発行されて listener が Programmed になるところと、内部から `https://reader.tgy.io` が引けるところまで確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TothShCHZfaxDJP3VFaRbe