### PR TITLE
ci: run detect and the gate on ubuntu-slim

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -61,7 +61,9 @@ jobs:
   # 中身を変えた PR がその leaf を走らせないのでは検証にならない。
   detect:
     name: detect changes
-    runs-on: ubuntu-latest
+    # checkout と paths-filter しか動かないので slim で足りる。ツールを要求
+    # するのは leaf 側で、そちらは ubuntu-latest のまま。
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read
@@ -239,7 +241,8 @@ jobs:
     # below and records the required check as a failure. A cancelled run has no
     # verdict to give, so the gate should be skipped along with it.
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
+    # 集計は bash の for ループだけなので slim で足りる。
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions: {}
     steps:


### PR DESCRIPTION
#613 で入れた `detect` と `CI Gate` は、どちらもフルランナーを要する仕事をしていない。

| job | やっていること |
|---|---|
| detect | checkout と dorny/paths-filter |
| CI Gate | `needs.*.result` を回す bash ループ |

leaf は `ubuntu-latest` のまま。プリインストールされたツールチェインを実際に使うのはそちら。

digest-cooldown #15 で先に実測して通っている（**detect 9s / gate 3s**）ので、ここは追随。

`actionlint` 通過。