### PR TITLE
Allow the trading reporter pod to reach shared-pg

### DIFF
--- a/manifests/database/netpol-shared-pg.yaml
+++ b/manifests/database/netpol-shared-pg.yaml
@@ -13,6 +13,10 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: trading
             trading: collector
+        # 週次の報告ジョブ。台帳（trading.category_counts）を読むだけ。
+        - matchLabels:
+            io.kubernetes.pod.namespace: trading
+            trading: reporter
         - matchLabels:
             app.kubernetes.io/name: grafana
             io.kubernetes.pod.namespace: monitoring


### PR DESCRIPTION
home-trading の週次報告 CronJob（ラベル `trading: reporter`、Tsuguya/home-trading の次 PR）が `trading.category_counts` を読むための ingress 許可。収集 Pod（`trading: collector`）とラベルを分けるのは、報告 Pod だけが GitHub への egress を持つため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9