### PR TITLE
Point repository references at Tsuguya-HC/home-cluster

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
     # `@main` is the design, not an oversight. A SHA would have to be bumped on
     # every change to the body, which puts this file back into Renovate's path
     # and reintroduces the exact failure the split exists to remove.
-    uses: Tsuguya/home-cluster/.github/workflows/_claude-review.yml@main # zizmor: ignore[unpinned-uses]
+    uses: Tsuguya-HC/home-cluster/.github/workflows/_claude-review.yml@main # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write # the reviewer merges the PR it approves
       pull-requests: write # review, approve, comment

--- a/apps/alloy.yaml
+++ b/apps/alloy.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: alloy
         valueFiles:
           - $values/helm-values/alloy/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/argo-config.yaml
+++ b/apps/argo-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: argo
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/argo
   destination:

--- a/apps/argo-events.yaml
+++ b/apps/argo-events.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: argo-events
         valueFiles:
           - $values/helm-values/argo-events/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/argo-workflows.yaml
+++ b/apps/argo-workflows.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: argo-workflows
         valueFiles:
           - $values/helm-values/argo-workflows/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/argocd-config.yaml
+++ b/apps/argocd-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: platform
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/argocd
   destination:

--- a/apps/argocd.yaml
+++ b/apps/argocd.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: argocd
         valueFiles:
           - $values/helm-values/argocd/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/blackbox-exporter.yaml
+++ b/apps/blackbox-exporter.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: blackbox-exporter
         valueFiles:
           - $values/helm-values/blackbox-exporter/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/cert-manager.yaml
+++ b/apps/cert-manager.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: cert-manager
         valueFiles:
           - $values/helm-values/cert-manager/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/cert-manager
   destination:

--- a/apps/cilium.yaml
+++ b/apps/cilium.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: cilium
         valueFiles:
           - $values/helm-values/cilium/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/claude-code.yaml
+++ b/apps/claude-code.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: argo
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/claude-code
   destination:

--- a/apps/cnpg.yaml
+++ b/apps/cnpg.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: cnpg
         valueFiles:
           - $values/helm-values/cnpg/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/cnpg-system
   destination:

--- a/apps/database.yaml
+++ b/apps/database.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: storage
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/database
   destination:

--- a/apps/external-dns.yaml
+++ b/apps/external-dns.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: external-dns
         valueFiles:
           - $values/helm-values/external-dns/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/external-dns
   destination:

--- a/apps/external-secrets.yaml
+++ b/apps/external-secrets.yaml
@@ -20,10 +20,10 @@ spec:
         releaseName: onepassword-connect
         valueFiles:
           - $values/helm-values/onepassword-connect/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/external-secrets
   destination:

--- a/apps/harbor.yaml
+++ b/apps/harbor.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: harbor
         valueFiles:
           - $values/helm-values/harbor/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/harbor
   destination:

--- a/apps/horenso.yaml
+++ b/apps/horenso.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/horenso
   destination:

--- a/apps/image-build.yaml
+++ b/apps/image-build.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: argo
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/image-build
   destination:

--- a/apps/infra.yaml
+++ b/apps/infra.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: networking
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/infra
   destination:

--- a/apps/kanidm.yaml
+++ b/apps/kanidm.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: security
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/kanidm
   destination:

--- a/apps/kube-prometheus-stack.yaml
+++ b/apps/kube-prometheus-stack.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: kube-prometheus-stack
         valueFiles:
           - $values/helm-values/kube-prometheus-stack/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/kube-system-config.yaml
+++ b/apps/kube-system-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: platform
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/kube-system
   destination:

--- a/apps/kyverno.yaml
+++ b/apps/kyverno.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: kyverno
         valueFiles:
           - $values/helm-values/kyverno/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/kyverno
   ignoreDifferences:

--- a/apps/loki.yaml
+++ b/apps/loki.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: loki
         valueFiles:
           - $values/helm-values/loki/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/memory.yaml
+++ b/apps/memory.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/memory
   destination:

--- a/apps/metrics-server.yaml
+++ b/apps/metrics-server.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: metrics-server
         valueFiles:
           - $values/helm-values/metrics-server/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/monitoring-config.yaml
+++ b/apps/monitoring-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: monitoring
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/monitoring
   destination:

--- a/apps/nextcloud.yaml
+++ b/apps/nextcloud.yaml
@@ -20,10 +20,10 @@ spec:
         releaseName: valkey
         valueFiles:
           - $values/helm-values/valkey/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/nextcloud
   destination:

--- a/apps/nfs-provisioner.yaml
+++ b/apps/nfs-provisioner.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: nfs-provisioner
         valueFiles:
           - $values/helm-values/nfs-provisioner/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/nfs-provisioner
   destination:

--- a/apps/oauth2-proxy-config.yaml
+++ b/apps/oauth2-proxy-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: security
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/oauth2-proxy
   destination:

--- a/apps/oauth2-proxy-hubble.yaml
+++ b/apps/oauth2-proxy-hubble.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: oauth2-proxy-hubble
         valueFiles:
           - $values/helm-values/oauth2-proxy-hubble/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/oauth2-proxy-rss.yaml
+++ b/apps/oauth2-proxy-rss.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: oauth2-proxy-rss
         valueFiles:
           - $values/helm-values/oauth2-proxy-rss/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/oauth2-proxy-seaweedfs.yaml
+++ b/apps/oauth2-proxy-seaweedfs.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: oauth2-proxy-seaweedfs
         valueFiles:
           - $values/helm-values/oauth2-proxy-seaweedfs/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/ollama.yaml
+++ b/apps/ollama.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: ollama
         valueFiles:
           - $values/helm-values/ollama/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/ollama
   destination:

--- a/apps/qdrant.yaml
+++ b/apps/qdrant.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: qdrant
         valueFiles:
           - $values/helm-values/qdrant/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/qdrant
   destination:

--- a/apps/qnap-csi.yaml
+++ b/apps/qnap-csi.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   project: storage
   sources:
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: kustomize/qnap-csi
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/trident
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/storage
   destination:

--- a/apps/reloader.yaml
+++ b/apps/reloader.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: reloader
         valueFiles:
           - $values/helm-values/reloader/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/rss.yaml
+++ b/apps/rss.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: apps
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/rss
   destination:

--- a/apps/seaweedfs-config.yaml
+++ b/apps/seaweedfs-config.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: storage
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/seaweedfs
   destination:

--- a/apps/seaweedfs.yaml
+++ b/apps/seaweedfs.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: seaweedfs
         valueFiles:
           - $values/helm-values/seaweedfs/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/secrets.yaml
+++ b/apps/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: security
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/secrets
   destination:

--- a/apps/smartctl-exporter.yaml
+++ b/apps/smartctl-exporter.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: smartctl-exporter
         valueFiles:
           - $values/helm-values/smartctl-exporter/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/spin-operator.yaml
+++ b/apps/spin-operator.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: spin-operator
         valueFiles:
           - $values/helm-values/spin-operator/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/spin-operator
   destination:

--- a/apps/talos-build.yaml
+++ b/apps/talos-build.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: argo
   source:
-    repoURL: https://github.com/Tsuguya/home-cluster.git
+    repoURL: https://github.com/Tsuguya-HC/home-cluster.git
     targetRevision: main
     path: manifests/talos-build
   destination:

--- a/apps/taskflow.yaml
+++ b/apps/taskflow.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   project: ai
   sources:
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: kustomize/taskflow
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/taskflow-system
   destination:

--- a/apps/tempo.yaml
+++ b/apps/tempo.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: tempo
         valueFiles:
           - $values/helm-values/tempo/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/tetragon.yaml
+++ b/apps/tetragon.yaml
@@ -13,7 +13,7 @@ spec:
         releaseName: tetragon
         valueFiles:
           - $values/helm-values/tetragon/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
   destination:

--- a/apps/trivy-operator.yaml
+++ b/apps/trivy-operator.yaml
@@ -13,10 +13,10 @@ spec:
         releaseName: trivy-operator
         valueFiles:
           - $values/helm-values/trivy-operator/values.yaml
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       ref: values
-    - repoURL: https://github.com/Tsuguya/home-cluster.git
+    - repoURL: https://github.com/Tsuguya-HC/home-cluster.git
       targetRevision: main
       path: manifests/trivy-system
   destination:

--- a/manifests/argo/pluto-check.yaml
+++ b/manifests/argo/pluto-check.yaml
@@ -175,7 +175,7 @@ spec:
           rm -f /tmp/app-key.pem
 
           echo "=== Cloning home-cluster ==="
-          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/home-cluster.git" /tmp/workspace
+          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya-HC/home-cluster.git" /tmp/workspace
           cd /tmp/workspace
 
           echo "[detect-all-in-cluster]"
@@ -211,7 +211,7 @@ spec:
           fi
 
           echo "=== Creating signed commit via GitHub GraphQL API ==="
-          REPO="Tsuguya/home-cluster"
+          REPO="Tsuguya-HC/home-cluster"
           BRANCH="fix/deprecated-api-$(date +%Y%m%d-%H%M%S)"
           BASE_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
           gh api "repos/${REPO}/git/refs" --method POST --input - <<JEOF

--- a/manifests/argo/renovate-webhook-sensor.yaml
+++ b/manifests/argo/renovate-webhook-sensor.yaml
@@ -105,7 +105,7 @@ spec:
                 arguments:
                   parameters:
                     - name: repositories
-                      value: '["Tsuguya/home-cluster"]'
+                      value: '["Tsuguya-HC/home-cluster"]'
     - template:
         name: renovate-home-infra
         conditions: "home-infra"

--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: repositories
-        value: '["Tsuguya/home-cluster","Tsuguya/home-infra","Tsuguya/home-cloudflare","Tsuguya/home-trading"]'
+        value: '["Tsuguya-HC/home-cluster","Tsuguya/home-infra","Tsuguya/home-cloudflare","Tsuguya/home-trading"]'
   synchronization:
     mutexes:
       - name: renovate

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -179,7 +179,7 @@ spec:
       active: false
       contentType: json
     renovate-home-cluster:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: home-cluster
       webhook:
         endpoint: /renovate-home-cluster

--- a/manifests/argocd/appproject-ai.yaml
+++ b/manifests/argocd/appproject-ai.yaml
@@ -8,7 +8,7 @@ spec:
   sourceRepos:
     - https://qdrant.github.io/qdrant-helm
     - https://helm.otwld.com/
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: qdrant

--- a/manifests/argocd/appproject-apps.yaml
+++ b/manifests/argocd/appproject-apps.yaml
@@ -9,7 +9,7 @@ spec:
     - https://nextcloud.github.io/helm/
     - https://valkey.io/valkey-helm/
     - https://helm.goharbor.io
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
     # trading のマニフェストは private リポに置く
     # （CNP の egress ルールが取引先とデータソースを列挙するため）
     - https://github.com/Tsuguya/home-trading.git

--- a/manifests/argocd/appproject-argo.yaml
+++ b/manifests/argocd/appproject-argo.yaml
@@ -7,7 +7,7 @@ spec:
   description: Argo ecosystem (argo-events, argo-workflows)
   sourceRepos:
     - https://argoproj.github.io/argo-helm
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
     - https://github.com/Tsuguya/home-rss.git
   destinations:
     - server: https://kubernetes.default.svc

--- a/manifests/argocd/appproject-monitoring.yaml
+++ b/manifests/argocd/appproject-monitoring.yaml
@@ -9,7 +9,7 @@ spec:
     - https://grafana.github.io/helm-charts
     - https://grafana-community.github.io/helm-charts
     - https://prometheus-community.github.io/helm-charts
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: monitoring

--- a/manifests/argocd/appproject-networking.yaml
+++ b/manifests/argocd/appproject-networking.yaml
@@ -8,7 +8,7 @@ spec:
   sourceRepos:
     - https://charts.jetstack.io
     - https://kubernetes-sigs.github.io/external-dns
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
     - https://github.com/kubernetes-sigs/gateway-api.git
   destinations:
     - server: https://kubernetes.default.svc

--- a/manifests/argocd/appproject-platform.yaml
+++ b/manifests/argocd/appproject-platform.yaml
@@ -11,7 +11,7 @@ spec:
     - https://kubernetes-sigs.github.io/metrics-server
     - https://stakater.github.io/stakater-charts
     - ghcr.io/spinframework/charts
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: argocd

--- a/manifests/argocd/appproject-security.yaml
+++ b/manifests/argocd/appproject-security.yaml
@@ -11,7 +11,7 @@ spec:
     - https://oauth2-proxy.github.io/manifests
     - https://aquasecurity.github.io/helm-charts
     - https://kyverno.github.io/kyverno/
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: '*'

--- a/manifests/argocd/appproject-storage.yaml
+++ b/manifests/argocd/appproject-storage.yaml
@@ -10,7 +10,7 @@ spec:
     - https://github.com/qnap-dev/QNAP-CSI-PlugIn.git
     - https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
     - https://seaweedfs.github.io/seaweedfs/helm
-    - https://github.com/Tsuguya/home-cluster.git
+    - https://github.com/Tsuguya-HC/home-cluster.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: cnpg-system

--- a/manifests/argocd/netpol-repo-server.yaml
+++ b/manifests/argocd/netpol-repo-server.yaml
@@ -20,6 +20,7 @@ spec:
   egress:
     - toFQDNs:
         - matchName: "github.com"
+        - matchName: "api.github.com"
         - matchName: "argoproj.github.io"
         - matchName: "grafana.github.io"
         - matchName: "grafana-community.github.io"

--- a/manifests/claude-code/cnp-doc-audit-cronworkflow.yaml
+++ b/manifests/claude-code/cnp-doc-audit-cronworkflow.yaml
@@ -16,7 +16,7 @@ spec:
     arguments:
       parameters:
         - name: repo
-          value: Tsuguya/home-cluster
+          value: Tsuguya-HC/home-cluster
         - name: branch
           value: doc-audit/cnp
         - name: skip-if-pr-exists

--- a/manifests/claude-code/wf-creator-wft.yaml
+++ b/manifests/claude-code/wf-creator-wft.yaml
@@ -83,7 +83,7 @@ spec:
             - |
               export GITHUB_TOKEN=$(cat /github-token/token)
               git config --global --add safe.directory /workspace
-              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/home-cluster.git" /workspace
+              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya-HC/home-cluster.git" /workspace
               cd /workspace
               git config user.name "tgy-cluster-bot[bot]"
               git config user.email "tgy-cluster-bot[bot]@users.noreply.github.com"
@@ -189,7 +189,7 @@ spec:
             ## Git コミット（署名付き）
             git commit + git push の代わりに、github-signed-commit.sh を使うこと。
             1. git add でファイルをステージ
-            2. /workspace/.bin/github-signed-commit.sh -r Tsuguya/home-cluster -m 'コミットメッセージ' を実行
+            2. /workspace/.bin/github-signed-commit.sh -r Tsuguya-HC/home-cluster -m 'コミットメッセージ' を実行
             これにより GitHub API 経由で署名付きコミットが作成され、ローカルも同期される。
             PR 作成は署名コミット後に gh pr create で行う。"
 

--- a/manifests/claude-code/wf-improver-wft.yaml
+++ b/manifests/claude-code/wf-improver-wft.yaml
@@ -85,7 +85,7 @@ spec:
             - |
               export GITHUB_TOKEN=$(cat /github-token/token)
               git config --global --add safe.directory /workspace
-              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/home-cluster.git" /workspace
+              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya-HC/home-cluster.git" /workspace
               cd /workspace
               git config user.name "tgy-cluster-bot[bot]"
               git config user.email "tgy-cluster-bot[bot]@users.noreply.github.com"
@@ -183,7 +183,7 @@ spec:
             ## Git コミット（署名付き）
             git commit + git push の代わりに、github-signed-commit.sh を使うこと。
             1. git add でファイルをステージ
-            2. /workspace/.bin/github-signed-commit.sh -r Tsuguya/home-cluster -m 'コミットメッセージ' を実行
+            2. /workspace/.bin/github-signed-commit.sh -r Tsuguya-HC/home-cluster -m 'コミットメッセージ' を実行
             これにより GitHub API 経由で署名付きコミットが作成され、ローカルも同期される。
             PR 作成は署名コミット後に gh pr create で行う。"
 

--- a/manifests/secrets/argocd-github-app-repo-creds.yaml
+++ b/manifests/secrets/argocd-github-app-repo-creds.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-app-repo-creds
+  namespace: argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: github-app-repo-creds
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repo-creds
+      data:
+        url: "https://github.com/Tsuguya-HC"
+        type: "git"
+        githubAppID: "2998228"
+        githubAppInstallationID: "157474973"
+        githubAppPrivateKey: "{{ .privateKey }}"
+  data:
+    - secretKey: privateKey
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: github-app-private-key
+        property: private-key
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -191,7 +191,7 @@
         "our own reusable workflow only delays fixes to the thing that gates every",
         "other check."
       ],
-      "matchPackageNames": ["Tsuguya/**"],
+      "matchPackageNames": ["Tsuguya/**", "Tsuguya-HC/**"],
       "minimumReleaseAge": "0"
     },
     {
@@ -302,7 +302,7 @@
         "helpers:pinGitHubActionDigests would otherwise do just that."
       ],
       "matchManagers": ["github-actions"],
-      "matchDepNames": ["Tsuguya/home-cluster"],
+      "matchDepNames": ["Tsuguya-HC/home-cluster"],
       "enabled": false
     },
     {


### PR DESCRIPTION
home-cluster was transferred to the Tsuguya-HC organization. GitHub redirects the old URL, but Argo CD webhook matching, the Argo Events GitHub EventSource (`owner`) and the Renovate repository lists compare the owner literally, so every reference is updated explicitly. `renovate.jsonc` also treats `Tsuguya-HC/**` as first-party (no soak).

A follow-up commit switches the Argo CD repo credential for `https://github.com/Tsuguya-HC` to GitHub App auth once tgy-cluster-bot is installed on the org (the existing fine-grained PAT is scoped to the personal account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S