### PR TITLE
fix(argo): move horenso-maintenance Role to argocd-config

### DIFF
--- a/manifests/argo/horenso-maintenance.yaml
+++ b/manifests/argo/horenso-maintenance.yaml
@@ -18,32 +18,6 @@ subjects:
     name: horenso-maintenance
     namespace: argo
 ---
-# ArgoCD Application の health/sync を読むだけ。horenso 本体に ArgoCD の
-# 読み取り権限を持たせず、この WF が集めた現状を渡す。
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: horenso-maintenance
-  namespace: argocd
-rules:
-  - apiGroups: [argoproj.io]
-    resources: [applications]
-    verbs: [get, list]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: horenso-maintenance
-  namespace: argocd
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: horenso-maintenance
-subjects:
-  - kind: ServiceAccount
-    name: horenso-maintenance
-    namespace: argo
----
 # horenso の日次整理。回復イベント (health-recovered / sync-succeeded) の
 # 取りこぼしで残った argocd 由来タスクを現状と突き合わせて閉じ、止まった
 # running を failed にし、古い event 投稿を消す。結果は horenso 自身に

--- a/manifests/argocd/rbac-horenso-maintenance.yaml
+++ b/manifests/argocd/rbac-horenso-maintenance.yaml
@@ -1,0 +1,26 @@
+# argo-workflows の horenso-maintenance WF (manifests/argo/horenso-maintenance.yaml)
+# が使う読み取り権限。AppProject argo は argocd namespace を配置先に持たないので、
+# argocd namespace 側のリソースはこちら (argocd-config / platform) に置く。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: horenso-maintenance
+  namespace: argocd
+rules:
+  - apiGroups: [argoproj.io]
+    resources: [applications]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: horenso-maintenance
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: horenso-maintenance
+subjects:
+  - kind: ServiceAccount
+    name: horenso-maintenance
+    namespace: argo


### PR DESCRIPTION
Follow-up to #619: `argo-config` sync was stuck on `namespace argocd is not permitted in project 'argo'`. The Role/RoleBinding now live under `manifests/argocd/` (platform project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhC3fgeu9BJiECjmHMHF5f