### PR TITLE
argo/rss: enable ingress enforcement on egress-only CNPs

### DIFF
--- a/manifests/argo/netpol-talos-extension-bump.yaml
+++ b/manifests/argo/netpol-talos-extension-bump.yaml
@@ -7,6 +7,9 @@ spec:
   endpointSelector:
     matchLabels:
       sensor-name: talos-extension-bump
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEndpoints:
         - matchLabels:

--- a/manifests/argo/netpol-task-status-sync.yaml
+++ b/manifests/argo/netpol-task-status-sync.yaml
@@ -7,6 +7,9 @@ spec:
   endpointSelector:
     matchLabels:
       eventsource-name: task-status-sync
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEndpoints:
         - matchLabels:
@@ -31,6 +34,9 @@ spec:
   endpointSelector:
     matchLabels:
       sensor-name: task-status-sync
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEndpoints:
         - matchLabels:
@@ -55,6 +61,9 @@ spec:
   endpointSelector:
     matchLabels:
       task-fail-sync: "true"
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEndpoints:
         - matchLabels:

--- a/manifests/rss/netpol-rss-apps.yaml
+++ b/manifests/rss/netpol-rss-apps.yaml
@@ -119,6 +119,9 @@ spec:
   endpointSelector:
     matchLabels:
       rss-cron: "true"
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEndpoints:
         - matchLabels:
@@ -168,6 +171,9 @@ spec:
   endpointSelector:
     matchLabels:
       workflows.argoproj.io/on-exit: "true"
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEntities:
         - kube-apiserver
@@ -200,6 +206,9 @@ spec:
   endpointSelector:
     matchLabels:
       app: rss-migration
+  ingressDeny:
+    - fromEntities:
+        - world
   egress:
     - toEndpoints:
         - matchLabels:


### PR DESCRIPTION
Seven CNPs carried only egress rules, so their pods had no ingress enforcement (reachable from any in-cluster endpoint; in practice only sensor metrics :7777 and short-lived Jobs). Adds the same `ingressDeny: [{fromEntities: [world]}]` marker the other sensor policies already use. No reach is widened. Found by the nightly cnp-check run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S