### PR TITLE
fix(monitoring): repair broken queries in Home Cluster Overview

### DIFF
--- a/manifests/infra/home-cluster-dashboard.yaml
+++ b/manifests/infra/home-cluster-dashboard.yaml
@@ -46,7 +46,7 @@ data:
           "title": "CPU Usage by Node",
           "type": "timeseries",
           "targets": [
-            { "expr": "1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))", "legendFormat": "{{ instance }}", "refId": "A" }
+            { "expr": "(1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))) * on(instance) group_left(nodename) node_uname_info", "legendFormat": "{{ nodename }}", "refId": "A" }
           ]
         },
         {
@@ -63,7 +63,7 @@ data:
           "title": "Memory Usage by Node",
           "type": "timeseries",
           "targets": [
-            { "expr": "1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes", "legendFormat": "{{ instance }}", "refId": "A" }
+            { "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * on(instance) group_left(nodename) node_uname_info", "legendFormat": "{{ nodename }}", "refId": "A" }
           ]
         },
         {
@@ -80,7 +80,7 @@ data:
           "title": "Disk Usage by Node",
           "type": "bargauge",
           "targets": [
-            { "expr": "1 - node_filesystem_avail_bytes{mountpoint=\"/var\",fstype=\"xfs\"} / node_filesystem_size_bytes{mountpoint=\"/var\",fstype=\"xfs\"}", "legendFormat": "{{ instance }}", "refId": "A" }
+            { "expr": "(1 - node_filesystem_avail_bytes{mountpoint=\"/var\",fstype=\"xfs\"} / node_filesystem_size_bytes{mountpoint=\"/var\",fstype=\"xfs\"}) * on(instance) group_left(nodename) node_uname_info", "legendFormat": "{{ nodename }}", "refId": "A" }
           ]
         },
         {
@@ -96,8 +96,8 @@ data:
           "title": "SeaweedFS Volume",
           "type": "stat",
           "targets": [
-            { "expr": "sum(SeaweedFS_volumeServer_total_disk_size)", "legendFormat": "Used", "refId": "A" },
-            { "expr": "sum(SeaweedFS_volumeServer_max_volume_count) * 30 * 1024 * 1024 * 1024", "legendFormat": "Max Volumes (est.)", "refId": "B" }
+            { "expr": "sum(SeaweedFS_volumeServer_resource{type=\"used\"})", "legendFormat": "Used", "refId": "A" },
+            { "expr": "sum(SeaweedFS_volumeServer_resource{type=\"all\"})", "legendFormat": "Total", "refId": "B" }
           ]
         },
         {
@@ -131,7 +131,7 @@ data:
           "title": "Network Receive by Node",
           "type": "timeseries",
           "targets": [
-            { "expr": "rate(node_network_receive_bytes_total{device=~\"enp.*\"}[$__rate_interval])", "legendFormat": "{{ instance }}", "refId": "A" }
+            { "expr": "rate(node_network_receive_bytes_total{device=~\"enp.*\"}[$__rate_interval]) * on(instance) group_left(nodename) node_uname_info", "legendFormat": "{{ nodename }} {{ device }}", "refId": "A" }
           ]
         },
         {
@@ -148,11 +148,11 @@ data:
           "title": "Network Transmit by Node",
           "type": "timeseries",
           "targets": [
-            { "expr": "rate(node_network_transmit_bytes_total{device=~\"enp.*\"}[$__rate_interval])", "legendFormat": "{{ instance }}", "refId": "A" }
+            { "expr": "rate(node_network_transmit_bytes_total{device=~\"enp.*\"}[$__rate_interval]) * on(instance) group_left(nodename) node_uname_info", "legendFormat": "{{ nodename }} {{ device }}", "refId": "A" }
           ]
         },
         {
-          "datasource": { "type": "loki" },
+          "datasource": { "type": "loki", "uid": "loki" },
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
           "options": { "showTime": true, "sortOrder": "Descending", "enableLogDetails": true, "dedupStrategy": "none", "wrapLogMessage": true },
           "title": "SeaweedFS Logs",


### PR DESCRIPTION
Grafana の Home Cluster Overview が 400 を返していたので、実データソースに投げて確認したうえで直した。

## 1. SeaweedFS Logs — datasource uid 欠落（400 の主因）

`"datasource": { "type": "loki" }` に uid がなく、Grafana がデフォルトデータソース（Prometheus）へフォールバック。LogQL が PromQL としてパースされて落ちていた。

```
bad_data: invalid parameter "query": 1:25: parse error: unexpected character: '|'
```

uid を `loki` に固定。

## 2. SeaweedFS Volume — 存在しないメトリクスと二重計上

| 旧クエリ | 実測 |
|---|---|
| `SeaweedFS_volumeServer_max_volume_count` | 0 系列。現在の名前は `_max_volumes` → 「Max Volumes (est.)」は常に No data |
| `sum(SeaweedFS_volumeServer_total_disk_size)` | `type="normal"` 81GB と `type="deleted_bytes"` 15GB を合算し 96GB と過大表示 |

`max_volumes` に直しても `maxVolumes: 0`（ディスクから自動算出）なので 1307 volumes × 30GiB = 38TB という無意味な推定になる。実容量を持つ `SeaweedFS_volumeServer_resource` に置き換え（used 208GB / all 1.49TB）。

## 3. legend がノード名にならない（ついで）

`{{ instance }}` は node-exporter のエンドポイント（`192.168.10.230:9100`）。`node_uname_info` を join して `{{ nodename }}` に。ネットワークは `{{ device }}` も出して、CP が持つ未使用の `enp1s0`（0 B/s）と実際に使っている `enp3s0` を区別できるようにした。

## 検証

全 9 パネル 11 target を稼働中の Prometheus / Loki に投げ、全て success かつデータありを確認。

```
prometheus $node                    OK series=1
prometheus CPU Usage by Node        OK series=6
prometheus Memory Usage by Node     OK series=6
prometheus Disk Usage by Node       OK series=6
prometheus SeaweedFS Volume         OK series=1  (x2)
prometheus Pods                     OK series=1  (x3)
prometheus Network Receive by Node  OK series=9
prometheus Network Transmit by Node OK series=9
loki       SeaweedFS Logs           OK series=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9