### PR TITLE
fix(claude-code): let the verify templates be submitted on their own

### DIFF
--- a/manifests/claude-code/horenso-verify-wft.yaml
+++ b/manifests/claude-code/horenso-verify-wft.yaml
@@ -13,6 +13,14 @@ metadata:
   name: horenso-verify
   namespace: claude-code
 spec:
+  # templateRef で呼ばれるほか、単体でも起動できるようにしておく。
+  # entrypoint と arguments が無いと `argo submit --from` が
+  # `spec.entrypoint is required` で落ちる
+  entrypoint: verify
+  arguments:
+    parameters:
+      - name: repo
+      - name: branch
   templates:
     - name: verify
       inputs:

--- a/manifests/claude-code/verify-skip-wft.yaml
+++ b/manifests/claude-code/verify-skip-wft.yaml
@@ -11,6 +11,14 @@ metadata:
   name: verify-skip
   namespace: claude-code
 spec:
+  # templateRef で呼ばれるほか、単体でも起動できるようにしておく。
+  # entrypoint と arguments が無いと `argo submit --from` が
+  # `spec.entrypoint is required` で落ちる
+  entrypoint: verify
+  arguments:
+    parameters:
+      - name: repo
+      - name: branch
   templates:
     - name: verify
       inputs:


### PR DESCRIPTION
#625 の本文に単体起動のコマンドを書いたが、**動かなかった**。

```
$ argo -n claude-code submit --from workflowtemplate/horenso-verify -p repo=... -p branch=...
Error: failed to submit workflow: rpc error: code = InvalidArgument
  desc = spec.entrypoint is required
```

両テンプレートは `templateRef` 経由で呼ばれる前提で書いたので、`spec.entrypoint` も `spec.arguments` も持っていなかった。**PR に書いた起動方法を実行していなかった。**

`entrypoint` と `arguments` を追加する。`templateRef` からの呼び出しは引き続き動き、記載したコマンドも動くようになる。

implement フローに繋ぐのが lint 例外を要する以上、**単体起動が当面の唯一の使い道**なので、そこが動かないのは実害がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn