### PR TITLE
refactor(claude-code): move the verify scripts into a ConfigMap and lint them

### DIFF
--- a/.github/workflows/_configmap-scripts.yml
+++ b/.github/workflows/_configmap-scripts.yml
@@ -1,0 +1,39 @@
+name: configmap scripts
+
+# ConfigMap に入ったスクリプトの構文検査を workflow_call で公開する leaf。
+# オーケストレーターは `Lint` (lint.yaml) で、必須チェックはそこの `CI Gate`
+# 1 個だけ。直接のトリガーは持たない — leaf 自身が pull_request で起動すると、
+# 同じコミットに対して gate 経由の結果と重複した check run が並ぶ。
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  # YAML の中の文字列は、クラスタに適用されて Pod が落ちるまで誰も構文を見ない。
+  # horenso-verify はネストしたヒアドキュメントの引用符を間違え、イメージに無い
+  # インタプリタを呼び、どちらも実 Pod の失敗で初めて分かった。スクリプトを
+  # ConfigMap のキーとして持てば、ここで検査できる。
+  #
+  # シェルは `sh -n` ではなく shellcheck をかける。文法だけ見ても
+  # `cd dir` が失敗して次に進む型の穴は通ってしまう（実際に通っていた）。
+  configmap-scripts:
+    name: configmap scripts
+    # shellcheck と node が要る。どちらも ubuntu-latest には入っているが、
+    # ubuntu-slim には無い。
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      # 検査に使った実装を記録する。指摘の有無はバージョンで変わる。
+      - name: shellcheck version
+        run: shellcheck --version
+
+      - name: Check scripts embedded in ConfigMaps
+        run: python3 scripts/lint-configmap-scripts.py

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -75,6 +75,7 @@ jobs:
       images: ${{ steps.filter.outputs.images }}
       argo: ${{ steps.filter.outputs.argo }}
       mcp: ${{ steps.filter.outputs.mcp }}
+      cmscripts: ${{ steps.filter.outputs.cmscripts }}
       workflows: ${{ steps.filter.outputs.workflows }}
       renovate: ${{ steps.filter.outputs.renovate }}
       aqua: ${{ steps.filter.outputs.aqua }}
@@ -127,6 +128,11 @@ jobs:
             mcp:
               - '.github/mcp/**'
               - '.github/workflows/_mcp.yml'
+            cmscripts:
+              - 'manifests/**'
+              - 'kustomize/**'
+              - 'scripts/lint-configmap-scripts.py'
+              - '.github/workflows/_configmap-scripts.yml'
             workflows:
               - '.github/workflows/**'
               - '.github/zizmor.yml'
@@ -183,6 +189,13 @@ jobs:
     permissions:
       contents: read
 
+  configmap-scripts:
+    needs: detect
+    if: ${{ needs.detect.outputs.cmscripts == 'true' }}
+    uses: ./.github/workflows/_configmap-scripts.yml
+    permissions:
+      contents: read
+
   # Most of this file is bash inside `run:` blocks, and none of it is exercised
   # until a push runs it. actionlint checks the expressions and the job graph,
   # and shells out to shellcheck for every script — which is where the real
@@ -233,6 +246,7 @@ jobs:
       - image-existence
       - mcp
       - argo-lint
+      - configmap-scripts
       - lint-workflows
       - lint-renovate
       - lint-aqua

--- a/manifests/claude-code/horenso-verify-wft.yaml
+++ b/manifests/claude-code/horenso-verify-wft.yaml
@@ -80,6 +80,9 @@ spec:
         - name: github-app-secret
           secret:
             secretName: github-app-private-key
+        - name: scripts
+          configMap:
+            name: horenso-verify-scripts
       # 使い捨ての PostgreSQL。本番 DB には一切触れない
       sidecars:
         - name: postgres
@@ -131,120 +134,18 @@ spec:
             limits: {memory: 64Mi}
       container:
         image: registry.infra.tgy.io/tools/claude-code:latest@sha256:d17af43d38f328323b115bf56d58479ac87f06088358d089a009388a1558419c
-        command: [sh, -c]
-        args:
-          - |
-            set -u
-            fail() {
-              printf '%s' rework > /work/verdict.txt
-              { echo "## 検証失敗"; echo; echo "$1"; } > /work/report.md
-              exit 0
-            }
-
-            export HOME=/tmp
-            GITHUB_TOKEN=$(cat /github-token/token)
-            git config --global --add safe.directory /work/src
-            # パイプを挟むと `||` がパイプライン（tail）の終了コードを見てしまい、
-            # clone の失敗を拾えない
-            if ! git clone --depth 1 --branch "{{inputs.parameters.branch}}" \
-                 "https://x-access-token:${GITHUB_TOKEN}@github.com/{{inputs.parameters.repo}}.git" \
-                 /work/src > /tmp/clone.log 2>&1; then
-              fail "ブランチを clone できませんでした: $(tail -c 400 /tmp/clone.log)"
-            fi
-            cd /work/src
-
-            npm ci > /tmp/install.log 2>&1 || fail "npm ci に失敗: $(tail -c 800 /tmp/install.log)"
-            npm run build > /tmp/build.log 2>&1 || fail "ビルドに失敗: $(tail -c 800 /tmp/build.log)"
-
-            # DISCORD_WEBHOOK_URL と TASK_DISPATCH_URL は設定しない。
-            # どちらも未設定なら何もしない実装なので、検証実行が通知や
-            # タスク投入といった外向きの副作用を起こさない
-            export DATABASE_URL="postgres://horenso:horenso@localhost:5432/horenso"
-            export PORT=3100
-
-            for _ in $(seq 1 30); do
-              nc -z localhost 5432 2>/dev/null && break
-              sleep 2
-            done
-            nc -z localhost 5432 2>/dev/null || fail "サイドカーの PostgreSQL が起動しませんでした"
-
-            node dist/index.js > /tmp/app.log 2>&1 &
-            APP_PID=$!
-            for _ in $(seq 1 30); do
-              curl -sf -o /dev/null "http://localhost:3100/health" && break
-              sleep 2
-            done
-            curl -sf -o /dev/null "http://localhost:3100/health" \
-              || fail "アプリが起動しませんでした: $(tail -c 800 /tmp/app.log)"
-
-            # ---- 書き込みパスを通す ----
-            # 読み取りが 200 を返すことは、意図した状態変化が起きた証明にならない。
-            # 日本語の長文を往復させ、バイト単位で一致するかまで見る（#76 の型）。
-            # このイメージに python3 は無い（node / npm / jq / curl / nc のみ）。
-            # node 24 は fetch を持つのでそれで書く。
-            cat > /tmp/probe.mjs <<'JS'
-            const BASE = "http://localhost:3100";
-            const LONG = "復旧手順を確認する。StatefulSet を scale してから PVC を確認する。".repeat(200);
-
-            async function req(method, path, payload) {
-              const r = await fetch(BASE + path, {
-                method,
-                headers: { "Content-Type": "application/json" },
-                body: payload === undefined ? undefined : JSON.stringify(payload),
-              });
-              if (!r.ok) throw new Error(`${method} ${path} -> HTTP ${r.status}`);
-              return r.json();
-            }
-
-            const created = await req("POST", "/tasks", {
-              title: "検証タスク（自動）",
-              description: LONG,
-              category: "investigate",
-            });
-            const id = created.id;
-
-            await req("PATCH", `/tasks/${id}`, { status: "completed", result: LONG });
-            const got = await req("GET", `/tasks/${id}`);
-
-            const problems = [];
-            for (const field of ["description", "result"]) {
-              const back = got[field] ?? "";
-              if (back !== LONG) {
-                const broken = back.slice(-4).includes("\uFFFD");
-                problems.push(
-                  `${field}: 送信 ${LONG.length} 文字 / ${Buffer.byteLength(LONG)} バイト → ` +
-                  `保存 ${back.length} 文字 / ${Buffer.byteLength(back)} バイト` +
-                  (broken ? "（末尾に REPLACEMENT CHARACTER）" : ""));
-              }
-            }
-            if (got.status !== "completed") {
-              problems.push(`status が completed になっていない: ${got.status}`);
-            }
-
-            console.log(JSON.stringify({ task: id, problems }));
-            process.exit(problems.length ? 1 : 0);
-            JS
-            node /tmp/probe.mjs > /work/probe.txt 2>&1
-            PROBE_RC=$?
-            kill "$APP_PID" 2>/dev/null || true
-
-            if [ "$PROBE_RC" != "0" ]; then
-              fail "$(cat /work/probe.txt)"
-            fi
-
-            printf '%s' pass > /work/verdict.txt
-            { echo "## 検証通過"; echo;
-              echo "使い捨ての PostgreSQL に対してブランチのコードを起動し、書き込みパスを往復させた。";
-              echo;
-              echo '```'; cat /work/probe.txt; echo '```'; } > /work/report.md
+        command: [sh, /scripts/verify.sh]
         env:
           - {name: HOME, value: /tmp}
+          - {name: REPO, value: "{{inputs.parameters.repo}}"}
+          - {name: BRANCH, value: "{{inputs.parameters.branch}}"}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities: {drop: [ALL]}
         volumeMounts:
           - {name: work, mountPath: /work}
           - {name: github-token, mountPath: /github-token, readOnly: true}
+          - {name: scripts, mountPath: /scripts, readOnly: true}
         resources:
           requests: {cpu: 200m, memory: 512Mi}
           limits: {memory: 2Gi}

--- a/manifests/claude-code/verify-scripts.yaml
+++ b/manifests/claude-code/verify-scripts.yaml
@@ -1,0 +1,116 @@
+# horenso-verify が実行するスクリプト。
+#
+# YAML の中の文字列ではなくファイルとして持つ。埋め込みだと
+#   - `sh -n` / `node --check` を CI でかけられない
+#   - ネストしたヒアドキュメントの引用符がバグになる（実際になった）
+# スクリプト側は Argo のテンプレート置換を使わない。
+# パラメータは環境変数（REPO / BRANCH）で渡す
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: horenso-verify-scripts
+  namespace: claude-code
+data:
+  verify.sh: |
+    set -u
+    fail() {
+      printf '%s' rework > /work/verdict.txt
+      { echo "## 検証失敗"; echo; echo "$1"; } > /work/report.md
+      exit 0
+    }
+
+    export HOME=/tmp
+    GITHUB_TOKEN=$(cat /github-token/token)
+    git config --global --add safe.directory /work/src
+    # パイプを挟むと `||` がパイプライン（tail）の終了コードを見てしまい、
+    # clone の失敗を拾えない
+    if ! git clone --depth 1 --branch "${BRANCH}" \
+         "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git" \
+         /work/src > /tmp/clone.log 2>&1; then
+      fail "ブランチを clone できませんでした: $(tail -c 400 /tmp/clone.log)"
+    fi
+    cd /work/src || fail "clone したはずのディレクトリがありません"
+
+    npm ci > /tmp/install.log 2>&1 || fail "npm ci に失敗: $(tail -c 800 /tmp/install.log)"
+    npm run build > /tmp/build.log 2>&1 || fail "ビルドに失敗: $(tail -c 800 /tmp/build.log)"
+
+    # DISCORD_WEBHOOK_URL と TASK_DISPATCH_URL は設定しない。
+    # どちらも未設定なら何もしない実装なので、検証実行が通知や
+    # タスク投入といった外向きの副作用を起こさない
+    export DATABASE_URL="postgres://horenso:horenso@localhost:5432/horenso"
+    export PORT=3100
+
+    for _ in $(seq 1 30); do
+      nc -z localhost 5432 2>/dev/null && break
+      sleep 2
+    done
+    nc -z localhost 5432 2>/dev/null || fail "サイドカーの PostgreSQL が起動しませんでした"
+
+    node dist/index.js > /tmp/app.log 2>&1 &
+    APP_PID=$!
+    for _ in $(seq 1 30); do
+      curl -sf -o /dev/null "http://localhost:3100/health" && break
+      sleep 2
+    done
+    curl -sf -o /dev/null "http://localhost:3100/health" \
+      || fail "アプリが起動しませんでした: $(tail -c 800 /tmp/app.log)"
+
+    # ---- 書き込みパスを通す ----
+    # 読み取りが 200 を返すことは、意図した状態変化が起きた証明にならない。
+    # 日本語の長文を往復させ、バイト単位で一致するかまで見る（#76 の型）。
+    # このイメージに python3 は無い（node / npm / jq / curl / nc のみ）。
+    # node 24 は fetch を持つのでそれで書く。
+    node /scripts/probe.mjs > /work/probe.txt 2>&1
+    PROBE_RC=$?
+    kill "$APP_PID" 2>/dev/null || true
+
+    if [ "$PROBE_RC" != "0" ]; then
+      fail "$(cat /work/probe.txt)"
+    fi
+
+    printf '%s' pass > /work/verdict.txt
+    { echo "## 検証通過"; echo;
+      echo "使い捨ての PostgreSQL に対してブランチのコードを起動し、書き込みパスを往復させた。";
+      echo;
+      echo '```'; cat /work/probe.txt; echo '```'; } > /work/report.md
+  probe.mjs: |
+    const BASE = "http://localhost:3100";
+    const LONG = "復旧手順を確認する。StatefulSet を scale してから PVC を確認する。".repeat(200);
+
+    async function req(method, path, payload) {
+      const r = await fetch(BASE + path, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: payload === undefined ? undefined : JSON.stringify(payload),
+      });
+      if (!r.ok) throw new Error(`${method} ${path} -> HTTP ${r.status}`);
+      return r.json();
+    }
+
+    const created = await req("POST", "/tasks", {
+      title: "検証タスク（自動）",
+      description: LONG,
+      category: "investigate",
+    });
+    const id = created.id;
+
+    await req("PATCH", `/tasks/${id}`, { status: "completed", result: LONG });
+    const got = await req("GET", `/tasks/${id}`);
+
+    const problems = [];
+    for (const field of ["description", "result"]) {
+      const back = got[field] ?? "";
+      if (back !== LONG) {
+        const broken = back.slice(-4).includes("\uFFFD");
+        problems.push(
+          `${field}: 送信 ${LONG.length} 文字 / ${Buffer.byteLength(LONG)} バイト → ` +
+          `保存 ${back.length} 文字 / ${Buffer.byteLength(back)} バイト` +
+          (broken ? "（末尾に REPLACEMENT CHARACTER）" : ""));
+      }
+    }
+    if (got.status !== "completed") {
+      problems.push(`status が completed になっていない: ${got.status}`);
+    }
+
+    console.log(JSON.stringify({ task: id, problems }));
+    process.exit(problems.length ? 1 : 0);

--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -20,7 +20,8 @@ data:
   push-iso.sh: |
     #!/bin/sh
     set -euo pipefail
-    export GITHUB_TOKEN=$(cat /github-token/token)
+    GITHUB_TOKEN="$(cat /github-token/token)"
+    export GITHUB_TOKEN
     export GH_TOKEN="$GITHUB_TOKEN"
 
     wget -qO /tmp/jq "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64"
@@ -55,7 +56,8 @@ data:
   finalize-release.sh: |
     #!/bin/sh
     set -euo pipefail
-    export GH_TOKEN=$(cat /github-token/token)
+    GH_TOKEN="$(cat /github-token/token)"
+    export GH_TOKEN
     wget -qO /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v2.74.1/gh_2.74.1_linux_amd64.tar.gz"
     tar xzf /tmp/gh.tar.gz -C /tmp gh_2.74.1_linux_amd64/bin/gh --strip-components=2
     chmod +x /tmp/gh

--- a/scripts/lint-configmap-scripts.py
+++ b/scripts/lint-configmap-scripts.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""ConfigMap に入ったスクリプトの構文検査。
+
+YAML の中の文字列は、クラスタに適用されて実行されるまで誰も構文を見ない。
+horenso-verify は埋め込みのままヒアドキュメントの引用符を間違え、
+存在しないインタプリタを呼び、それぞれ実 Pod が落ちて初めて分かった。
+
+キー名の拡張子でインタプリタを選び、構文検査だけをかける（実行はしない）。
+"""
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+# 拡張子 -> 検査コマンド（ファイル名を末尾に足して実行）。
+# シェルは `sh -n` ではなく shellcheck をかける。`sh -n` は文法しか見ないので、
+# `cd dir` が失敗したまま次に進む種類の穴を通してしまう（実際に通していた）。
+# SC3040 (POSIX sh に pipefail は無い) は除外する。これらが動く alpine:3.24 の
+# busybox ash は `set -o pipefail` を受け付け、実際に効くことを実測した
+# (`false | true` が非ゼロになる)。ここでは移植性の警告が当たらない。
+CHECKERS = {
+    ".sh": ["shellcheck", "-s", "sh", "-e", "SC3040"],
+    ".bash": ["shellcheck", "-s", "bash"],
+    ".mjs": ["node", "--check"],
+    ".js": ["node", "--check"],
+    ".py": ["python3", "-m", "py_compile"],
+}
+
+ROOTS = ["manifests", "kustomize"]
+
+
+def main() -> int:
+    checked = 0
+    failed = []
+    for root in ROOTS:
+        for path in sorted(Path(root).rglob("*.y*ml")):
+            try:
+                docs = list(yaml.safe_load_all(path.read_text()))
+            except yaml.YAMLError as e:
+                print(f"::error file={path}::YAML として読めません: {e}")
+                failed.append(str(path))
+                continue
+            for doc in docs:
+                if not isinstance(doc, dict) or doc.get("kind") != "ConfigMap":
+                    continue
+                for key, body in (doc.get("data") or {}).items():
+                    cmd = CHECKERS.get(Path(key).suffix)
+                    if cmd is None or not isinstance(body, str):
+                        continue
+                    checked += 1
+                    if shutil.which(cmd[0]) is None:
+                        # 見つからないものを黙って飛ばすと、検査したつもりの
+                        # 緑になる
+                        print(f"::error file={path}::{key}: {cmd[0]} が無い")
+                        failed.append(f"{path}:{key}")
+                        continue
+                    with tempfile.TemporaryDirectory() as d:
+                        f = Path(d) / Path(key).name
+                        f.write_text(body)
+                        r = subprocess.run(
+                            [*cmd, str(f)], capture_output=True, text=True
+                        )
+                    if r.returncode != 0:
+                        # 一時ディレクトリ名は読み手の役に立たないので落とす
+                        detail = (r.stderr or r.stdout).replace(str(f), key).strip()
+                        print(f"::error file={path}::{key}: {detail}")
+                        failed.append(f"{path}:{key}")
+                    else:
+                        print(f"ok  {path}  {key}")
+
+    if failed:
+        print(f"\n{len(failed)} 件が構文検査に落ちた。")
+        return 1
+    # 0 件は「全部通った」ではなく「何も見ていない」。検査対象が消えたことに
+    # 気づけないので、黙って緑にしない
+    print(f"\n{checked} 件を検査した。")
+    if checked == 0:
+        print("::error::検査対象が 1 件も見つからない。抽出条件が壊れていないか。")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 何を

`horenso-verify` が持っていたシェルと probe を ConfigMap に出し、`/scripts` にマウントして実行する形にした。あわせて **ConfigMap に入ったスクリプトを CI で構文検査する leaf** を追加した。

## なぜ

YAML の中の文字列は、クラスタに適用されて Pod が落ちるまで誰も構文を見ない。horenso-verify が通るまでに落ちた原因のうち 2 つはこの層のもの:

- イメージに無いインタプリタ（`python3`）を呼んでいた
- ネストしたヒアドキュメントの引用が壊れていた

どちらも実 Pod の失敗としてしか観測できなかった。ファイルとして持てば `shellcheck` / `node --check` を向けられる。

スクリプト側は Argo のテンプレート置換を使わない。パラメータは env（`REPO` / `BRANCH`）で渡すので、ファイル単体で Argo 無しに検査・実行できる。

## linter が初回に見つけたもの

`sh -n` ではなく shellcheck をかけている。文法だけ見ても、これは通ってしまうため:

```sh
cd /work/src        # ← 失敗しても次に進む（set -e は無い）
npm ci ...
```

clone がディレクトリを作れていなければ `/work` のまま `npm ci` に進む。ガードを足した。

`manifests/talos-build/scripts.yaml` の 3 本も対象に入り、`export X=$(cat token)` の SC2155/SC2046 が出たので直した。

## SC3040 を除外した根拠

talos-build の 3 本は `sh` で起動され `set -euo pipefail` を書いている。alpine:3.24 の busybox ash で**実測**したところ受け付け、かつ実際に効く:

```
set-ok
pipefail-effective     # (false | true) が非ゼロ
```

移植性の警告としては正しいが、この実行環境には当たらない。

## 検証

- `shellcheck` / `node --check`: 5 件全て通過（意図的に構文を壊すと exit 1 になることも確認）
- ConfigMap ↔ 元スクリプトのラウンドトリップが**バイト一致**
- `actionlint`, `kubeconform -strict`, `argo lint --offline` 通過

**振る舞いが変わっていないことの確認はマージ後**に行う。ArgoCD sync 後に `horenso-verify` を `branch=main` で再実行し、リファクタ前と同じ `pass` が出ることを見る。リファクタ前の基準値:

```
verdict = pass
{"task":1,"problems":[]}
```