### PR TITLE
taskflow: deploy the controller from the taskflow repo's config/default

### DIFF
--- a/apps/taskflow.yaml
+++ b/apps/taskflow.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: taskflow
+  namespace: argocd
+spec:
+  project: ai
+  sources:
+    - repoURL: https://github.com/Tsuguya/home-cluster.git
+      targetRevision: main
+      path: kustomize/taskflow
+    - repoURL: https://github.com/Tsuguya/home-cluster.git
+      targetRevision: main
+      path: manifests/taskflow-system
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: taskflow-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      # taskhandlers CRD は 642KB で client-side apply の 256KB 上限を超える（設計 §15）
+      - ServerSideApply=true

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# taskflow のコントローラ本体は Tsuguya/taskflow リポの config/default（CRD・RBAC・
+# Deployment）をそのまま remote base として取り込む。home-cluster 側が持つのは
+# イメージの差し替えとクラスタ固有の patch だけ（設計 §14: 「どう動くか」は taskflow、
+# 「何ができるか」は home-cluster）。ref は commit SHA で固定し Renovate が追う。
+resources:
+  - https://github.com/Tsuguya/taskflow//config/default?ref=f96dbf9be674dcfaf803900541f4bbb0c3eea8bf
+
+images:
+  - name: controller
+    newName: registry.infra.tgy.io/tools/taskflow
+    newTag: latest
+    digest: sha256:9a2db9aa91dbad69ae4090be6bd7e6126d8de73690c38c1bf7a7caac929168db
+
+patches:
+  # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
+  - target:
+      kind: Namespace
+      name: taskflow-system
+    patch: |-
+      - op: add
+        path: /metadata/labels
+        value:
+          pod-security.kubernetes.io/enforce: restricted
+  # CPU limit は付けない（CFS throttling 回避、このリポの規約）。memory は scaffold の
+  # 128Mi のままで、CRD 3 つを watch するだけのコントローラには足りる。
+  - target:
+      kind: Deployment
+      name: taskflow-controller-manager
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 50m

--- a/manifests/argocd/appproject-ai.yaml
+++ b/manifests/argocd/appproject-ai.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ai
   namespace: argocd
 spec:
-  description: AI/ML infrastructure (Qdrant, Ollama)
+  description: AI/ML infrastructure (Qdrant, Ollama, taskflow)
   sourceRepos:
     - https://qdrant.github.io/qdrant-helm
     - https://helm.otwld.com/
@@ -14,6 +14,8 @@ spec:
       namespace: qdrant
     - server: https://kubernetes.default.svc
       namespace: ollama
+    - server: https://kubernetes.default.svc
+      namespace: taskflow-system
   clusterResourceWhitelist:
     - group: '*'
       kind: CustomResourceDefinition

--- a/manifests/taskflow-system/netpol.yaml
+++ b/manifests/taskflow-system/netpol.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: taskflow-controller
+  namespace: taskflow-system
+spec:
+  endpointSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: taskflow
+  ingress:
+    # kubelet の liveness / readiness probe（:8081）
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8081"
+              protocol: TCP
+  egress:
+    # コントローラが話す相手は apiserver だけ。Job を作り、Pod の status を読むのみで、
+    # ワークスペースにも store にも触らない（設計 §6「2 ホップ」）。DNS は CCNP で共通適用済み。
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP


### PR DESCRIPTION
taskflow controller の初デプロイ。

- `kustomize/taskflow/`: Tsuguya/taskflow の `config/default`（CRD・RBAC・Deployment）を **remote base**（commit SHA 固定）で取り込み、`images:` で Harbor の署名済みビルド（digest ピン）へ差し替え。home-cluster 側の patch は restricted PSA ラベルと CPU limit 除去だけ（設計 §14 の分担）
- `manifests/taskflow-system/netpol.yaml`: egress は kube-apiserver:6443 のみ、ingress は probe 用に host/remote-node → 8081
- `apps/taskflow.yaml`: project `ai`、multi-source、`ServerSideApply=true`（taskhandlers CRD 642KB）
- AppProject `ai` に `taskflow-system` を追加

ローカルで `kubectl kustomize` レンダリング（23 リソース）+ kubeconform 通過。handler / TaskFlow / Task はこの後、claude-code namespace 側で別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9