### PR TITLE
feat(horenso): daily maintenance workflow and health-recovered notification

### DIFF
--- a/helm-values/argocd/values.yaml
+++ b/helm-values/argocd/values.yaml
@@ -225,6 +225,10 @@ notifications:
         - on-sync-succeeded
         - on-sync-failed
         - on-health-degraded
+    - recipients:
+        - horenso
+      triggers:
+        - on-health-recovered
   triggers:
     trigger.on-sync-succeeded: |
       - description: Application syncing has succeeded
@@ -241,6 +245,13 @@ notifications:
         send:
           - app-health-degraded
         when: app.status.health.status == 'Degraded'
+    # horenso が health-degraded で自動作成した調査タスクを閉じるため。
+    # Discord には流さない (Healthy は平常なので通知価値がない)。
+    trigger.on-health-recovered: |
+      - description: Application has recovered to Healthy
+        send:
+          - app-health-recovered
+        when: app.status.health.status == 'Healthy'
     trigger.on-deployed: |
       - description: Application is synced and healthy. Triggered once per commit.
         oncePer: app.status.operationState.syncResult.revision
@@ -319,6 +330,17 @@ notifications:
             {
               "app": "{{.app.metadata.name}}",
               "event": "health-degraded",
+              "health_status": "{{.app.status.health.status}}",
+              "url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
+            }
+    template.app-health-recovered: |
+      webhook:
+        horenso:
+          method: POST
+          body: |
+            {
+              "app": "{{.app.metadata.name}}",
+              "event": "health-recovered",
               "health_status": "{{.app.status.health.status}}",
               "url": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}"
             }

--- a/manifests/argo/horenso-maintenance.yaml
+++ b/manifests/argo/horenso-maintenance.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: horenso-maintenance
+  namespace: argo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: horenso-maintenance
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-edit
+subjects:
+  - kind: ServiceAccount
+    name: horenso-maintenance
+    namespace: argo
+---
+# ArgoCD Application の health/sync を読むだけ。horenso 本体に ArgoCD の
+# 読み取り権限を持たせず、この WF が集めた現状を渡す。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: horenso-maintenance
+  namespace: argocd
+rules:
+  - apiGroups: [argoproj.io]
+    resources: [applications]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: horenso-maintenance
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: horenso-maintenance
+subjects:
+  - kind: ServiceAccount
+    name: horenso-maintenance
+    namespace: argo
+---
+# horenso の日次整理。回復イベント (health-recovered / sync-succeeded) の
+# 取りこぼしで残った argocd 由来タスクを現状と突き合わせて閉じ、止まった
+# running を failed にし、古い event 投稿を消す。結果は horenso 自身に
+# report として投稿される (0 件でも投稿 — 沈黙と正常を区別する)。
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: horenso-maintenance
+  namespace: argo
+spec:
+  activeDeadlineSeconds: 300
+  serviceAccountName: horenso-maintenance
+  entrypoint: main
+  templates:
+    - name: main
+      metadata:
+        labels:
+          horenso-maintenance: "true"
+      container:
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:d29e837e2601fadc50e346398e86934c9cf49b309448b89b19b867122c9bf74b
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        env:
+          - name: HOME
+            value: /tmp
+        command: [sh, -c]
+        args:
+          - |
+            set -eu
+
+            kubectl get applications -n argocd -o json \
+              | jq '{apps: [.items[] | {name: .metadata.name, health: .status.health.status, sync: .status.sync.status}]}' \
+              > /tmp/apps.json
+
+            echo "=== $(jq '.apps | length' /tmp/apps.json) applications ==="
+
+            curl -fsS -X POST http://horenso.horenso.svc.cluster.local:3000/maintenance \
+              -H 'Content-Type: application/json' \
+              --data @/tmp/apps.json \
+              | jq .
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: horenso-maintenance
+  namespace: argo
+spec:
+  schedules:
+    - "30 4 * * *"
+  timezone: Asia/Tokyo
+  concurrencyPolicy: Replace
+  workflowSpec:
+    workflowTemplateRef:
+      name: horenso-maintenance

--- a/manifests/argo/netpol-horenso-maintenance.yaml
+++ b/manifests/argo/netpol-horenso-maintenance.yaml
@@ -1,0 +1,19 @@
+# kube-apiserver への egress は workflow-pods CNP が持つ。ここは horenso 向けだけ。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: horenso-maintenance
+  namespace: argo
+spec:
+  endpointSelector:
+    matchLabels:
+      horenso-maintenance: "true"
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            app: horenso
+            io.kubernetes.pod.namespace: horenso
+      toPorts:
+        - ports:
+            - port: "3000"
+              protocol: TCP

--- a/manifests/horenso/netpol.yaml
+++ b/manifests/horenso/netpol.yaml
@@ -31,6 +31,9 @@ spec:
         - matchLabels:
             task-fail-sync: "true"
             io.kubernetes.pod.namespace: argo
+        - matchLabels:
+            horenso-maintenance: "true"
+            io.kubernetes.pod.namespace: argo
       toPorts:
         - ports:
             - port: "3000"


### PR DESCRIPTION
Pairs with Tsuguya/horenso#80.

- ArgoCD notifications: new `on-health-recovered` trigger → horenso only (no Discord)
- `horenso-maintenance` WorkflowTemplate + CronWorkflow 04:30 JST; SA has get/list on `applications` in argocd only
- CNP: egress from workflow pod to horenso:3000; horenso ingress from `horenso-maintenance: "true"`

Note: on first rollout every currently-Healthy app fires `health-recovered` once (~50 event posts); they are purged by the 30d retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhC3fgeu9BJiECjmHMHF5f