### PR TITLE
Run Grafana dashboard sidecar as a container again, keeping skipReload

### DIFF
--- a/helm-values/kube-prometheus-stack/values.yaml
+++ b/helm-values/kube-prometheus-stack/values.yaml
@@ -78,9 +78,8 @@ grafana:
       limits:
         memory: 256Mi
     dashboards:
-      skipReload: true
-      initDashboards: true # no running sidecar — restart pod after dashboard ConfigMap changes
-      watchMethod: LIST
+      skipReload: true # no reload API call — Grafana's file provisioner polls the directory itself
+      watchMethod: WATCH
     datasources:
       skipReload: true
       initDatasources: true


### PR DESCRIPTION
The initContainer pattern (17d6a00) was chosen to avoid the reload API 401, but only datasource provisioning needs that API. Dashboards are picked up by Grafana's own file provider (`updateIntervalSeconds: 30`), so a running sidecar with `skipReload` reflects ConfigMap changes without a pod restart. Datasources stay in init mode.

Rendered: `grafana-sc-dashboard` becomes a regular container (METHOD=WATCH, no REQ_URL), datasources init unchanged. unread-values / kubeconform pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VA39Gmq4sDrftq83AjDLy