### PR TITLE
trivy-system: let trivy-operator reach trivy-server

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -260,9 +260,9 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **trivy-operator** | prometheus (monitoring) → 8080; host → 9090 (probes) | kube-apiserver, mirror.gcr.io + registry-1.docker.io + auth.docker.io + production.cloudflare.docker.com + ghcr.io + registry.k8s.io + *.pkg.dev + quay.io + *.quay.io + public.ecr.aws :443 |
+| **trivy-operator** | prometheus (monitoring) → 8080; host → 9090 (probes) | trivy-server:4954 (readiness check before creating scan jobs), kube-apiserver, mirror.gcr.io + registry-1.docker.io + auth.docker.io + production.cloudflare.docker.com + ghcr.io + registry.k8s.io + *.pkg.dev + quay.io + *.quay.io + public.ecr.aws :443 |
 | **scan-jobs** (managed-by: trivy-operator) | deny world | 0.0.0.0/0:443 — registry CDN backends (S3, R2, CloudFront, etc.) are too numerous and dynamic for toFQDNs. Ephemeral pods, HTTPS only; harbor-nginx (harbor):8443; trivy-server:4954 |
-| **trivy-server** | scan-jobs → 4954; host → 4954 (probes) | mirror.gcr.io:443 (vuln DB) |
+| **trivy-server** | scan-jobs, trivy-operator → 4954; host → 4954 (probes) | mirror.gcr.io:443 (vuln DB) |
 | **node-collector** (app: node-collector) | deny world | kube-apiserver |
 
 ## nfs-provisioner (1 policy)

--- a/manifests/trivy-system/netpol-trivy-operator.yaml
+++ b/manifests/trivy-system/netpol-trivy-operator.yaml
@@ -23,6 +23,13 @@ spec:
             - port: "9090"
               protocol: TCP
   egress:
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: trivy-server
+      toPorts:
+        - ports:
+            - port: "4954"
+              protocol: TCP
     - toEntities:
         - kube-apiserver
       toPorts:

--- a/manifests/trivy-system/netpol-trivy-server.yaml
+++ b/manifests/trivy-system/netpol-trivy-server.yaml
@@ -11,6 +11,8 @@ spec:
     - fromEndpoints:
         - matchLabels:
             app.kubernetes.io/managed-by: trivy-operator
+        - matchLabels:
+            app.kubernetes.io/name: trivy-operator
       toPorts:
         - ports:
             - port: "4954"


### PR DESCRIPTION
#642 の追従。operator は scan Job を作る前に trivy-server:4954 へ疎通確認するが、CNP で落ちて Job が作られなかった（hubble で Policy denied を確認）。operator → server の egress と server 側 ingress を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXzfkPgC7AVyiBFjTbdQvt