### PR TITLE
claude-code: add Prometheus endpoint to investigation prompts

### DIFF
--- a/manifests/claude-code/adjudicator-wft.yaml
+++ b/manifests/claude-code/adjudicator-wft.yaml
@@ -78,6 +78,7 @@ spec:
             - kubectl で関連リソースの状態を確認
             - 必要に応じて Hubble で通信状況を確認
             - 必要に応じて Loki でログを確認（logcli, endpoint: http://loki-gateway.monitoring:80）
+            - 必要に応じて Prometheus でメトリクスを確認（curl http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/query）
 
             ## クラスタ情報
             - CNI: Cilium（全 Pod にデフォルト deny の CiliumNetworkPolicy 適用）

--- a/manifests/claude-code/alert-investigate-wft.yaml
+++ b/manifests/claude-code/alert-investigate-wft.yaml
@@ -61,6 +61,7 @@ spec:
             - kubectl（読み取り専用）
             - hubble observe（kubectl exec -n kube-system <cilium-pod> -- hubble observe）
             - logcli（Loki: http://loki-gateway.monitoring:80）
+            - Prometheus（curl http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/query）
             - helm
 
             クラスタ情報:


### PR DESCRIPTION
The investigation prompts name the Loki endpoint but not Prometheus, even though the claude-code CNP already allows prometheus:9090 and the pods query it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5UV8pRJhDiEWSWTsfLpNb