### PR TITLE
fix(renovate): let qnap-csi digest pins land, silence unreadable ghcr lookups

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -112,10 +112,13 @@
     },
     {
       // Operator flag, not a container spec — the kubernetes manager cannot see it.
+      // The optional currentDigest group is what lets docker:pinDigests land: Renovate
+      // re-extracts after writing and fails the branch ("update failure") unless the
+      // digest it just appended is captured back.
       "customType": "regex",
       "managerFilePatterns": ["/kustomize/qnap-csi/upstream\\.yaml$/"],
       "matchStrings": [
-        "--qts-cgi-image=(?<depName>[^:]+):(?<currentValue>v\\S+)"
+        "--qts-cgi-image=(?<depName>[^:]+):(?<currentValue>v[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "datasourceTemplate": "docker"
     },
@@ -124,7 +127,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/kustomize/qnap-csi/upstream\\.yaml$/"],
       "matchStrings": [
-        "tridentImage: (?<depName>[^:]+):(?<currentValue>v\\S+)"
+        "tridentImage: (?<depName>[^:]+):(?<currentValue>v[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
       "datasourceTemplate": "docker"
     },
@@ -234,6 +237,19 @@
       "description": "Do not automerge critical infrastructure",
       "matchPackageNames": ["cilium", "tetragon", "https://github.com/kubernetes-sigs/gateway-api.git"],
       "automerge": false
+    },
+    {
+      "description": [
+        "ghcr.io/tsuguya/home-rss-* are private packages. The GitHub App installation",
+        "token Renovate runs with has packages:write, yet ghcr answers DENIED:",
+        "installation not allowed to Read organization package (measured 2026-08-23) —",
+        "ghcr only honours the Actions GITHUB_TOKEN for App-style auth, not a third-party",
+        "App. Until the images move to Harbor (where Renovate already authenticates)",
+        "every run logs four lookup failures on the Dependency Dashboard; releases are",
+        "bumped by hand from home-rss in the meantime."
+      ],
+      "matchPackageNames": ["ghcr.io/tsuguya/**"],
+      "enabled": false
     },
     {
       "description": "Group QNAP CSI packages (chart version + all images)",


### PR DESCRIPTION
Dependency Dashboard (#410) has carried two warnings:

- **`Error updating branch: update failure` on `renovate/qnap-csi`** — `docker:pinDigests` appends `@sha256:…` to the two regex-managed references in `kustomize/qnap-csi/upstream.yaml` (`--qts-cgi-image=` and `tridentImage:`), but the `matchStrings` had no `currentDigest` group. Renovate re-extracts after writing (`confirmIfUpdated` → "Digest is not updated") and throws the branch away. Added an optional `currentDigest` capture and stopped `currentValue` from swallowing `@…`.
- **`Package lookup failures` for `ghcr.io/tsuguya/home-rss-*`** — the packages are private. Measured with the App's own installation token: ghcr answers `DENIED: installation not allowed to Read organization package` even though the App has `packages: write`. Disabled those deps with the reason in `description`; the real fix is moving the images to Harbor.

`renovate-config-validator --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fW4nhh69GZEjhGhcF6XiD