### PR TITLE
fix(tetragon): unblock the JSON export and drop container-runtime noise

### DIFF
--- a/helm-values/tetragon/values.yaml
+++ b/helm-values/tetragon/values.yaml
@@ -13,6 +13,11 @@ tetragon:
       memory: 256Mi
     limits:
       memory: 1Gi
+  # export-stdout サイドカーは非 root (65532) で動くので、chart 既定の 600
+  # (root:root) だと tetragon.log を開けない。エラーも再起動も出さずに黙って
+  # 0 行を吐き続けるため、導入以来イベントが 1 件も Loki に届いていなかった。
+  # ファイルは node ローカルの /var/run 配下で Talos にはユーザーシェルもない。
+  exportFilePerm: "644"
   exportDenyList: |-
     {"health_check":true}
     {"namespace":["","cilium","kube-system"]}

--- a/manifests/kube-system/tracingpolicy-privileges-raise.yaml
+++ b/manifests/kube-system/tracingpolicy-privileges-raise.yaml
@@ -2,6 +2,11 @@ apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
   name: privileges-raise
+# matchNamespaces (Pid NotIn host_ns) だけではコンテナ起動そのものを拾ってしまう。
+# runc / shim / virtiofsd は新しい PID namespace の中で root へ setuid するため
+# この条件を通過し、実測で 44,921 件/日 = policy イベント全体の 98.4% を占めていた。
+# 除外はカーネル側で行い、ring buffer と CPU も含めて削る。
+# 代償: workload が自前の /usr/bin/runc を実行した場合は検知できない。
 spec:
   kprobes:
     - call: "security_capset"
@@ -24,6 +29,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 2
               operator: "NotEqual"
@@ -37,6 +48,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 3
               operator: "NotEqual"
@@ -50,6 +67,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 4
               operator: "NotEqual"
@@ -71,6 +94,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchCapabilities:
             - type: Effective
               operator: NotIn
@@ -92,6 +121,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 0
               operator: "Equal"
@@ -113,6 +148,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 0
               operator: "Equal"
@@ -136,6 +177,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 0
               operator: "Equal"
@@ -149,6 +196,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 1
               operator: "Equal"
@@ -172,6 +225,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 0
               operator: "Equal"
@@ -185,6 +244,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 1
               operator: "Equal"
@@ -210,6 +275,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 1
               operator: "Equal"
@@ -223,6 +294,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 2
               operator: "Equal"
@@ -248,6 +325,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 1
               operator: "Equal"
@@ -261,6 +344,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 2
               operator: "Equal"
@@ -282,6 +371,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 0
               operator: "Equal"
@@ -303,6 +398,12 @@ spec:
               operator: NotIn
               values:
                 - "host_ns"
+          matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/local/bin/containerd-shim-spin-v2"
+                - "/usr/local/libexec/virtiofsd"
           matchArgs:
             - index: 0
               operator: "Equal"


### PR DESCRIPTION
## 背景

Tetragon は導入（2026-02-22、185日前）以来、**イベントを 1 件も Loki に届けていなかった**。Grafana ダッシュボードは metrics ベースなので緑に見え続けていた。

計測（6ノード実測）:

| 項目 | 値 |
|---|---|
| `export-stdout` サイドカーの出力 | **全期間 0 行**（再起動 0、エラーなし） |
| ノード上の `tetragon.log` | 生きている。10MB × 5 でローテート = 保持 約半日 |
| tetragon 全イベント | 598,017 /日 |
| policy イベント | 45,639 /日（うち `privileges-raise` 44,921 = **98.4%**） |
| `sensitive-file-access` | 発火 0（本 PR の対象外） |

## 変更

### 1. `exportFilePerm: "644"` — 出口を開ける

`export-stdout` は uid 65532 で動くのに、tetragon は chart 既定の `export-file-perm: 600` で root:root のファイルを書く。サイドカーはファイルを開けず、**エラーも再起動も出さずに黙って 0 行を吐き続ける**。

`export.securityContext` を root に戻す選択肢もあるが、サイドカーに root を与えるより perm を緩める方が筋が良い。ファイルは node ローカルの `/var/run/cilium/tetragon/` 配下にあり、Talos にはユーザーシェルもないため露出は限定的。

### 2. `privileges-raise` に `matchBinaries: NotIn` — カーネル側でノイズを落とす

`privileges-raise` の 44,921 件/日 の実体:

| binary | 件数 | namespace |
|---|---|---|
| `/usr/bin/runc` | 177,371 | `""`（ホスト） |
| `/usr/local/libexec/virtiofsd` | 161 | `""` |
| `/usr/local/bin/containerd-shim-spin-v2` | 90 | `""` |

いずれもコンテナ起動そのもの。既存の `matchNamespaces: Pid NotIn host_ns` は「コンテナ内のプロセスだけ見る」意図だが、runc は**新しい PID namespace の中で** root へ setuid するのでこの条件を通過してしまう。

export の denylist（`{"namespace":["","cilium","kube-system"]}`）が `ns=""` を落とすため Loki には元々届いていないが、eBPF ring buffer・userspace 処理・メトリクス基数のコストは払っている（tetragon の RSS は 6 ノード合計 981 MiB）。カーネル側で落とす。

**代償**: workload が自前の `/usr/bin/runc` を実行した場合は検知できなくなる。Kyverno の署名検証が効いている前提での許容。

## 検証

- `scripts/unread-values.py` — tetragon に指摘なし
- `helm template` — `export-file-perm = '644'` を確認
- `kubectl apply --dry-run=server` — 実 CRD で通過。`matchBinaries` が 16 selector 全部に入っていること、kprobe 10 個のパースを確認
- `/lint` — 全ルール通過

## 反映後に見るもの

- ConfigMap に `checksum/configmap` が効いているので DaemonSet は自動で rolling restart する
- **既存の `tetragon.log` は 600 のまま残る**（`open(2)` の perm は新規作成時しか効かない）。次のローテーション（10MB、実測 2〜4 時間）で 644 の新ファイルができて初めて流れ始める見込み
- 流れ始めたら export 量を実測する。現状の内訳は `PROCESS_EXEC`/`EXIT` が 99%（trivy-system 61% / rss 26% / monitoring 12%）で **policy 発火は 1%**、約 220MB/日（raw、6ノード計）。ここを絞るかは数字を見てから別途判断

## 積み残し（別 PR）

- `sensitive-file-access` が 185 日間 発火 0 — `/etc/shadow` 完全一致では実効性がない
- tetragon 関連の PrometheusRule が存在しない（今回のような沈黙を検知できない）
- `apps/tetragon.yaml` の `syncPolicy.syncOptions` に `ServerSideApply=true` がない（本 PR の変更対象外のため未修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9
