### PR TITLE
fix(claude-code): give the postgres sidecar its command

### DIFF
--- a/manifests/claude-code/horenso-verify-wft.yaml
+++ b/manifests/claude-code/horenso-verify-wft.yaml
@@ -53,6 +53,12 @@ spec:
           # 本番（CNPG）は PostgreSQL 18。メジャーを揃えてある。
           # Kyverno の署名検証は registry.infra.tgy.io/* のみが対象なので上流イメージで通る
           image: postgres:18-alpine@sha256:d3e1620b530c944afa6e887d22eb899824da68e19c52024bf98f5220c88a65b2
+          # emissary executor はイメージの entrypoint を知る必要があり、
+          # 自分の index に無いものは registry へ問い合わせに行く。argo から
+          # docker.io への egress は無いので、そこで Pod が Pending のまま止まる。
+          # crane config で読んだ値をそのまま明示して問い合わせを不要にする
+          command: [docker-entrypoint.sh]
+          args: [postgres]
           env:
             - {name: POSTGRES_USER, value: horenso}
             - {name: POSTGRES_PASSWORD, value: horenso}


### PR DESCRIPTION
検証用の Pod が起動しなかった。

```
failed to look-up entrypoint/cmd for image "postgres:18-alpine@sha256:…",
you must either explicitly specify the command, or list the image's command in the index
Get "https://index.docker.io/v2/": dial tcp 100.63.54.175:443: i/o timeout
```

**emissary executor はイメージの entrypoint を知る必要がある。** 自分の index に持たないイメージは registry に問い合わせに行くが、`argo` から docker.io への egress は無いのでタイムアウトし、Pod が `Pending` のまま止まる。

しかもこのエラーは **Pod にも Events にも出ない**（workflow のノード message にしか現れない）ため、`kubectl get pods` は空、イベントは `WorkflowRunning` だけという状態になる。

## 修正

`command` と `args` を明示する。値は**このテンプレートを書く前に `crane config` で読んでいた**もの（イメージの user を確認するため）で、単に書き留めていなかった:

```yaml
command: [docker-entrypoint.sh]
args: [postgres]
```

明示すれば問い合わせ自体が発生しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn