### PR TITLE
image-build: size the Kata VM by giving BuildKit a CPU limit

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -235,9 +235,15 @@ spec:
             readOnly: true
         resources:
           requests:
-            cpu: 100m
+            cpu: "2"
             memory: 512Mi
+          # CPU limit はこのリポジトリでは付けない規約だが、Kata は VM の vCPU 数を
+          # コンテナの CPU limit（cgroup quota）から決める。limit が無いと VM は
+          # default_vcpus=1 のまま — golang:1.27 の展開に 750 秒、COPY 1 回に 250 秒、
+          # go build -a は 30 分に収まらない（2026-08-25 実測。ホストの CPU は半分空いていた）。
+          # ここでの limit は throttling ではなく VM の大きさの指定。
           limits:
+            cpu: "6"
             memory: 4Gi
       outputs:
         parameters:

--- a/manifests/image-build/workflowtemplate.yaml
+++ b/manifests/image-build/workflowtemplate.yaml
@@ -327,9 +327,15 @@ spec:
             readOnly: true
         resources:
           requests:
-            cpu: 100m
+            cpu: "2"
             memory: 512Mi
+          # CPU limit はこのリポジトリでは付けない規約だが、Kata は VM の vCPU 数を
+          # コンテナの CPU limit（cgroup quota）から決める。limit が無いと VM は
+          # default_vcpus=1 のまま — golang:1.27 の展開に 750 秒、COPY 1 回に 250 秒、
+          # go build -a は 30 分に収まらない（2026-08-25 実測。ホストの CPU は半分空いていた）。
+          # ここでの limit は throttling ではなく VM の大きさの指定。
           limits:
+            cpu: "6"
             memory: 4Gi
       outputs:
         parameters:


### PR DESCRIPTION
実測で原因確定: Kata は VM の vCPU 数をコンテナの **CPU limit**（cgroup quota）から決める。build コンテナは `requests.cpu: 100m`・limit なしだったので、VM は `default_vcpus=1` のまま（ノード設定 `/usr/local/share/kata-containers/configuration.toml` で確認）。ホスト CPU が半分空いていても golang:1.27 の展開に 750 秒、`COPY` 1 回に 200 秒、`go build -a` に到達せず 30 分期限切れ。alpine ベースの小さいイメージでは収まっていたので今まで顕在化しなかった。単発ビルドと並列ビルドでステップ時間がほぼ同じ（203s vs 251s）ことから、#668 で疑った LLM 同居は主因ではない。

- `limits.cpu: "6"`: このリポの「CPU limit を付けない」規約（CFS throttling 回避）の意図的な例外。Kata では limit が VM の大きさ。ホストのコア数で頭打ちになるので N100（4 コア）でも問題ない
- `requests.cpu: "2"`: スケジューラにビルドを 100m の Pod として扱わせない

両テンプレート（images 用 / single-repo 用）に適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9