### PR TITLE
fix(claude-code): drop the build command the check no longer runs

### DIFF
--- a/manifests/claude-code/implement-wft.yaml
+++ b/manifests/claude-code/implement-wft.yaml
@@ -25,8 +25,6 @@ spec:
       - name: pr-title
       - name: pr-labels
         default: ""
-      - name: build-cmd       # check フェーズが走らせる決定論的な検証
-        default: "pnpm install --frozen-lockfile && pnpm build"
       - name: workdir
         default: "."
       - name: rework-budget


### PR DESCRIPTION
`check` フェーズはリポジトリ側の CI を待つ形に変えたので、`build-cmd` は**宣言されているだけで誰も読まない**パラメータになっていた。

しかも `argo submit --from` は `spec.arguments.parameters` の `default` を採らないため、**使われていないパラメータでも毎回渡さないと submit が失敗する**:

```
Error: spec.arguments.build-cmd.value or spec.arguments.build-cmd.valueFrom is required
```

削除する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn