### PR TITLE
fix(monitoring): let prometheus egress reach cert-manager metrics

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -149,7 +149,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **prometheus** | grafana, tempo, claude-code (claude-code), kube-apiserver/remote-node (service proxy, RBAC services/proxy で制御) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
+| **prometheus** | grafana, tempo, claude-code (claude-code), kube-apiserver/remote-node (service proxy, RBAC services/proxy で制御) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, cert-manager controller/webhook/cainjector (cert-manager):9402, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
 | **alertmanager** | prometheus → 9093/8080 | discord.com:443, discordapp.com:443, alertmanager-eventsource (argo):12001 |
 | **grafana** | ingress → 3000 (L7 HTTP); prometheus → 3000 | kube-apiserver, prometheus:9090, loki-gateway:8080, tempo:3200, shared-pg (database):5432, kanidm (kanidm):8443 |
 | **kube-state-metrics** | prometheus → 8080 | kube-apiserver |

--- a/manifests/monitoring/netpol-prometheus.yaml
+++ b/manifests/monitoring/netpol-prometheus.yaml
@@ -83,6 +83,22 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
+    # chart の ServiceMonitor は 3 コンポーネントとも対象にするので 3 つ書く。
+    # matchLabels はラベルを跨いだパターンマッチができないため列挙が必要。
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: cert-manager
+            io.kubernetes.pod.namespace: cert-manager
+        - matchLabels:
+            app.kubernetes.io/name: webhook
+            io.kubernetes.pod.namespace: cert-manager
+        - matchLabels:
+            app.kubernetes.io/name: cainjector
+            io.kubernetes.pod.namespace: cert-manager
+      toPorts:
+        - ports:
+            - port: "9402"
+              protocol: TCP
     - toEndpoints:
         - matchLabels:
             app.kubernetes.io/name: tempo


### PR DESCRIPTION
## 背景

#693 で cert-manager の ServiceMonitor を有効にし、3コンポーネントの ingress に 9402 を開けたが、**scrape はまだ down のまま**（`context deadline exceeded`）。

cert-manager 側は正しい。`cilium-dbg bpf policy get` で確認:

```
Allow  Ingress  k8s:app.kubernetes.io/name=prometheus ...  9402/TCP  ...  BYTES=-  PACKETS=-
```

ルールは prometheus の identity に対して**正しくロードされているが、バイト数がゼロ**。接続が Prometheus から出ていない。

## 原因

`netpol-prometheus.yaml` の egress は**スクレイプ先を明示的に列挙する方式**で、cert-manager が入っていなかった。

**#693 で私は cert-manager 側の ingress を3つとも検証しながら、スクレイプする側の egress を見ていなかった。** 実際に塞いでいたのはそちら。

## 変更

`netpol-prometheus.yaml` の egress に cert-manager の3コンポーネント → 9402 を追加。`matchLabels` はラベルを跨いだパターンマッチができないので、3つとも列挙する。

`docs/network-policies.md` の prometheus 行も更新。

## 検証

- `kubectl apply --dry-run=server` 通過
- 反映後に scrape target が up になること、`certmanager_certificate_expiration_timestamp_seconds` が返ることを確認する（前回はここまで見ずに完了扱いにしかけた）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9
