### PR TITLE
fix(monitoring): give grafana headroom over its real working set

### DIFF
--- a/helm-values/kube-prometheus-stack/values.yaml
+++ b/helm-values/kube-prometheus-stack/values.yaml
@@ -88,9 +88,9 @@ grafana:
   resources:
     requests:
       cpu: 25m
-      memory: 256Mi
+      memory: 384Mi
     limits:
-      memory: 512Mi
+      memory: 1Gi
   admin:
     existingSecret: grafana-admin
     userKey: admin-user


### PR DESCRIPTION
Grafana が **2026-08-27 23:45 JST に OOMKilled** されていた（Discord のアラートと一致）。#695 / #696 でダッシュボードの定義を直した件とは別の、独立した問題。

## 実測

```
18:28 〜 23:28   346〜350Mi   5時間フラット
23:43            501Mi        ← ダッシュボードを開いた瞬間
23:45            OOMKilled    limit 512Mi
```

7日間のピークは **506Mi / 512Mi = 99%**。アイドルですら 350Mi あり、`requests: 256Mi` は一度も守られたことのない数字でスケジューリングされていた。

参考に、同じ7日で OOMKilled になった他のコンテナと比べても Grafana だけが突出している:

| コンテナ | limit | 7日ピーク | |
|---|---|---|---|
| monitoring/grafana | 512Mi | 506Mi | **99%** |
| argo/main (eventbus) | 3072Mi | 1439Mi | 47% |
| kube-system/tetragon | 1024Mi | 474Mi | 46% |
| harbor/trivy | 2048Mi | 416Mi | 20% |
| harbor/nginx | 512Mi | 99Mi | 19% |

## 変更

- `limits.memory`: 512Mi → **1Gi** — ダッシュボードを開くコストを、プロセスではなくヘッドルームで払う
- `requests.memory`: 256Mi → **384Mi** — 実測のアイドル値に合わせる

## 検証

- `unread-values.py --changed`: `checked 1 values file(s), no unread keys`
- `helm template` → grafana コンテナに `limits.memory: 1Gi` / `requests.memory: 384Mi` が反映されることを確認
- `kubeconform -strict`: 116 resources すべて Valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9