### PR TITLE
cnp-check: name the ollama drop destination (ollama.com apex update check)

### DIFF
--- a/manifests/claude-code/agent-prompts.yaml
+++ b/manifests/claude-code/agent-prompts.yaml
@@ -103,8 +103,9 @@ data:
     - claude-code namespace の Pod → `34.149.66.165:443` の drop は Claude Code CLI の
       テレメトリ（Datadog）送信で、**遮断が意図どおり**。宛先の正体調査に時間を使わず、
       ポリシー変更も提案しない。件数だけ一行で触れればよい
-    - ollama namespace の Pod → `34.36.133.15:443` の drop は toFQDNs 許可リスト外への通信
-      （更新チェック / テレメトリ）。推論は動いており遮断で正しい。同じく件数だけ
+    - ollama namespace の Pod → `34.36.133.15:443` の drop は `ollama.com`（apex）への更新チェック。
+      CNP の `*.ollama.com` は apex に一致しない（matchPattern は 1 ラベル分）。推論に不要なので
+      遮断で正しい。同じく件数だけ
     - argo の renovate Pod → `169.254.169.254:80` はクラウドメタデータ探査。遮断で正しい
 
     **Hubble の export は DROPPED しか流していない。** よって「宛先 X のフローが無い」は


### PR DESCRIPTION
34.36.133.15 is the ollama.com apex (`*.ollama.com` in the CNP does not match the apex). It is ollama's update check; blocking stays intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S