### PR TITLE
fix(cert-manager): scrape the metrics nobody was collecting

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -215,9 +215,9 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **controller** | host → 9403 | kube-apiserver, acme-v02.api.letsencrypt.org:443, api.cloudflare.com:443, external DNS 53 (propagation check) |
-| **cainjector** | (deny world) | kube-apiserver |
-| **webhook** | kube-apiserver/remote-node → 10250; host → 6080 | kube-apiserver |
+| **controller** | host → 9403; prometheus (monitoring) → 9402 (metrics) | kube-apiserver, acme-v02.api.letsencrypt.org:443, api.cloudflare.com:443, external DNS 53 (propagation check) |
+| **cainjector** | (deny world); prometheus (monitoring) → 9402 (metrics) | kube-apiserver |
+| **webhook** | kube-apiserver/remote-node → 10250; host → 6080; prometheus (monitoring) → 9402 (metrics) | kube-apiserver |
 | **startupapicheck** (Job) | (deny world) | kube-apiserver |
 
 ## external-dns (1 policy)

--- a/helm-values/cert-manager/values.yaml
+++ b/helm-values/cert-manager/values.yaml
@@ -2,6 +2,17 @@ crds:
   enabled: true
   keep: true
 
+# chart 既定は prometheus.enabled: true だが servicemonitor/podmonitor はどちらも
+# false なので、9402 が Service に出ているだけで誰もスクレイプしていなかった。
+# 結果 certmanager_* が Prometheus に 1 つも存在せず、cluster-observe の証明書
+# 期限チェックが書かれて以来ずっと空ベクタを受け取って発火し得なかった。
+# キーは servicemonitor（小文字）で labels。tetragon の extraLabels とは別名。
+prometheus:
+  servicemonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+
 resources:
   requests:
     cpu: 10m

--- a/manifests/cert-manager/netpol-cainjector.yaml
+++ b/manifests/cert-manager/netpol-cainjector.yaml
@@ -10,6 +10,18 @@ spec:
   ingressDeny:
     - fromEntities:
         - world
+  # chart の ServiceMonitor は cainjector も対象にする。ingress は既に Enabled
+  # （デフォルト deny）なので、これは posture の切り替えではなく純粋な追加。
+  # cainjector に probe は無いので kubelet 向けの host ルールは要らない。
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prometheus
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9402"
+              protocol: TCP
   egress:
     - toEntities:
         - kube-apiserver

--- a/manifests/cert-manager/netpol-controller.yaml
+++ b/manifests/cert-manager/netpol-controller.yaml
@@ -14,6 +14,16 @@ spec:
         - ports:
             - port: "9403"
               protocol: TCP
+    # ServiceMonitor を有効にしても、この ingress がないと scrape は落ちる。
+    # certmanager_* が Prometheus に存在しなかった原因の片割れ。
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prometheus
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9402"
+              protocol: TCP
   egress:
     - toEntities:
         - kube-apiserver

--- a/manifests/cert-manager/netpol-webhook.yaml
+++ b/manifests/cert-manager/netpol-webhook.yaml
@@ -21,6 +21,16 @@ spec:
         - ports:
             - port: "6080"
               protocol: TCP
+    # chart の ServiceMonitor は controller / webhook / cainjector の 3 つを対象に
+    # するので、ここを開けないと webhook が常時 down のターゲットとして残る。
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prometheus
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9402"
+              protocol: TCP
   egress:
     - toEntities:
         - kube-apiserver


### PR DESCRIPTION
## 背景

`cluster-observe` は書かれて以来ずっと「証明書の期限 <14日」をチェックしているが、**一度も発火したことがない**。証明書が健全だからではなく、**`certmanager_*` が Prometheus に1つも存在しない**ため。空ベクタが返り、`if [ -n "$CERT_EXPIRING" ]` が真にならない。

原因は2つあり、**片方だけ直しても動かない**。

### 1. ServiceMonitor が作られていない

chart 既定は `prometheus.enabled: true` だが `servicemonitor.enabled` / `podmonitor.enabled` は**両方 false**。9402 は3つの Service に出ているのに、誰もスクレイプしていなかった。

### 2. CNP が scrape を落とす

`netpol-controller.yaml` の ingress は `host → 9403` のみ。ServiceMonitor を有効にしても、Prometheus から 9402 への経路がないので全部 drop される。

## 「外された履歴」ではないことの確認

全ブランチを通して:

- `prometheus` / `servicemonitor` / `serviceMonitor` は `helm-values/cert-manager/` に**一度も登場していない**
- `9402` は `manifests/cert-manager/` に**一度も登場していない**
- 削除された ServiceMonitor マニフェストも無い
- `values.yaml` の変更履歴は5件のみで、すべて resources / securityContext / ログ形式

tetragon の export と同じ **初期設定の抜け**であって、意図的に無効化された判断を覆すものではない。

## 変更

| ファイル | 内容 |
|---|---|
| `helm-values/cert-manager/values.yaml` | `prometheus.servicemonitor.enabled: true` + `labels.release: kube-prometheus-stack` |
| `netpol-controller.yaml` | prometheus (monitoring) → 9402 |
| `netpol-webhook.yaml` | 同上 |
| `netpol-cainjector.yaml` | 同上（`ingress` セクション自体を新設） |
| `docs/network-policies.md` | cert-manager の表を更新 |

**webhook / cainjector も開けているのは、レンダリング結果から分かったこと。** chart の ServiceMonitor は selector が `matchExpressions: app.kubernetes.io/name In [cainjector, cert-manager, webhook]` になっていて3つとも対象にするので、controller だけ開けると**残り2つが常時 down のターゲットとして残る**。「targets down が常に 2」は、無視されるようになる種類のノイズなので避ける。

**cainjector は `ingressDeny` だけで `ingress` セクションが無かった。** ここにルールを足すと enforcement が切り替わって probe が落ちる懸念があったため確認したところ:

- Cilium 上の endpoint は既に `ingress=Enabled`（つまり既にデフォルト deny）→ posture の切り替えではなく純粋な追加
- cainjector に liveness/readiness probe は無い → kubelet 向けの `host` ルールは不要

## 検証

- `scripts/unread-values.py` — 指摘なし（キーは `servicemonitor` 小文字・`labels`。tetragon の `extraLabels` とは別名）
- `helm template` — ServiceMonitor がレンダリングされ、`release: kube-prometheus-stack` が付き（Prometheus の `serviceMonitorSelector` と一致）、endpoint は `targetPort: http-metrics` / `path: /metrics`
- `kubectl apply --dry-run=server` — CNP 3つとも通過
- `ingressDeny` と `ingress` の共存をパースで確認
- `/lint` — 全ルール通過

## 反映後に確認すること

- Prometheus の targets に cert-manager 3つが up で出るか
- `certmanager_certificate_expiration_timestamp_seconds` が返るか
- `hubble observe --verdict DROPPED` に 9402 の drop が残っていないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9
