### PR TITLE
fix(image-build): let an unlabelled workflow report that it failed

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -167,11 +167,16 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 |---|---|---|
 | **claude-code** (claude-code=true) | (deny world) | kube-apiserver, api.anthropic.com + github.com + api.github.com + *.githubusercontent.com + index.crates.io + static.crates.io + registry.npmjs.org + discord.com + gitmcp.io :443, seaweedfs-filer (seaweedfs):8333, loki-gateway (monitoring):8080, prometheus (monitoring):9090, horenso (horenso):3000, task-dispatch-eventsource (argo):12002, argocd-server (argocd):8080 |
 
-## image-build (1 policy)
+## image-build (2 policies)
 
 | Component | Ingress | Egress |
 |---|---|---|
 | **image-build** (image-build=true) | (deny world) | kube-apiserver, 0.0.0.0/0:443, harbor-nginx (harbor):8443 (internal push), seaweedfs-filer (seaweedfs):8333 |
+| **workflow-pods** (workflows.argoproj.io/workflow が付き image-build=true が付かない Pod) | (deny world) | kube-apiserver, seaweedfs-filer (seaweedfs):8333, discord.com:443 |
+
+`workflow-pods` は「ラベルを持たないまま投入されたワークフローが**自分の失敗を報告できる**」ための
+最小限であって、任意のワークフローを動かすためのものではない。ビルドに要る egress は
+`image-build` 側にある。
 
 ## seaweedfs (4 policies)
 

--- a/manifests/image-build/netpol-workflow-pods.yaml
+++ b/manifests/image-build/netpol-workflow-pods.yaml
@@ -1,0 +1,55 @@
+# Argo attaches a discord-notify exit hook to every workflow in every namespace
+# (argo-workflows' workflowDefaults), and argoexec needs the API server to report
+# a step's outcome and the artifact repository to store its logs. A workflow pod
+# that matches no policy gets none of that: the run fails, the failure is not
+# reported, and the notification that would have said so is dropped too.
+#
+# `image-build` above covers pods the WorkflowTemplate labels. Anything else
+# submitted into this namespace carries only the labels Argo generates, and
+# argo's netpol-workflow-pods equivalent does not exist here — a workflow
+# without the label was silently cut off from both the API server and the
+# artifact store (204 and 160 POLICY_DENIED from one such run).
+#
+# This is deliberately not a way to make arbitrary workflows work: it grants
+# what a run needs to *report itself*, and nothing it would need to do its job.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: workflow-pods
+  namespace: image-build
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: workflows.argoproj.io/workflow
+        operator: Exists
+      # Pods the WorkflowTemplate labels keep the narrower `image-build` policy.
+      - key: image-build
+        operator: DoesNotExist
+  ingressDeny:
+    - fromEntities:
+        - world
+  egress:
+    # argoexec reports each step's outcome.
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+    # argoexec stores the step's logs as an artifact.
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: seaweedfs
+            app.kubernetes.io/component: filer
+            io.kubernetes.pod.namespace: seaweedfs
+      toPorts:
+        - ports:
+            - port: "8333"
+              protocol: TCP
+    # The exit hook every workflow inherits from workflowDefaults.
+    - toFQDNs:
+        - matchName: "discord.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
`image-build` namespace には CNP が **1 本しかなく**、WorkflowTemplate が付けるラベル（`image-build: "true"`）で選択している。`argo` にある `netpol-workflow-pods` に相当する catch-all が無い。

そこにラベル無しでワークフローが投入されると**どのポリシーにも当たらない**:

- argoexec が API server に届かず、ステップの結果を記録できない
- artifact リポジトリにも届かず、ログが残らない
- `workflowDefaults` が全ワークフローに付ける **discord-notify の exit hook も落ちる**

つまり**失敗し、失敗したことを報告できず、報告できなかったことも通知されない**。

## 実際に起きていた

Hubble（直近 7 日）:

```
204  when-semantics-lmnxn-emit-*  ->  kube-apiserver:6443
160  when-semantics-lmnxn-emit-*  ->  seaweedfs-filer:8333
```

この実行はこれ以外に痕跡を残していない。`when-semantics` は現存せずマニフェストにも無いので、一時的に投入されたワークフローだと思われる。

## 変更

`argo/netpol-workflow-pods` と同型だが、**意図的に狭くしてある**。

| 許可 | 理由 |
|---|---|
| kube-apiserver:6443 | argoexec がステップの結果を報告する |
| seaweedfs-filer:8333 | argoexec がログを artifact として保存する |
| discord.com:443（`toFQDNs`） | `workflowDefaults` から継承する exit hook |

**ビルドに要るものは 1 つも入れていない**（`0.0.0.0/0:443` も harbor も無い）。任意のワークフローを動かすためではなく、**自分の失敗を報告できるようにする**ためのポリシー。

selector は `image-build: "true"` を `DoesNotExist` で除外しているので、既存の `image-build` ポリシーの範囲は変わらない。

## ついでに

`docs/network-policies.md` は seaweedfs filer の ingress 元として **既に `workflow-pods (image-build)` を挙げていた**。ポリシーが存在する前提でドキュメントが書かれていた。

## 検証

`kubectl apply --dry-run=server` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn