### PR TITLE
feat(claude-code): add a weekly counts-only inventory report

### DIFF
--- a/manifests/claude-code/weekly-inventory-cwf.yaml
+++ b/manifests/claude-code/weekly-inventory-cwf.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: weekly-inventory
+  namespace: claude-code
+spec:
+  schedules:
+    - "0 9 * * 0"
+  timezone: Asia/Tokyo
+  concurrencyPolicy: Forbid
+  workflowSpec:
+    entrypoint: main
+    serviceAccountName: claude-code-sre
+    activeDeadlineSeconds: 300
+    podMetadata:
+      labels:
+        claude-code: "true"
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    templates:
+      - name: main
+        securityContext:
+          runAsUser: 65532
+          runAsNonRoot: true
+          runAsGroup: 65532
+          fsGroup: 65532
+        container:
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          command: [sh, -c]
+          args:
+            - |
+              set -u
+              LOKI="http://loki-gateway.monitoring.svc:80"
+              PROM="http://kube-prometheus-stack-prometheus.monitoring.svc:9090"
+
+              # 判定はしない。数字をそのまま並べる。異常時だけ喋る仕組みだと
+              # 「異常なし」と「そもそも動いていない」と「検査対象が 0 件だった」が
+              # 区別できないため、無条件に毎回送る。
+              # クエリに = { } " ~ が入るので --data-urlencode 必須。wget --post-data だと
+              # エンコードされず毎回 0 か ? を報告する動かないレポートになる。
+              # 取得失敗は 0 ではなく ? を返す。「本当に 0 件」と「取れなかった」は別物。
+              lq() {
+                curl -sS --max-time 20 --data-urlencode "query=$1" "$LOKI/loki/api/v1/query" 2>/dev/null \
+                  | jq -er '[.data.result[]?.value[1]? | tonumber] | add // 0 | floor' 2>/dev/null || echo "?"
+              }
+              pq() {
+                curl -sS --max-time 20 --data-urlencode "query=$1" "$PROM/api/v1/query" 2>/dev/null \
+                  | jq -er '[.data.result[]?.value[1]? | tonumber] | add // 0 | floor' 2>/dev/null || echo "?"
+              }
+
+              # 観測系の出口。ここが 0 なら「壊れた」ではなく「一度も動いていない」
+              # 可能性がある。2026-08-27 の tetragon はこの形で 185 日見逃された。
+              T_EXPORT=$(lq 'sum(count_over_time({namespace="kube-system",pod=~"tetragon-.*",container="export-stdout"}[7d]))')
+              HUBBLE=$(lq 'sum(count_over_time({job="hubble"}[7d]))')
+              ALLOY=$(lq 'sum(count_over_time({namespace="monitoring",pod=~"alloy-.*"}[7d]))')
+              ARGO_LOG=$(lq 'sum(count_over_time({namespace="argo"}[7d]))')
+
+              T_POLICY=$(pq 'sum(increase(tetragon_policy_events_total[7d]))')
+              TGT_UP=$(pq 'sum(up)')
+              TGT_DOWN=$(pq 'sum(up == 0) or vector(0)')
+
+              NODES=$(kubectl get nodes --no-headers 2>/dev/null \
+                | awk '$2=="Ready"{r++} END{printf "%d/%d", r, NR}')
+              PODS=$(kubectl get pods -A -o json 2>/dev/null \
+                | jq -r '[.items[].status.phase] | "Running \([.[]|select(.=="Running")]|length) / Succeeded \([.[]|select(.=="Succeeded")]|length) / Failed \([.[]|select(.=="Failed")]|length) / Pending \([.[]|select(.=="Pending")]|length)"')
+              NOTREADY=$(kubectl get pods -A --no-headers 2>/dev/null \
+                | awk '$4=="Running"{split($3,a,"/"); if(a[1]!=a[2]) n++} END{printf "%d", n}')
+              APPS=$(kubectl get app -n argocd --no-headers 2>/dev/null \
+                | awk '$2=="Synced"{r++} END{printf "%d/%d", r, NR}')
+              CNP_NS=$(kubectl get cnp -A --no-headers 2>/dev/null | awk '{print $1}' | sort -u | wc -l)
+              ALL_NS=$(kubectl get ns --no-headers 2>/dev/null | wc -l)
+
+              REPORT=$(printf '**観測系の出口（直近7日・Loki）**\n'
+                printf 'tetragon export: `%s` 行\n' "$T_EXPORT"
+                printf 'hubble: `%s` 行\n' "$HUBBLE"
+                printf 'alloy: `%s` 行\n' "$ALLOY"
+                printf 'argo: `%s` 行\n' "$ARGO_LOG"
+                printf '\n**Tetragon（直近7日）**\n'
+                printf 'policy 発火: `%s` 件\n' "$T_POLICY"
+                printf '\n**クラスタ**\n'
+                printf 'Node Ready: `%s`\n' "$NODES"
+                printf 'Pod: `%s`\n' "$PODS"
+                printf 'Running だが Ready でない Pod: `%s`\n' "$NOTREADY"
+                printf 'ArgoCD Synced: `%s`\n' "$APPS"
+                printf 'Prometheus targets: up `%s` / down `%s`\n' "$TGT_UP" "$TGT_DOWN"
+                printf 'CNP を持つ namespace: `%s/%s`\n' "$CNP_NS" "$ALL_NS")
+
+              echo "$REPORT"
+
+              # Discord の上限は 4096 "文字"。jq の文字列スライスは文字単位。
+              BODY=$(printf '%s' "$REPORT" \
+                | jq -Rsr --argjson max 3900 \
+                    'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end')
+              WF_NAME="{{workflow.name}}"
+              NS="{{workflow.namespace}}"
+              URL="https://argo.infra.tgy.io/workflows/${NS}/${WF_NAME}"
+              TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+              PAYLOAD=$(jq -n \
+                --arg title "週次クラスタ棚卸し" \
+                --arg url "$URL" \
+                --argjson color 3447003 \
+                --arg report "$BODY" \
+                --arg ts "$TIMESTAMP" \
+                '{embeds: [{title: $title, url: $url, color: $color, description: $report, timestamp: $ts}]}')
+
+              wget -qO /dev/null --header="Content-Type: application/json" \
+                --post-data="$PAYLOAD" "$DISCORD_WEBHOOK_URL"
+          env:
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: discord-webhook-argo
+                  key: url
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 256Mi


### PR DESCRIPTION
## 背景

`cluster-observe` は 1日2回動いているが、**7つのチェックすべてが「壊れているものを探す」型**（restart>5 / OOMKilled / 非Running / node conditions / disk>80% / mem>85% / cert<14d）。

2026-08-27 に発覚した tetragon の件は、この 7 つを**全部通過**していた。Pod は Running、restart 0、OOM なし、ノードもディスクもメモリも正常。**壊れていなかったからで、単に一度も仕事をしていなかった**（#689 / #691）。

「あるべきものが出ているか」という不在ベースの問いが、クラスタのどこにも無い。さらに `cluster-observe` は異常時しか喋らないので、**「異常なし」と「そもそも動いていない」と「検査対象が0件だった」が区別できない**。

## 変更

判定を一切せず**件数だけを並べる週次レポート**を追加する。`cluster-observe`（検出系）は変更しない。両者は役割が違う。

- **無条件に毎回送る** — 沈黙は「異常なし」ではなく「ジョブが動かなかった」を意味するようになる
- **0 が可視になる** — 発火しない条件式ではなく、行として `0` が出る
- **取得失敗は `?`、本当の0件は `0`** — Loki に繋がらなかったことが「イベント0件」に化けない

出力例（実データ、347文字）:

```
**観測系の出口（直近7日・Loki）**
tetragon export: `17812` 行
hubble: `300633` 行
alloy: `52438` 行
argo: `478525` 行

**Tetragon（直近7日）**
policy 発火: `495540` 件

**クラスタ**
Node Ready: `6/6`
Pod: `Running 157 / Succeeded 22 / Failed 4 / Pending 0`
Running だが Ready でない Pod: `0`
ArgoCD Synced: `49/50`
Prometheus targets: up `82` / down `0`
CNP を持つ namespace: `29/35`
```

観測系の出口を先頭に置いたのは、それが tetragon の失敗を隠していた種類だから。

## 新しい稼働物を増やしていない

日曜 09:00 JST、**素のシェルスクリプト（LLM なし）** なので Claude の枠を食わない。既存の部品をそのまま使う:

| 必要なもの | 既存 |
|---|---|
| CNP | `claude-code` CNP が `claude-code: "true"` ラベルで選択。egress は Loki / Prometheus / apiserver / discord.com 許可済み |
| RBAC | `claude-code-sre` に pods / nodes / namespaces / cnp / applications の read あり |
| Discord | `discord-webhook-argo` Secret が同 namespace に存在 |
| イメージ | `argo-tools`（`cnp-check` / `cluster-observe` と同じ digest） |

## 検証

- **全クエリを本番クラスタで実行し、実数が返ることを確認**（上の出力はその実データ）
- ヘルパー関数を4ケースで検証: 正常クエリ→`82` / 存在しないメトリクス→`0` / 到達不能→`?` / `=` `{` `}` を含むクエリ→`18`
- **`wget --post-data` では URL エンコードされず壊れることを発見**し、`curl --data-urlencode` に修正。イメージに `curl` があることを実際にコンテナを起動して確認済み
- レンダリング本文 347 / 4096 文字、JSON payload の組み立ても確認
- `kubectl apply --dry-run=server` 通過
- `/lint` 全ルール通過（CNP カバレッジは `claude-code` ラベル付与で担保、機密値は `secretKeyRef`、`limits.cpu` なし）

## 検証中に見つかった別件（本PRでは直さない）

**`certmanager_*` は Prometheus にメトリクス名として1つも存在しない。** つまり `cluster-observe` のチェック7（証明書期限 <14日）は、書かれて以来ずっと空ベクタを受け取っていて、一度も発火し得ない状態にある。本レポートからは意図的に外した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9
