### PR TITLE
fix(tetragon): cut export volume by filtering polling noise

### DIFF
--- a/helm-values/tetragon/values.yaml
+++ b/helm-values/tetragon/values.yaml
@@ -18,9 +18,23 @@ tetragon:
   # 0 行を吐き続けるため、導入以来イベントが 1 件も Loki に届いていなかった。
   # ファイルは node ローカルの /var/run 配下で Talos にはユーザーシェルもない。
   exportFilePerm: "644"
+  # health_check は Tetragon 自身の内部ヘルスチェック用で、Kubernetes の probe とは
+  # 無関係。probe は素通りするので binary_regex で個別に落とす。実測 1,028 MiB/日
+  # (raw, 6ノード計) のうち smartctl 50.5% / pg_isready 13.5% / runc init 1.6%。
+  # いずれも定期的に機械的に起きるものだけで、人間や侵入者の行為は含まれない。
+  # postgres 本体や argocd の git は実活動なので残す。
   exportDenyList: |-
     {"health_check":true}
     {"namespace":["","cilium","kube-system"]}
+    {"binary_regex":["^/usr/sbin/smartctl$"]}
+    {"binary_regex":["/pg_isready$"]}
+    {"parent_binary_regex":["/runc$"],"binary_regex":["^/proc/self/fd/"]}
+  # 1イベント 3,733 バイトのうち process.pod 823B + parent.pod 約800B が pod
+  # メタデータの重複。parent.pod は process.pod とほぼ常に同一なので落とす。
+  # イベント自体は捨てないので検知能力は変わらない。
+  # node_labels (390B) も冗長だが chart に knob がないため残る。
+  fieldFilters: |-
+    {"fields":"parent.pod","action":"EXCLUDE"}
   prometheus:
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
## 背景

#689 で export が開通した結果、**実レートは 1,028 MiB/日（raw、6ノード計）** だった。#689 時点の見積もり 220 MB/日 の約 4.7 倍。

内訳を実測（9,000 イベントのサンプル）したところ、2/3 が「機械が自分を定期的に叩いている」だけのものだった。

| binary | シェア | 正体 |
|---|---|---|
| `/usr/sbin/smartctl` | **50.5%** | smartctl_exporter のディスク health polling |
| `pg_isready` 系 | 13.5% | CNPG の readiness probe（親 `/controller/manager`）。ラッパーと実体で2重に出る |
| `/proc/self/fd/6`（親 runc） | 1.6% | コンテナ init |

## 変更

### 1. `exportDenyList` に `binary_regex` を追加

既存の `{"health_check":true}` は **Tetragon 自身の内部ヘルスチェック**を指すもので、Kubernetes の probe とは無関係。probe は素通りする。名前から取り違えやすい。

上記3種を binary で落とす。いずれもタイマー駆動で、背後に人間も侵入者もいない。**`postgres` 本体（9.6%）と argocd の git（4.2%）は実活動なので残す。**

### 2. `fieldFilters` で `parent.pod` を除外

1イベント 3,733 バイトの解剖:

| フィールド | バイト | 割合 |
|---|---|---|
| `process.pod` | 823 B | 26% |
| `parent.pod` | 約 800 B | 26% |
| `node_labels` | 390 B | 12% |
| 実際の情報（binary / arguments / pid 等） | 約 200 B | 6% |

`parent.pod` は `process.pod` とほぼ常に同一内容の重複。**イベント自体は 1 件も捨てないので検知能力は変わらない。**

`node_labels` も冗長だが chart に knob がないため残る。

## 検証

- 9,000 件の実イベントに**実際の正規表現を適用してシミュレーション**: 65.6% drop / 34.5% keep。keep 側には postgres・git・gpg・helm・argoexec が残存（実活動を誤って消していないことを確認）
- `helm template` で `export-denylist` と `field-filters` の両方が `tetragon-config` に出ることを確認（`fieldFilters` はドット記法対応をチャートのコメントで確認済み）
- `scripts/unread-values.py` — 指摘なし
- `/lint` — 全ルール通過

## 見込み

1,028 → **約 262 MiB/日 (raw)** → 圧縮 5.54 倍で 47 MiB/日 → 14 日保持（`retention_period: 336h`）で **約 0.65 GiB**

## 反映後に確認すること

- 1イベントの平均バイト数が 3,733 から下がっているか（`fieldFilters` が効いた証拠）
- tetragon の起動ログにフィルタのパースエラーが出ていないか
- smartctl / pg_isready が export から消えているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9
