### PR TITLE
fix(claude-code): label the verify pods so the network policy selects them

### DIFF
--- a/manifests/claude-code/horenso-verify-wft.yaml
+++ b/manifests/claude-code/horenso-verify-wft.yaml
@@ -17,6 +17,13 @@ spec:
   # entrypoint と arguments が無いと `argo submit --from` が
   # `spec.entrypoint is required` で落ちる
   entrypoint: verify
+  # namespace の CNP はこのラベルで選択する。template 側の
+  # `metadata.labels` だけでは、単体起動したとき（呼び出し元の
+  # podMetadata が無いとき）にベースラインのカバレッジから静かに外れ、
+  # github-auth が GitHub に届かず exit 28 で落ちる。
+  podMetadata:
+    labels:
+      claude-code: "true"
   arguments:
     parameters:
       - name: repo

--- a/manifests/claude-code/verify-skip-wft.yaml
+++ b/manifests/claude-code/verify-skip-wft.yaml
@@ -15,6 +15,13 @@ spec:
   # entrypoint と arguments が無いと `argo submit --from` が
   # `spec.entrypoint is required` で落ちる
   entrypoint: verify
+  # namespace の CNP はこのラベルで選択する。template 側の
+  # `metadata.labels` だけでは、単体起動したとき（呼び出し元の
+  # podMetadata が無いとき）にベースラインのカバレッジから静かに外れ、
+  # github-auth が GitHub に届かず exit 28 で落ちる。
+  podMetadata:
+    labels:
+      claude-code: "true"
   arguments:
     parameters:
       - name: repo


### PR DESCRIPTION
単体起動した検証実行が、最初の init コンテナで落ちた。

```
github-auth: Error (exit code 28)          ← curl のタイムアウト
wget: can't connect to remote host (...)   ← exit hook も届かない
```

Pod が持つラベルは template の `metadata.labels`（`agent.tgy.io/phase: verifying`）だけ。namespace の CNP が選択に使うのは **`claude-code: "true"`** で、それは **workflow レベルの `podMetadata`** から来る。templateRef で呼ばれるときは呼び出し元のものが効くが、**単体起動では誰も付けない**。

`podMetadata` を spec に足す。

## 今日 3 回目

| 回 | 対象 |
|---|---|
| 1 | 再帰の probe（`podMetadata` を書かず 7 分無言停止） |
| 2 | rss の CronWorkflow（template 単位ラベルのみ） |
| 3 | **これ** |

しかも `implement-wft.yaml` には**このテンプレートを書く数時間前に自分で書いたコメント**が残っている:

```yaml
# namespace の CNP はこのラベルで選択する。フェーズ別ラベルだけにすると
# ベースラインのカバレッジから静かに外れ、argoexec が API server に届かない
```

メモリにも記録した。それでも新しいテンプレートでは付け忘れた。

**テンプレートごとに手で再適用する規約は、それを文書化した本人が忘れる。** 「規約ではなく構造で担保する」という設計方針の、実例として記録しておく。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxRHAu4adMyfFPS2Zvn8qn