### PR TITLE
feat(claude-code): tell an API failure apart from an agent that would not decide

### DIFF
--- a/manifests/claude-code/agent-diagnose.yaml
+++ b/manifests/claude-code/agent-diagnose.yaml
@@ -1,0 +1,106 @@
+# claude の実行が「判定を出せなかった」ときに、どの層が失敗したのかを切り分ける。
+#
+# `claude -p ... || true` は終了コードも出力も捨てるので、API 認証エラーも
+# レート制限もエージェントの判断放棄も、すべて同じ indeterminate に潰れていた。
+# 人間に渡す以上、渡す相手が次に何をすべきか（再実行か、調査か）が分かる必要がある。
+#
+# 判定はしない。verdict を決めるのは呼び出し側で、ここは説明を書くだけ。
+# ただし「どちらの層か」は終了コードで返す（0 = エージェント側 / 10 = 基盤側）。
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-diagnose
+  namespace: claude-code
+data:
+  claude-diagnose.sh: |
+    # 使い方: sh claude-diagnose.sh <stream-json ログ> <終了コード> [stderr ログ]
+    # 標準出力に markdown を出す。
+    #
+    # 各フィールドの意味は claude-code イメージで実測した (2026-08-23):
+    #
+    #   正常          exit 0 / is_error=false / api_error_status=null
+    #                 subtype=success / terminal_reason=completed
+    #   max-turns     exit 1 / is_error=true  / api_error_status=null
+    #                 subtype=error_max_turns / terminal_reason=max_turns
+    #   認証失敗      exit 1 / is_error=true  / api_error_status=401
+    #                 subtype=**success**
+    #
+    # 最後の行が重要で、`subtype` は API エラーでも "success" のままになる。
+    # `subtype == "success"` を合格条件にすると 401 を成功として通す。
+    # 使えるのは is_error と api_error_status。
+    # 終了コードで層を返す:
+    #   0  = エージェント側（正常完了 / ターン上限など、判断の問題）
+    #   10 = 実行基盤側（API エラー・レート制限・途中終了）。再実行で直りうる
+    set -u
+    LOG="${1:-}"
+    RC="${2:-?}"
+    ERRLOG="${3:-}"
+
+    emit_stderr() {
+      if [ -n "$ERRLOG" ] && [ -s "$ERRLOG" ]; then
+        echo; echo "stderr の末尾:"; echo '```'
+        tail -c 600 "$ERRLOG"; echo '```'
+      fi
+    }
+
+    if [ ! -s "$LOG" ]; then
+      echo "**claude の出力が空です**（終了コード ${RC}）。プロセスが起動していない可能性があります。"
+      emit_stderr
+      exit 10
+    fi
+
+    RESULT=$(jq -c 'select(.type == "result")' "$LOG" 2>/dev/null | tail -1)
+
+    # レート制限は result の有無と関係なく出るので先に見る。
+    # status は正常時 "allowed"。それ以外を制限として扱う
+    RL=$(jq -c 'select(.type == "rate_limit_event") | .rate_limit_info' "$LOG" 2>/dev/null | tail -1)
+    if [ -n "$RL" ]; then
+      RL_STATUS=$(printf '%s' "$RL" | jq -r '.status // "?"')
+      if [ "$RL_STATUS" != "allowed" ]; then
+        RESET=$(printf '%s' "$RL" | jq -r '.resetsAt // empty')
+        echo "**レート制限に当たっています**（status: \`${RL_STATUS}\`）。"
+        [ -n "$RESET" ] && echo "解除予定: $(date -u -d "@${RESET}" 2>/dev/null || echo "epoch ${RESET}")"
+        echo; echo "エージェントの判断の問題ではないので、時間をおいて再実行すれば通る見込みです。"
+        exit 10
+      fi
+    fi
+
+    if [ -z "$RESULT" ]; then
+      echo "**claude が result イベントを出さずに終了しました**（終了コード ${RC}）。"
+      echo "会話の途中で落ちています。エージェントの判断ではなく実行基盤側の問題です。"
+      echo; echo "出たイベント:"; echo '```'
+      jq -r '.type' "$LOG" 2>/dev/null | sort | uniq -c
+      echo '```'
+      emit_stderr
+      exit 10
+    fi
+
+    IS_ERR=$(printf '%s' "$RESULT" | jq -r '.is_error // false')
+    API_STATUS=$(printf '%s' "$RESULT" | jq -r '.api_error_status // empty')
+    SUBTYPE=$(printf '%s' "$RESULT" | jq -r '.subtype // "?"')
+    TERM=$(printf '%s' "$RESULT" | jq -r '.terminal_reason // "?"')
+    TURNS=$(printf '%s' "$RESULT" | jq -r '.num_turns // "?"')
+
+    if [ -n "$API_STATUS" ] && [ "$API_STATUS" != "null" ]; then
+      echo "**API が HTTP ${API_STATUS} を返しています**。エージェントの判断ではなく実行基盤側の問題です。"
+      case "$API_STATUS" in
+        401|403) echo; echo "認証の失敗です。\`claude-code-token\` の期限切れ・失効を確認してください。" ;;
+        429)     echo; echo "レート制限です。時間をおいて再実行すれば通る見込みです。" ;;
+        5*)      echo; echo "API 側の障害の可能性があります。https://status.anthropic.com を確認してください。" ;;
+      esac
+      emit_stderr
+      exit 10
+    fi
+
+    if [ "$IS_ERR" = "true" ]; then
+      echo "**claude がエラー終了しました**（subtype: \`${SUBTYPE}\` / terminal_reason: \`${TERM}\` / ${TURNS} ターン）。"
+      case "$TERM" in
+        max_turns) echo; echo "ターン上限に達しています。タスクが大きすぎるか、同じ手順を繰り返している可能性があります。" ;;
+      esac
+      emit_stderr
+      # エージェントが走った上での失敗なので基盤側ではない
+      exit 0
+    fi
+
+    echo "claude の実行自体は正常に完了しています（${TURNS} ターン / terminal_reason: \`${TERM}\`）。"
+    echo "実行基盤ではなく、エージェントが判定を出せていません。"

--- a/manifests/claude-code/implement-wft.yaml
+++ b/manifests/claude-code/implement-wft.yaml
@@ -51,6 +51,9 @@ spec:
       emptyDir: {}
     - name: helpers
       emptyDir: {}
+    - name: diagnose
+      configMap:
+        name: agent-diagnose
     - name: prompt
       projected:
         sources:
@@ -235,7 +238,24 @@ spec:
               --allowedTools "Bash,Read,Write,Edit,Grep,Glob" \
               --model sonnet \
               --max-turns 60 \
-              "$PROMPT" || true
+              "$PROMPT" > /tmp/claude.jsonl 2>/tmp/claude.err
+            CLAUDE_RC=$?
+            # ログは捨てない。判定不能になった理由は後から追えなければ意味がない
+            cat /tmp/claude.jsonl
+            [ -s /tmp/claude.err ] && cat /tmp/claude.err >&2
+
+            # エラーのときは、まず claude 自身が動けていたのかを見る。
+            # API 認証切れもレート制限も、放っておくと「PR が見つかりません」に
+            # 化けて、エージェントが実装に失敗したかのように見える
+            if [ "$CLAUDE_RC" != "0" ]; then
+              sh /diagnose/claude-diagnose.sh /tmp/claude.jsonl "$CLAUDE_RC" /tmp/claude.err > /tmp/diag.md
+              DIAG_RC=$?
+              echo "## 実装フェーズが完走しませんでした"
+              cat /tmp/diag.md
+              # 基盤側の失敗はエージェントの判断ではない。差し戻し予算を
+              # 消費させず、ワークフローとして失敗させて人間に渡す
+              [ "$DIAG_RC" = "10" ] && exit 1
+            fi
 
             cd /workspace
             if git diff --quiet && git diff --cached --quiet; then
@@ -292,6 +312,7 @@ spec:
           - {name: github-token, mountPath: /github-token, readOnly: true}
           - {name: helpers, mountPath: /helpers, readOnly: true}
           - {name: prompt, mountPath: /prompt, readOnly: true}
+          - {name: diagnose, mountPath: /diagnose, readOnly: true}
         resources:
           requests: {cpu: 200m, memory: 1Gi}
           limits: {memory: 6Gi}
@@ -393,6 +414,13 @@ spec:
               | gh pr comment "$PR" --repo "$REPO" --body-file - || true
             exit 0
           fi
+
+          # 取り直す。ループ内の $RAW は Gate が完了した瞬間のもので、
+          # reusable workflow の leaf はまだ起動前のプレースホルダ名
+          # （`argo-lint`）で並んでいる。起動後は `argo-lint / argo lint` という
+          # 別エントリになるので、そのまま出すと落ちた job を取り違える
+          FRESH=$(gh api "repos/${REPO}/commits/${SHA}/check-runs" 2>/dev/null)
+          printf '%s' "$FRESH" | jq -e 'has("check_runs")' >/dev/null 2>&1 && RAW="$FRESH"
 
           GATE_CONCLUSION=$(printf '%s' "$RAW" | jq -r --arg g "$GATE" '[.check_runs[] | select(.name == $g)] | .[0].conclusion')
 
@@ -511,7 +539,10 @@ spec:
               --allowedTools "Bash,Read,Grep,Glob,Write" \
               --model sonnet \
               --max-turns 40 \
-              "$PROMPT" || true
+              "$PROMPT" > /tmp/claude.jsonl 2>/tmp/claude.err
+            CLAUDE_RC=$?
+            cat /tmp/claude.jsonl
+            [ -s /tmp/claude.err ] && cat /tmp/claude.err >&2
 
             # ---- 判定の回収。ここから先はエージェントの発話を一切読まない ----
             FOUND=""; COUNT=0
@@ -527,7 +558,11 @@ spec:
                 < "/work/out/$FOUND/report.md" > /work/report.md 2>/dev/null || true
             else
               VERDICT=indeterminate
-              { echo "非空のディレクトリが $COUNT 個ありました（ちょうど 1 個であるべき）。"; ls -laR /work/out; } > /work/report.md 2>&1
+              # 判定が無いときは、まずレビュアーが動けていたのかを見る。
+              # API 側の失敗とエージェントの判断放棄は、人間の次の一手が違う
+              { echo "非空のディレクトリが $COUNT 個ありました（ちょうど 1 個であるべき）。"; echo;
+                sh /diagnose/claude-diagnose.sh /tmp/claude.jsonl "$CLAUDE_RC" /tmp/claude.err;
+                echo; ls -laR /work/out; } > /work/report.md 2>&1
             fi
             [ -s /work/report.md ] || echo "レポートが空でした。" > /work/report.md
             printf '%s' "$VERDICT" > /work/verdict.txt
@@ -544,6 +579,7 @@ spec:
           - {name: github-token, mountPath: /github-token, readOnly: true}
           - {name: verdict, mountPath: /work}
           - {name: prompt, mountPath: /prompt, readOnly: true}
+          - {name: diagnose, mountPath: /diagnose, readOnly: true}
         resources:
           requests: {cpu: 200m, memory: 512Mi}
           limits: {memory: 4Gi}


### PR DESCRIPTION
## 何を

`claude -p ... || true` をやめ、**どの層が失敗したのか**を切り分けて人間に渡す。

判定に使うフィールドの意味は、推測せず claude-code イメージで実測した:

| 状況 | exit | `is_error` | `api_error_status` | `subtype` | `terminal_reason` |
|---|---|---|---|---|---|
| 正常 | 0 | false | null | `success` | `completed` |
| ターン上限 | 1 | true | null | `error_max_turns` | `max_turns` |
| 認証失敗 | 1 | true | **401** | **`success`** | — |

**最下段が重要**で、`subtype` は API 認証エラーでも `"success"` のまま。`subtype == "success"` を合格条件に書くと **401 を成功として通す**。使えるのは `is_error` と `api_error_status`。

## なぜ

今は、期限切れトークンもレート制限も「エージェントが判定を出さなかった」も、すべて同じ `indeterminate` になる。実装フェーズに至っては `ドラフト PR が見つかりません` として現れるので、**エージェントが実装に失敗したように見える**。人間の次の一手（再実行 / 調査）が全く違うのに、区別が付かない。

## どうした

`claude-diagnose.sh` を ConfigMap から `/diagnose` にマウントして呼ぶ。層を終了コードで返す:

- `0` — エージェント側（正常完了、ターン上限など判断の問題）
- `10` — 実行基盤側（API エラー・レート制限・途中終了・出力空）

実装ステップは層 10 なら**ワークフローとして失敗させる**。差し戻し予算を消費させず、誤解を招く escalate にもしない。レビューステップは判定を回収できなかったときに診断をレポートへ添える。

## ついでに直したもの

CI レポートをループ内で捕まえた `$RAW` から組んでいた。Gate 完了時点では reusable workflow の leaf がまだプレースホルダ名（`argo-lint`）で並んでおり、起動後の名前（`argo-lint / argo lint`）とは別エントリになる。そのまま出すと**落ちた job を取り違える**。完了後に取り直すようにした。

これは今日このリポジトリの PR #637 を待っているときに自分で踏んで、`kubeconform` と `argo-lint` が skip されたと誤読した現象そのもの。

## 検証

- 診断スクリプトを実測形の 6 パターン（正常 / ターン上限 / 401 / result 無し / レート制限 / 空）に対して実行し、文面と終了コードを確認
- `shellcheck`（#637 で入れた ConfigMap スクリプト検査に自動で乗る）、`argo lint`、インライン `sh -n` 通過

## 残っている穴

`implement-wft.yaml` の**インラインスクリプトは新しい linter の対象外**（ConfigMap のキーだけを見るため）。今回は `sh -n` を手で回している。これらも ConfigMap に出せば自動で検査に乗る。