### PR TITLE
fix(monitoring): fill in the logs panel options Grafana requires

### DIFF
--- a/manifests/infra/home-cluster-dashboard.yaml
+++ b/manifests/infra/home-cluster-dashboard.yaml
@@ -154,11 +154,11 @@ data:
         {
           "datasource": { "type": "loki", "uid": "loki" },
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
-          "options": { "showTime": true, "sortOrder": "Descending", "enableLogDetails": true, "dedupStrategy": "none", "wrapLogMessage": true },
+          "options": { "showTime": true, "sortOrder": "Descending", "enableLogDetails": true, "dedupStrategy": "none", "wrapLogMessage": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": false, "showLogContextToggle": false },
           "title": "SeaweedFS Logs",
           "type": "logs",
           "targets": [
-            { "expr": "{namespace=\"seaweedfs\"} |~ \"(?i)(error|warn|fail|panic)\"", "refId": "A" }
+            { "datasource": { "type": "loki", "uid": "loki" }, "expr": "{namespace=\"seaweedfs\"} |~ \"(?i)(error|warn|fail|panic)\"", "refId": "A" }
           ]
         }
       ],


### PR DESCRIPTION
#695 で datasource uid を直したあとも SeaweedFS Logs だけ **「読み込みエラー：logs」** のままだったので、その続き。

## クエリではなくパネルの初期化が落ちていた

サーバー側は成功している。ユーザーがパネルを開いた瞬間のログ:

```
dsUid=loki lokiPath=/loki/api/v1/query_range status=ok statusCode=200 framesLength=1
query={namespace="seaweedfs"} |~ "(?i)(error|warn|fail|panic)"
```

`logsPanel.<hash>.js` も Pod 直・公開経路（Cloudflare 経由）の双方で 200・同一サイズで配信されており、logs パネル関連の 404 は 1 件も無い。**データは届いていて、描画側で例外になっている。**

## 原因: Grafana 13.2 の logs パネル定義に対して options が足りない

`public/app/plugins/panel/logs/panelcfg.gen.ts` で 9 個が非オプショナル:

| 必須 option | 修正前 |
|---|---|
| `dedupStrategy` / `enableLogDetails` / `showTime` / `sortOrder` / `wrapLogMessage` | あり |
| `prettifyLogMessage` / `showCommonLabels` / `showLabels` / `showLogContextToggle` | **欠落** |

このダッシュボードは `schemaVersion: 39`（Grafana 10 相当）のまま書かれている一方、13.2 の logs パネルは `detailsMode` / `fontSize` / `showControls` / `syntaxHighlighting` / `enableInfiniteScrolling` など options が大幅に増えている。そして `module.tsx` に `setMigrationHandler` が無いので、**古い定義は自動補完されない** — 欠けたものは undefined のまま初期化に渡る。

同居している `kubernetes-logs` ダッシュボードは前 3 つを持っていて正常に描画される。片方だけ壊れていた差分はここ。

## 変更

- 欠けていた必須 option 4 つを明示（いずれも Grafana 側の既定と同じ値）
- target にも `datasource` ブロックを持たせ、panel からの継承だけに頼らない形にした（`kubernetes-logs` の書き方に合わせた）

`schemaVersion` は上げていない。手で上げると他の migration を飛ばすため、必須 option を明示するほうが安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9