### PR TITLE
fix(claude-code): stop the CI wait from corrupting its own input

### DIFF
--- a/manifests/claude-code/implement-wft.yaml
+++ b/manifests/claude-code/implement-wft.yaml
@@ -335,19 +335,34 @@ spec:
             exit 0
           fi
 
-          # CI が出そろうまで待つ。出そろわないまま時間切れなら判定不能
+          # CI が出そろうまで待つ。出そろわないまま時間切れなら判定不能。
+          #
+          # `gh pr checks` は pending や failure があると **JSON を出したうえで非ゼロ終了する**。
+          # `$(... || echo '[]')` と書くと実データの後ろに `[]` が連結され、`jq length` が
+          # 2 行を返して数値比較が常に偽になる。終了コードは出力と分けて扱う。
+          #
+          # 毎回ログを出す。出さないと、20 分回って何も分からないという今日踏んだ状態になる。
           DONE=0
-          for _ in $(seq 1 60); do
-            RAW=$(gh pr checks "$PR" --repo "$REPO" --json name,state 2>/dev/null || echo '[]')
-            PENDING=$(echo "$RAW" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
-            TOTAL=$(echo "$RAW" | jq 'length')
-            if [ "$TOTAL" -gt 0 ] && [ "$PENDING" = "0" ]; then DONE=1; break; fi
-            sleep 20
+          for i in $(seq 1 40); do
+            RAW=$(gh pr checks "$PR" --repo "$REPO" --json name,state 2>/tmp/gh.err)
+            RC=$?
+            if ! printf '%s' "$RAW" | jq -e 'type == "array"' >/dev/null 2>&1; then
+              echo "poll $i: rc=$RC 出力が配列でない: $(printf '%s' "$RAW" | head -c 120) / err=$(head -c 120 /tmp/gh.err)"
+              sleep 15
+              continue
+            fi
+            TOTAL=$(printf '%s' "$RAW" | jq 'length')
+            PENDING=$(printf '%s' "$RAW" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS" or .state == "REQUESTED" or .state == "WAITING")] | length')
+            echo "poll $i: rc=$RC total=$TOTAL pending=$PENDING"
+            if [ "$TOTAL" -gt 0 ] && [ "$PENDING" -eq 0 ]; then DONE=1; break; fi
+            sleep 15
           done
 
           if [ "$DONE" != "1" ]; then
             printf '%s' indeterminate > /verdict/verdict.txt
-            echo "CI が時間内に完了しませんでした（判定不能）。" > /verdict/report.md
+            { echo "## CI が時間内に完了しませんでした（判定不能）"; echo;
+              echo "最後に観測した状態:"; echo '```';
+              printf '%s' "$RAW" | head -c 800; echo; echo '```'; } > /verdict/report.md
             exit 0
           fi
 


### PR DESCRIPTION
`check` ステップが 20 分ポーリングして「CI が完了しなかった」と判定した。**実際には PR のチェックは 2 分で全部緑になっていた。**

## 原因

`gh pr checks` は **pending や failure があると JSON を出力したうえで非ゼロ終了する**。

```sh
RAW=$(gh pr checks ... --json name,state 2>/dev/null || echo '[]')
```

この書き方だと、非ゼロ終了のたびに `||` が発火して**実データの後ろに `[]` が連結**される。

```
[{"name":"CI Gate","state":"SUCCESS"},...]
[]
```

`jq 'length'` はこれを 2 つの文書として数え、**2 行**を返す。`[ "$TOTAL" -gt 0 ]` に複数行の値を渡すと常に偽。**pending が 1 つでもある間はループが成功しえない** — つまり待つ意味のある全ての周回で。

終了コードと出力を分離し、配列としてパースできることを確認してから読むようにした。

## もう 1 つの問題

**20 分間、ログを 1 行も出していなかった。** そのため「GitHub が遅い」のか「こちらが壊れている」のかを実行後に区別できなかった。原因の特定にログではなくスクリプトの読み直しが必要になった。

- 毎周のポーリング結果（rc / total / pending）を出力
- タイムアウト時のレポートに**最後に観測した状態**を含める

**待つのが仕事のステップは、何を待っているかを言うべき。** 今日ずっと扱ってきた「失敗が自己申告されない」を自分で作っていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn