### PR TITLE
monitoring: apiserver proxy arrives as remote-node in tunnel mode

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -146,7 +146,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **prometheus** | grafana, tempo, claude-code (claude-code), kube-apiserver (service proxy, RBAC services/proxy で制御) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
+| **prometheus** | grafana, tempo, claude-code (claude-code), kube-apiserver/remote-node (service proxy, RBAC services/proxy で制御) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
 | **alertmanager** | prometheus → 9093/8080 | discord.com:443, discordapp.com:443, alertmanager-eventsource (argo):12001 |
 | **grafana** | ingress → 3000 (L7 HTTP); prometheus → 3000 | kube-apiserver, prometheus:9090, loki-gateway:8080, tempo:3200, shared-pg (database):5432, kanidm (kanidm):8443 |
 | **kube-state-metrics** | prometheus → 8080 | kube-apiserver |

--- a/manifests/monitoring/netpol-prometheus.yaml
+++ b/manifests/monitoring/netpol-prometheus.yaml
@@ -21,9 +21,12 @@ spec:
             - port: "9090"
               protocol: TCP
     # kube-apiserver service proxy (Freelens/Lens cluster metrics).
+    # In tunnel mode the apiserver's traffic is SNATed to cilium_host and
+    # arrives as remote-node (same as prometheus-operator webhook).
     # Reachability is gated by RBAC services/proxy in monitoring.
     - fromEntities:
         - kube-apiserver
+        - remote-node
       toPorts:
         - ports:
             - port: "9090"


### PR DESCRIPTION
Follow-up to #664. hubble showed the apiserver proxy SYN arriving from the CP node's cilium_host IP with identity `remote-node`, not `kube-apiserver` (tunnel-mode SNAT). Same pattern already used for the prometheus-operator webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5UV8pRJhDiEWSWTsfLpNb