### PR TITLE
image-build: keep buildkitd's state on the workspace volume

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -234,6 +234,14 @@ spec:
         env:
           - name: DOCKER_CONFIG
             value: /docker-config
+          # buildctl-daemonless.sh は --root を渡さないので、buildkitd の state
+          # （レイヤ展開の実体）は既定の /var/lib/buildkit = コンテナ rootfs に置かれる。
+          # Kata ではコンテナ rootfs 自体がホストから virtiofs で共有されているため、
+          # workspace volume を何にしても展開は virtiofs 越しのままだった（2026-08-25
+          # 実測: emptyDir でもブロック PVC でも golang:1.27 の展開に 700〜1000 秒）。
+          # state を workspace 側へ置いて初めて、上のブロック PVC が効く。
+          - name: BUILDKITD_FLAGS
+            value: --root /workspace/.buildkit/root
         securityContext:
           privileged: true
           allowPrivilegeEscalation: true


### PR DESCRIPTION
#671（ブロック PVC）が効かなかった理由: `buildctl-daemonless.sh` は `--root` を渡さないので buildkitd の state（レイヤ展開の実体）は既定の `/var/lib/buildkit` = **コンテナ rootfs** に置かれる。Kata ではコンテナ rootfs 自体がホストから virtiofs で共有されているため、workspace volume を emptyDir にしようがブロック PVC にしようが展開は virtiofs 越しのままだった（golang:1.27 展開 884 秒で不変）。`TMPDIR` もスクリプト内で `/tmp` 固定で無視されている。

`BUILDKITD_FLAGS="--root /workspace/.buildkit/root"`（スクリプトが buildkitd に渡す唯一のフック）で state を PVC 側へ。これで初めて #671 のブロック PVC が効く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9