### PR TITLE
Disable Grafana basic auth, leaving Kanidm SSO as the only login path

### DIFF
--- a/helm-values/kube-prometheus-stack/values.yaml
+++ b/helm-values/kube-prometheus-stack/values.yaml
@@ -118,7 +118,7 @@ grafana:
     auth:
       disable_login_form: true
     auth.basic:
-      enabled: true
+      enabled: false # SSO only; the sidecar reload API that needed this is no longer used
     auth.generic_oauth:
       enabled: true
       name: Kanidm


### PR DESCRIPTION
`auth.basic` was enabled in 54fb0d9 for the sidecar reload API. After #705 dashboards reflect via Grafana's file provisioner and datasources use init mode, so nothing uses the built-in admin credentials over HTTP anymore. `disable_login_form` only hides the form; this closes the `/api/*` Basic path so Kanidm SSO is the only login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VA39Gmq4sDrftq83AjDLy