### PR TITLE
image-build: steer BuildKit away from nodes running an LLM batch

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -58,6 +58,22 @@ spec:
 
     - name: buildkit-build
       podSpecPatch: '{"runtimeClassName": "kata"}'
+      # BuildKit は Kata VM 内で virtiofs を thread-pool-size=1 で回すので、ホスト CPU が
+      # 飽和すると 1 レイヤのコミットに数分かかり 30 分の期限に届かない（2026-08-25、
+      # wn-03 で LLM バッチと同居して実測）。LLM バッチ Pod が名乗る
+      # workload-class=cpu-saturating から逃げる。preferred なので LLM が走っていなければ
+      # 一番速い wn-03 を使える。requests だけでは同居を避けられない（16 スレッドに
+      # 両方収まる）ので、スケジューラにはこの形で伝える。
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    workload-class: cpu-saturating
+                namespaceSelector: {}
+                topologyKey: kubernetes.io/hostname
       metadata:
         annotations:
           io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["--thread-pool-size=1", "--announce-submounts", "--xattr"]'

--- a/manifests/image-build/workflowtemplate.yaml
+++ b/manifests/image-build/workflowtemplate.yaml
@@ -159,6 +159,22 @@ spec:
         parameters:
           - name: image-dir
       podSpecPatch: '{"runtimeClassName": "kata"}'
+      # BuildKit は Kata VM 内で virtiofs を thread-pool-size=1 で回すので、ホスト CPU が
+      # 飽和すると 1 レイヤのコミットに数分かかり 30 分の期限に届かない（2026-08-25、
+      # wn-03 で LLM バッチと同居して実測）。LLM バッチ Pod が名乗る
+      # workload-class=cpu-saturating から逃げる。preferred なので LLM が走っていなければ
+      # 一番速い wn-03 を使える。requests だけでは同居を避けられない（16 スレッドに
+      # 両方収まる）ので、スケジューラにはこの形で伝える。
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    workload-class: cpu-saturating
+                namespaceSelector: {}
+                topologyKey: kubernetes.io/hostname
       metadata:
         annotations:
           io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["--thread-pool-size=1", "--announce-submounts", "--xattr"]'


### PR DESCRIPTION
2026-08-25 実測: taskflow のビルド 2 本が wn-03 で home-trading の `model-screening`（8 コア）と同居し、golang pull 937 秒・`COPY go.mod` 260 秒で 30 分期限切れ。BuildKit は Kata VM 内の virtiofs（`--thread-pool-size=1`）なので、ホスト CPU が飽和すると 1 レイヤのコミットが数分待つ。

- requests だけでは同居は避けられない（wn-03 は 16 スレッド、LLM 7 + build 4 は収まる）
- taint は LLM 不在時も wn-03 を専用化してしまう
- → build ステップに preferred な `podAntiAffinity`。LLM バッチ Pod のラベル `workload-class: cpu-saturating`（trading 側と合意、次回バッチから付く）から逃げる。LLM 不在なら最速の wn-03 をそのまま使える

両テンプレート（images 用 / single-repo 用）に同じものを入れた。LLM 側は別途 `requests.cpu: "7"` を付ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9