### PR TITLE
Wire taskflow into the aqua-checksum sensor

### DIFF
--- a/manifests/argo/aqua-checksum-sensor.yaml
+++ b/manifests/argo/aqua-checksum-sensor.yaml
@@ -12,7 +12,7 @@ metadata:
 # trigger could not read the repository and branch out of whichever event
 # actually arrived.
 #
-# All seven repositories that have an aqua.yaml.
+# All eight repositories that have an aqua.yaml.
 spec:
   template:
     serviceAccountName: workflow-executor
@@ -86,6 +86,11 @@ spec:
     - name: home-trading
       eventSourceName: github-webhook
       eventName: home-trading
+      filters:
+        script: *aquaFilter
+    - name: taskflow
+      eventSourceName: github-webhook
+      eventName: taskflow
       filters:
         script: *aquaFilter
   triggers:
@@ -281,6 +286,36 @@ spec:
               dest: spec.arguments.parameters.0.value
             - src:
                 dependencyName: home-trading
+                dataKey: body.pull_request.head.ref
+              dest: spec.arguments.parameters.1.value
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: aqua-checksum-
+                namespace: argo
+              spec:
+                workflowTemplateRef:
+                  name: aqua-checksum
+                arguments:
+                  parameters:
+                    - name: repository
+                      value: overwritten-by-parameters
+                    - name: branch
+                      value: overwritten-by-parameters
+    - template:
+        name: aqua-checksum-taskflow
+        conditions: "taskflow"
+        argoWorkflow:
+          operation: submit
+          parameters:
+            - src:
+                dependencyName: taskflow
+                dataKey: body.repository.full_name
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: taskflow
                 dataKey: body.pull_request.head.ref
               dest: spec.arguments.parameters.1.value
           source:

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -163,6 +163,20 @@ spec:
         key: credential
       active: false
       contentType: json
+    taskflow:
+      owner: Tsuguya
+      repository: taskflow
+      webhook:
+        endpoint: /taskflow
+        port: "12000"
+        method: POST
+      events:
+        - pull_request
+      webhookSecret:
+        name: taskflow-github-webhook
+        key: credential
+      active: false
+      contentType: json
     renovate-home-cluster:
       owner: Tsuguya
       repository: home-cluster

--- a/manifests/secrets/argo-taskflow-github-webhook.yaml
+++ b/manifests/secrets/argo-taskflow-github-webhook.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: taskflow-github-webhook
+  namespace: argo
+# Same shape as home-actions-github-webhook: a Password item mapped field by
+# field so the Secret key stays `credential` for the EventSource.
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: taskflow-github-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: credential
+      remoteRef:
+        key: taskflow-github-webhook
+        property: password


### PR DESCRIPTION
taskflow は aqua.yaml と lint-aqua を持つのに、github-webhook EventSource / aqua-checksum Sensor に登録されていなかった。そのため Renovate の aqua-registry 更新（taskflow #44）が `aqua-checksums.json` を書き直す役なしで赤のまま止まっていた（home-actions では bot が checksum をコミットして通っている）。

home-actions と同じ形で配線: EventSource に pull_request の webhook エントリ、その ExternalSecret（1Password `taskflow-github-webhook`、op に生成させた Password item）、Sensor に依存 + トリガ。GitHub 側の webhook（`argo-hook.tgy.io/taskflow`）は登録済み。

`/lint` 通過（CNP 変更なし: 既存 sensor / eventsource へのエントリ追加のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9