### PR TITLE
image-build: try a wider virtiofsd thread pool and writeback for BuildKit

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -76,7 +76,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       metadata:
         annotations:
-          io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["--thread-pool-size=1", "--announce-submounts", "--xattr"]'
+          io.katacontainers.config.hypervisor.virtio_fs_extra_args: '["--thread-pool-size=16", "--announce-submounts", "--xattr", "--writeback"]'
       securityContext:
         runAsUser: 0
         runAsNonRoot: false


### PR DESCRIPTION
#669 の vCPU 修正は効かなかった: 6 vCPU・ホスト空きでも golang:1.27 の pull に 1012 秒、レイヤ展開 1 枚 280 秒。ボトルネックは CPU ではなく **virtiofs 越しの小ファイル I/O**（BuildKit の state dir が emptyDir = virtiofs、`virtio_fs_cache_size=0`、virtiofsd 1 スレッド）。

ノードの Kata 設定が Pod に許す annotation は `virtio_fs_extra_args` / `kernel_params` / `enable_iommu` のみ。なので virtiofsd 引数だけ変える実験: `--thread-pool-size=16` + `--writeback`。single-repo テンプレートに限定（images 用は据え置き）。

効かなければ Kata + virtiofs は大レイヤの展開に構造的に向かないと判断し、taskflow のイメージは GHA → GHCR（元々の到達点）へ前倒しする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9