### PR TITLE
fix(argocd): ignore the followChildren default on matchBinaries

### DIFF
--- a/apps/kube-system-config.yaml
+++ b/apps/kube-system-config.yaml
@@ -19,6 +19,7 @@ spec:
         - .spec.kprobes[].args[] | (.maxData, .resolve, .returnCopy)
         - .spec.kprobes[] | .return
         - .spec.kprobes[].selectors[].matchCapabilities[]? | .isNamespaceCapability
+        - .spec.kprobes[].selectors[].matchBinaries[]? | .followChildren
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
`kube-system-config` が #689 以降 OutOfSync のままだったので直す。

## drift は Tetragon 自身のデフォルト注入だけ

マニフェストと live オブジェクトをフィールド単位で突き合わせた結果:

- **値の食い違い: 0 件** — ポリシーの中身は git と live で完全一致
- live 側にだけ存在するキー: **87 件**（`maxData` / `resolve` / `returnCopy` / `return` / `isNamespaceCapability` / `followChildren`）

つまり実害はないが、`selfHeal: true` なので ArgoCD は一致済みのポリシーを延々と sync し続ける。

## なぜ今になって出たか

`ignoreDifferences` は f3cd873 (2026-02-24) でまさにこの問題のために入っていて、5種類をカバーしている。**`followChildren` だけが漏れていた** — これは `matchBinaries` に付くデフォルトで、`matchBinaries` をこのポリシーに持ち込んだのが #689（capset kprobe から runc / spin shim / virtiofsd を除外する変更）だから。2月時点では存在しないフィールドだった。

## 検証

live オブジェクトに対して各式を実際に評価:

| 式 | 選択数 |
|---|---|
| `.spec.kprobes[].args[] \| (.maxData, .resolve, .returnCopy)` | 60 |
| `.spec.kprobes[] \| .return` | 10 |
| `.spec.kprobes[].selectors[].matchCapabilities[]? \| .isNamespaceCapability` | 1 |
| **`.spec.kprobes[].selectors[].matchBinaries[]? \| .followChildren`**（追加） | **16** |
| 合計 | **87** |

検出された 87 件と一致するので、取りこぼしはない。追加分の値はすべて `false`（デフォルト）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvF7SyXzfD7Z2h24nMyqV9