### PR TITLE
image-build: try a memory-backed emptyDir for BuildKit's workspace

### DIFF
--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -87,15 +87,14 @@ spec:
         # virtio-blk で VM に直接挿し、ファイルシステムは VM の中に居るので往復が消える。
         # generic ephemeral volume なので Pod と一緒に消える（reclaim は Delete）。
         # qnap-iscsi は worker にしか挿せないが、Kata Pod は元々 worker にしか載らない。
+        # medium: Memory の emptyDir は Kata が VM の中に tmpfs として作るので virtiofs を
+        # 通らない。ゲストカーネル 6.18 の tmpfs は user xattr を持つ（6.6 以降）ので
+        # BuildKit のレイヤ export も通る。VM のメモリはコンテナの memory limit で決まる
+        # ため、下の limits.memory にこの分を上乗せしてある。
         - name: workspace
-          ephemeral:
-            volumeClaimTemplate:
-              spec:
-                accessModes: [ReadWriteOnce]
-                storageClassName: qnap-iscsi
-                resources:
-                  requests:
-                    storage: 20Gi
+          emptyDir:
+            medium: Memory
+            sizeLimit: 6Gi
         - name: docker-config
           emptyDir: {}
         - name: github-token
@@ -264,7 +263,7 @@ spec:
           # ここでの limit は throttling ではなく VM の大きさの指定。
           limits:
             cpu: "6"
-            memory: 4Gi
+            memory: 10Gi
       outputs:
         parameters:
           - name: digest


### PR DESCRIPTION
E3（#672、iSCSI ブロック PVC + buildkitd --root）との比較用。**draft、E3 の計測が出るまでマージしない。**

`emptyDir: {medium: Memory}` は Kata が **VM の中の tmpfs** として作るので virtiofs を通らない。ゲストカーネル 6.18 の tmpfs は user xattr を持つ（6.6 以降）ので、当初 tmpfs を避けた理由（xattr 非対応）は今は当たらないはず。sizeLimit 6Gi、Kata では memory limit が VM メモリなので limits.memory を 10Gi に。

QNAP 依存が無く attach も要らないので、速度が同等以上なら iSCSI よりこちら。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9