### PR TITLE
image-build: build taskflow's controller and sidecar images

### DIFF
--- a/manifests/argo/single-repo-build-sensor.yaml
+++ b/manifests/argo/single-repo-build-sensor.yaml
@@ -78,6 +78,29 @@ spec:
             end
           end
           return false
+    - name: taskflow-push
+      eventSourceName: github-webhook
+      eventName: taskflow
+      filters:
+        # Go なので共通フィルタは当たらない。Dockerfile* と Go ソース・モジュール
+        # ファイルだけを見る（docs/ や config/ の変更でビルドしない）。
+        script: |-
+          if event.body == nil or event.body.ref ~= "refs/heads/main" or event.body.commits == nil then
+            return false
+          end
+          for _, c in ipairs(event.body.commits) do
+            for _, list in ipairs({c.added or {}, c.modified or {}, c.removed or {}}) do
+              for _, f in ipairs(list) do
+                if string.find(f, "Dockerfile", 1, true)
+                  or string.sub(f, -3) == ".go"
+                  or f == "go.mod"
+                  or f == "go.sum" then
+                  return true
+                end
+              end
+            end
+          end
+          return false
   triggers:
     - template:
         name: memory-build
@@ -174,5 +197,71 @@ spec:
           parameters:
             - src:
                 dependencyName: home-trading-push
+                dataKey: body.after
+              dest: spec.arguments.parameters.2.value
+    # taskflow は 1 リポジトリから 2 イメージ（controller と Pod 内 sidecar）。
+    # 同じ push で 2 本の Workflow を投げ、Dockerfile だけ切り替える。
+    - template:
+        name: taskflow-build
+        conditions: "taskflow-push"
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: taskflow-build-
+                namespace: image-build
+              spec:
+                workflowTemplateRef:
+                  name: single-repo-image-build
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: github.com/Tsuguya/taskflow
+                    - name: image-name
+                      value: taskflow
+                    - name: commit-sha
+                      value: ""
+                    # commit-sha は位置参照 (parameters.2.value) されているので末尾に足す
+                    - name: project
+                      value: tools
+          parameters:
+            - src:
+                dependencyName: taskflow-push
+                dataKey: body.after
+              dest: spec.arguments.parameters.2.value
+    - template:
+        name: taskflow-sidecar-build
+        conditions: "taskflow-push"
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: taskflow-sidecar-build-
+                namespace: image-build
+              spec:
+                workflowTemplateRef:
+                  name: single-repo-image-build
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: github.com/Tsuguya/taskflow
+                    - name: image-name
+                      value: agent-sidecar
+                    - name: commit-sha
+                      value: ""
+                    # commit-sha は位置参照 (parameters.2.value) されているので末尾に足す
+                    - name: project
+                      value: tools
+                    - name: dockerfile
+                      value: Dockerfile.sidecar
+          parameters:
+            - src:
+                dependencyName: taskflow-push
                 dataKey: body.after
               dest: spec.arguments.parameters.2.value

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -171,6 +171,7 @@ spec:
         port: "12000"
         method: POST
       events:
+        - push
         - pull_request
       webhookSecret:
         name: taskflow-github-webhook

--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -21,6 +21,11 @@ spec:
         value: ""
       - name: commit-sha
         value: main
+      # リポジトリルートからの Dockerfile 名。1 リポジトリから複数イメージを出す
+      # とき（taskflow の controller と sidecar）に、context は共通のまま
+      # ファイルだけ切り替える。既定はこれまでどおりルートの Dockerfile。
+      - name: dockerfile
+        value: Dockerfile
   podMetadata:
     labels:
       image-build: "true"
@@ -189,6 +194,7 @@ spec:
               --frontend dockerfile.v0 \
               --local context=/workspace \
               --local dockerfile=/workspace \
+              --opt filename={{workflow.parameters.dockerfile}} \
               --output 'type=image,"name=registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}:{{workflow.parameters.commit-sha}},registry.infra.tgy.io/{{workflow.parameters.project}}/{{workflow.parameters.image-name}}:latest",push=true' \
               --metadata-file /workspace/metadata.json
             jq -r '."containerimage.digest"' /workspace/metadata.json > /workspace/digest


### PR DESCRIPTION
taskflow は 1 リポジトリから 2 イメージ（controller = `Dockerfile`、Pod 内 sidecar = `Dockerfile.sidecar`）を出す最初のリポ。`single-repo-image-build` はルートの Dockerfile 決め打ちだったので `dockerfile` パラメータ（既定 `Dockerfile`、既存 3 リポは無変更）を足して buildctl の `--opt filename` に渡す。

- Sensor: `taskflow-push`（Go 向けフィルタ: Dockerfile*, *.go, go.mod, go.sum）+ 同じ push で 2 本のトリガ（`taskflow` / `agent-sidecar`、どちらも `tools` プロジェクト）
- EventSource: taskflow に `push` を追加。GitHub 側の hook は `active: false` で手動管理なので、マージ後に `gh api` で events に push を足す

push 先は `registry.infra.tgy.io/tools/{taskflow,agent-sidecar}`。robot$tools は project 単位の push 権限なので Harbor 側の変更は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9