### PR TITLE
fix(renovate): give the qnap-csi regex managers a replace template so digest pins can be written

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -120,7 +120,10 @@
       "matchStrings": [
         "--qts-cgi-image=(?<depName>[^:]+):(?<currentValue>v[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      // Without this the regex manager only swaps currentValue for newValue and
+      // has nowhere to put a newly pinned digest.
+      "autoReplaceStringTemplate": "--qts-cgi-image={{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     },
     {
       // Same: a CR field holding an image reference.
@@ -129,7 +132,8 @@
       "matchStrings": [
         "tridentImage: (?<depName>[^:]+):(?<currentValue>v[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"
       ],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "tridentImage: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     },
     {
       // Generic `# renovate:` annotation over a shell-style assignment, for versions


### PR DESCRIPTION
Follow-up to #628 — the qnap-csi branch still failed on the next run. `doAutoReplace` only replaces `currentValue`→`newValue` inside the matched string; a digest that was not there before is only inserted when `autoReplaceStringTemplate` says where. Added templates for both regex managers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fW4nhh69GZEjhGhcF6XiD