### PR TITLE
fix(claude-code): keep the commit helper out of the work tree

### DIFF
--- a/manifests/claude-code/implement-wft.yaml
+++ b/manifests/claude-code/implement-wft.yaml
@@ -49,6 +49,8 @@ spec:
         secretName: github-app-private-key
     - name: verdict
       emptyDir: {}
+    - name: helpers
+      emptyDir: {}
     - name: prompt
       projected:
         sources:
@@ -183,9 +185,9 @@ spec:
               git config user.name "tgy-cluster-bot[bot]"
               git config user.email "tgy-cluster-bot[bot]@users.noreply.github.com"
               # 署名コミットのスクリプトは argo-tools イメージにあり、main の
-              # claude-code イメージには無い。workspace 経由で渡す
-              mkdir -p /workspace/.bin
-              cp /usr/local/bin/github-signed-commit.sh /workspace/.bin/
+              # claude-code イメージには無い。専用ボリューム経由で渡す。
+              # 作業ツリーの中に置くと git add -A が拾って PR に混入する
+              cp /usr/local/bin/github-signed-commit.sh /helpers/
           env:
             - {name: HOME, value: /tmp}
           securityContext:
@@ -196,6 +198,7 @@ spec:
           volumeMounts:
             - {name: workspace, mountPath: /workspace}
             - {name: github-token, mountPath: /github-token, readOnly: true}
+            - {name: helpers, mountPath: /helpers}
           resources:
             requests: {cpu: 10m, memory: 64Mi}
             limits: {memory: 256Mi}
@@ -255,7 +258,7 @@ spec:
               echo "ブランチ ${BRANCH} を作成しました"
             fi
 
-            /workspace/.bin/github-signed-commit.sh \
+            /helpers/github-signed-commit.sh \
               -r "$REPO" \
               -b "$BRANCH" \
               -m "{{workflow.parameters.pr-title}}"
@@ -287,6 +290,7 @@ spec:
           - {name: workspace, mountPath: /workspace}
           - {name: claude-home, mountPath: /claude-home}
           - {name: github-token, mountPath: /github-token, readOnly: true}
+          - {name: helpers, mountPath: /helpers, readOnly: true}
           - {name: prompt, mountPath: /prompt, readOnly: true}
         resources:
           requests: {cpu: 200m, memory: 1Gi}


### PR DESCRIPTION
init が `github-signed-commit.sh` を `/workspace/.bin/` にコピーしていた（main の claude-code イメージには無いため）。**`/workspace` はリポジトリそのものなので、`git add -A` が拾って PR に入った。**

最初に出た PR（[home-rss#87](https://github.com/Tsuguya/home-rss/pull/87)）:

```
.bin/github-signed-commit.sh   +101/-0     ← 混入
ui/package.json                  +1/-1
ui/pnpm-lock.yaml              +201/-131
```

依頼は 2 行の依存更新なのに、ツール本体が 101 行付いてきている。

専用ボリューム（`/helpers`）に移した。**フローが内部で必要とするものを、編集対象のツリーに置かない。**

## 実行中の観察について

この PR を出した時点で、混入したまま走っている実行があります。レビューフェーズのプロンプトには「依頼に含まれない変更が混ざっていないか確認する」と書いてあるので、**レビュアーがこれを検出するかの試験**として意図的に流しています（検出すれば rework、しなければ pass）。

なお 2 周目でも init が再コピーするため差し戻しでは直らず、予算切れで escalate になるはずです。エージェントに直せない問題への振る舞いとしては正しい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn