### PR TITLE
trivy-operator: run a built-in trivy server (ClientServer mode)

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -256,12 +256,13 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | **oauth2-proxy-seaweedfs** | ingress → 4180 (L7 HTTP) | seaweedfs-filer (seaweedfs):8888, kanidm (kanidm):8443 |
 | **oauth2-proxy-rss** | ingress, cloudflared (argocd) → 4180 (L7 HTTP) | rss-ui (rss):80, rss-server (rss):80, kanidm (kanidm):8443 |
 
-## trivy-system (3 policies)
+## trivy-system (4 policies)
 
 | Component | Ingress | Egress |
 |---|---|---|
 | **trivy-operator** | prometheus (monitoring) → 8080; host → 9090 (probes) | kube-apiserver, mirror.gcr.io + registry-1.docker.io + auth.docker.io + production.cloudflare.docker.com + ghcr.io + registry.k8s.io + *.pkg.dev + quay.io + *.quay.io + public.ecr.aws :443 |
-| **scan-jobs** (managed-by: trivy-operator) | deny world | 0.0.0.0/0:443 — registry CDN backends (S3, R2, CloudFront, etc.) are too numerous and dynamic for toFQDNs. Ephemeral pods, HTTPS only; harbor-nginx (harbor):8443 |
+| **scan-jobs** (managed-by: trivy-operator) | deny world | 0.0.0.0/0:443 — registry CDN backends (S3, R2, CloudFront, etc.) are too numerous and dynamic for toFQDNs. Ephemeral pods, HTTPS only; harbor-nginx (harbor):8443; trivy-server:4954 |
+| **trivy-server** | scan-jobs → 4954; host → 4954 (probes) | mirror.gcr.io:443 (vuln DB) |
 | **node-collector** (app: node-collector) | deny world | kube-apiserver |
 
 ## nfs-provisioner (1 policy)

--- a/helm-values/trivy-operator/values.yaml
+++ b/helm-values/trivy-operator/values.yaml
@@ -24,6 +24,12 @@ operator:
   #       | grep OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
   #   OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "10"   ← 3 が届いていなかった
   scanJobsConcurrentLimit: 3
+  # 脆弱性 DB を持つ trivy server を常駐させ、scan job は client として問い合わせる。
+  # Standalone では job ごとに DB (+ Java DB) をダウンロードして捨てていたので、
+  # job が増えるほど wn-03 の NVMe 書き込みとレジストリ往復が比例して増えていた。
+  # trivy.mode / trivy.serverURL はこのフラグが上書きする（values に書いても無視）。
+  # trivy.clientServerSkipUpdate もこの分岐では出力されない (0.35.0 の templates/configmaps/trivy.yaml)
+  builtInTrivyServer: true
 
 resources:
   requests:
@@ -35,6 +41,30 @@ resources:
 
 trivy:
   ignoreUnfixed: true
+  # server の DB キャッシュは再起動時に落とせばよいので emptyDir。
+  # PVC にすると既定の qnap-nfs に bbolt (trivy-db) を置くことになる
+  storageClassEnabled: false
+  server:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: null
+        memory: 1Gi
+    podSecurityContext:
+      runAsUser: 65534
+      runAsNonRoot: true
+      fsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
   configFile:
     cache:
       backend: memory

--- a/manifests/trivy-system/netpol-trivy-scan-jobs.yaml
+++ b/manifests/trivy-system/netpol-trivy-scan-jobs.yaml
@@ -11,6 +11,13 @@ spec:
     - fromEntities:
         - world
   egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: trivy-server
+      toPorts:
+        - ports:
+            - port: "4954"
+              protocol: TCP
     - toCIDR:
         - 0.0.0.0/0
       toPorts:

--- a/manifests/trivy-system/netpol-trivy-server.yaml
+++ b/manifests/trivy-system/netpol-trivy-server.yaml
@@ -1,0 +1,30 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: trivy-server
+  namespace: trivy-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: trivy-server
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/managed-by: trivy-operator
+      toPorts:
+        - ports:
+            - port: "4954"
+              protocol: TCP
+    - fromEntities:
+        - host
+      toPorts:
+        - ports:
+            - port: "4954"
+              protocol: TCP
+  egress:
+    - toFQDNs:
+        - matchName: "mirror.gcr.io"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP


### PR DESCRIPTION
scan job ごとに脆弱性 DB（+ Java DB）を /tmp に落として捨てていたのを、常駐 trivy server に問い合わせる ClientServer モードへ。job 数が増えても NVMe 書き込みが比例しなくなる。

- `operator.builtInTrivyServer: true`（mode / serverURL はチャートが上書き。`clientServerSkipUpdate` はこの分岐では出力されないので書いていない — unread-values で検出）
- DB キャッシュは emptyDir（PVC だと bbolt を qnap-nfs に置くことになる）
- server の securityContext を restricted 準拠に、CPU limit なし
- CNP: trivy-server ← scan-jobs / host:4954、→ mirror.gcr.io:443。scan-jobs → trivy-server:4954

レンダリング: unread-values 31 ファイル UNREAD なし、kubeconform 24/24 valid。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXzfkPgC7AVyiBFjTbdQvt