### PR TITLE
qdrant: disable telemetry

### DIFF
--- a/helm-values/qdrant/values.yaml
+++ b/helm-values/qdrant/values.yaml
@@ -6,6 +6,8 @@ image:
 config:
   cluster:
     enabled: false
+  # telemetry.qdrant.io への送信。CNP で落ちて 1 日 400〜800 件の drop になっていたので送信側で止める
+  telemetry_disabled: true
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Stops the telemetry.qdrant.io calls at the source (`config.telemetry_disabled: true` → production.yaml) instead of treating the resulting CNP drops as known noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S