### PR TITLE
Resolve the GitHub App installation from the target repository

### DIFF
--- a/manifests/argo/aqua-checksum.yaml
+++ b/manifests/argo/aqua-checksum.yaml
@@ -68,7 +68,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -94,7 +94,7 @@ spec:
             limits:
               memory: 64Mi
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |

--- a/manifests/argo/aqua-checksum.yaml
+++ b/manifests/argo/aqua-checksum.yaml
@@ -73,8 +73,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{workflow.parameters.repository}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/argo/cluster-discord-notify-wft.yaml
+++ b/manifests/argo/cluster-discord-notify-wft.yaml
@@ -6,7 +6,7 @@ spec:
   templates:
     - name: send
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         resources:
           requests:
             cpu: 10m

--- a/manifests/argo/horenso-maintenance.yaml
+++ b/manifests/argo/horenso-maintenance.yaml
@@ -37,7 +37,7 @@ spec:
         labels:
           horenso-maintenance: "true"
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         resources:
           requests:
             cpu: 10m

--- a/manifests/argo/image-digest-audit.yaml
+++ b/manifests/argo/image-digest-audit.yaml
@@ -85,7 +85,7 @@ spec:
         labels:
           image-digest-audit: "true"
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         resources:
           requests:
             cpu: 10m

--- a/manifests/argo/pluto-check.yaml
+++ b/manifests/argo/pluto-check.yaml
@@ -155,8 +155,8 @@ spec:
                 key: private-key
           - name: GITHUB_APP_ID
             value: "2998228"
-          - name: GITHUB_APP_INSTALLATION_ID
-            value: "113765957"
+          - name: GITHUB_REPO
+            value: "Tsuguya-HC/home-cluster"
         source: |
           set -euo pipefail
 
@@ -166,10 +166,16 @@ spec:
           HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 -w 0 | tr '+/' '-_' | tr -d '=')
           PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 600))" "$GITHUB_APP_ID" | base64 -w 0 | tr '+/' '-_' | tr -d '=')
           SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign /tmp/app-key.pem -binary | base64 -w 0 | tr '+/' '-_' | tr -d '=')
-          GITHUB_TOKEN=$(curl -s -X POST \
-            -H "Authorization: Bearer ${HEADER}.${PAYLOAD}.${SIGNATURE}" \
+          JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+          INSTALLATION_ID=$(curl -sf \
+            -H "Authorization: Bearer ${JWT}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+            "https://api.github.com/repos/${GITHUB_REPO}/installation" \
+            | jq -r '.id')
+          GITHUB_TOKEN=$(curl -sf -X POST \
+            -H "Authorization: Bearer ${JWT}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens" \
             | jq -r '.token')
           export GITHUB_TOKEN
           rm -f /tmp/app-key.pem

--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: repositories
-        value: '["Tsuguya-HC/home-cluster","Tsuguya/home-infra","Tsuguya/home-cloudflare","Tsuguya/home-trading"]'
+        value: '["Tsuguya-HC/home-cluster"]'
   synchronization:
     mutexes:
       - name: renovate
@@ -68,8 +68,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{=jsonpath(workflow.parameters.repositories, '$[0]')}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -156,3 +156,25 @@ spec:
   workflowSpec:
     workflowTemplateRef:
       name: renovate
+---
+# One installation token covers one account, so repositories under the
+# personal account run separately from the organization's. The mutex on the
+# template serialises the two runs.
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: renovate-periodic-personal
+  namespace: argo
+spec:
+  schedules:
+    - "30 */4 * * *"
+  timezone: Asia/Tokyo
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  workflowSpec:
+    workflowTemplateRef:
+      name: renovate
+    arguments:
+      parameters:
+        - name: repositories
+          value: '["Tsuguya/home-infra","Tsuguya/home-cloudflare","Tsuguya/home-trading"]'

--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -63,7 +63,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID

--- a/manifests/argo/task-status-sync-sensor.yaml
+++ b/manifests/argo/task-status-sync-sensor.yaml
@@ -45,7 +45,7 @@ spec:
                       runAsUser: 65532
                       runAsNonRoot: true
                     script:
-                      image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+                      image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
                       command: [sh]
                       source: |
                         TASK_ID="{{workflow.parameters.task-id}}"

--- a/manifests/argo/tofu-cloudflare.yaml
+++ b/manifests/argo/tofu-cloudflare.yaml
@@ -78,8 +78,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/home-cloudflare"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -192,8 +192,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/home-cloudflare"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/argo/tofu-cloudflare.yaml
+++ b/manifests/argo/tofu-cloudflare.yaml
@@ -73,7 +73,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -187,7 +187,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -213,7 +213,7 @@ spec:
             limits:
               memory: 64Mi
         - name: copy-tools
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - cp /usr/local/bin/jq /usr/local/bin/gh /tools/

--- a/manifests/argo/tofu-harbor.yaml
+++ b/manifests/argo/tofu-harbor.yaml
@@ -38,8 +38,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/home-harbor"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -155,8 +155,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/home-harbor"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/argo/tofu-harbor.yaml
+++ b/manifests/argo/tofu-harbor.yaml
@@ -33,7 +33,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -150,7 +150,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -176,7 +176,7 @@ spec:
             limits:
               memory: 64Mi
         - name: copy-tools
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - cp /usr/local/bin/jq /usr/local/bin/gh /tools/

--- a/manifests/argo/tofu-unifi.yaml
+++ b/manifests/argo/tofu-unifi.yaml
@@ -29,7 +29,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -55,7 +55,7 @@ spec:
             limits:
               memory: 64Mi
         - name: copy-tools
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - cp /usr/local/bin/jq /usr/local/bin/gh /tools/

--- a/manifests/argo/tofu-unifi.yaml
+++ b/manifests/argo/tofu-unifi.yaml
@@ -34,8 +34,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/home-unifi"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/argo/upgrade-k8s.yaml
+++ b/manifests/argo/upgrade-k8s.yaml
@@ -125,7 +125,7 @@ spec:
 
     - name: validate
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         resources:
           requests:
             cpu: 10m

--- a/manifests/claude-code/adjudicator-wft.yaml
+++ b/manifests/claude-code/adjudicator-wft.yaml
@@ -172,7 +172,7 @@ spec:
         runAsGroup: 65532
         fsGroup: 65532
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |
@@ -236,7 +236,7 @@ spec:
         runAsUser: 65532
         runAsNonRoot: true
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |

--- a/manifests/claude-code/alert-investigate-wft.yaml
+++ b/manifests/claude-code/alert-investigate-wft.yaml
@@ -112,7 +112,7 @@ spec:
         runAsUser: 65532
         runAsNonRoot: true
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |

--- a/manifests/claude-code/claude-code-generic-wft.yaml
+++ b/manifests/claude-code/claude-code-generic-wft.yaml
@@ -71,8 +71,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{workflow.parameters.repo}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -138,8 +138,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{workflow.parameters.repo}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -252,8 +252,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{workflow.parameters.repo}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/claude-code/claude-code-generic-wft.yaml
+++ b/manifests/claude-code/claude-code-generic-wft.yaml
@@ -66,7 +66,7 @@ spec:
         runAsNonRoot: true
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -92,7 +92,7 @@ spec:
             limits:
               memory: 64Mi
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           export GITHUB_TOKEN=$(cat /github-token/token)
@@ -133,7 +133,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -159,7 +159,7 @@ spec:
             limits:
               memory: 64Mi
         - name: setup
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |
@@ -247,7 +247,7 @@ spec:
         runAsNonRoot: true
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -273,7 +273,7 @@ spec:
             limits:
               memory: 64Mi
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           set -eu

--- a/manifests/claude-code/cluster-observe-cwf.yaml
+++ b/manifests/claude-code/cluster-observe-cwf.yaml
@@ -26,7 +26,7 @@ spec:
           runAsGroup: 65532
           fsGroup: 65532
         container:
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/cnp-check-cwf.yaml
+++ b/manifests/claude-code/cnp-check-cwf.yaml
@@ -121,7 +121,7 @@ spec:
           fsGroup: 65532
         initContainers:
           - name: prepare
-            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
             command: [sh, -c]
             args:
               - |
@@ -237,7 +237,7 @@ spec:
           runAsUser: 65532
           runAsNonRoot: true
         container:
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/horenso-verify-wft.yaml
+++ b/manifests/claude-code/horenso-verify-wft.yaml
@@ -115,7 +115,7 @@ spec:
             limits: {memory: 512Mi}
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}

--- a/manifests/claude-code/horenso-verify-wft.yaml
+++ b/manifests/claude-code/horenso-verify-wft.yaml
@@ -119,7 +119,7 @@ spec:
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
-            - {name: GITHUB_APP_INSTALLATION_ID, value: "113765957"}
+            - {name: GITHUB_REPO, value: "{{inputs.parameters.repo}}"}
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532

--- a/manifests/claude-code/implement-wft.yaml
+++ b/manifests/claude-code/implement-wft.yaml
@@ -153,7 +153,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -172,7 +172,7 @@ spec:
             requests: {cpu: 10m, memory: 32Mi}
             limits: {memory: 64Mi}
         - name: setup
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |
@@ -327,7 +327,7 @@ spec:
           agent.tgy.io/phase: checks
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
@@ -344,7 +344,7 @@ spec:
             requests: {cpu: 10m, memory: 32Mi}
             limits: {memory: 64Mi}
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           set -u
@@ -473,7 +473,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
@@ -491,7 +491,7 @@ spec:
             requests: {cpu: 10m, memory: 32Mi}
             limits: {memory: 64Mi}
         - name: prepare
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |
@@ -598,7 +598,7 @@ spec:
           - {name: check}
           - {name: review}
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           set -u
@@ -640,7 +640,7 @@ spec:
     - name: ready-for-review
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
@@ -657,7 +657,7 @@ spec:
             requests: {cpu: 10m, memory: 32Mi}
             limits: {memory: 64Mi}
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           set -eu
@@ -687,7 +687,7 @@ spec:
         parameters: [{name: verdict}]
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
@@ -704,7 +704,7 @@ spec:
             requests: {cpu: 10m, memory: 32Mi}
             limits: {memory: 64Mi}
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           set -u

--- a/manifests/claude-code/implement-wft.yaml
+++ b/manifests/claude-code/implement-wft.yaml
@@ -158,8 +158,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{workflow.parameters.repo}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -331,7 +331,7 @@ spec:
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
-            - {name: GITHUB_APP_INSTALLATION_ID, value: "113765957"}
+            - {name: GITHUB_REPO, value: "{{workflow.parameters.repo}}"}
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -477,7 +477,7 @@ spec:
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
-            - {name: GITHUB_APP_INSTALLATION_ID, value: "113765957"}
+            - {name: GITHUB_REPO, value: "{{workflow.parameters.repo}}"}
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
@@ -644,7 +644,7 @@ spec:
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
-            - {name: GITHUB_APP_INSTALLATION_ID, value: "113765957"}
+            - {name: GITHUB_REPO, value: "{{workflow.parameters.repo}}"}
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -691,7 +691,7 @@ spec:
           command: [github-auth.sh]
           env:
             - {name: GITHUB_APP_ID, value: "2998228"}
-            - {name: GITHUB_APP_INSTALLATION_ID, value: "113765957"}
+            - {name: GITHUB_REPO, value: "{{workflow.parameters.repo}}"}
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/claude-code/task-executor-write-wft.yaml
+++ b/manifests/claude-code/task-executor-write-wft.yaml
@@ -9,6 +9,8 @@ spec:
   entrypoint: main
   arguments:
     parameters:
+      - name: repo
+        value: Tsuguya-HC/home-cluster
       - name: task-id
       - name: task-title
       - name: task-description
@@ -61,8 +63,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{workflow.parameters.repo}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/claude-code/task-executor-write-wft.yaml
+++ b/manifests/claude-code/task-executor-write-wft.yaml
@@ -58,7 +58,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -84,7 +84,7 @@ spec:
             limits:
               memory: 64Mi
         - name: setup
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/taskflow-cnp-check.yaml
+++ b/manifests/claude-code/taskflow-cnp-check.yaml
@@ -126,7 +126,7 @@ spec:
           # 人間への報告。framework の関心事ではない（設計 §7 / §9）。SIGTERM で
           # report.md があれば Discord に投げ、無ければ「判定なし」を投げる。
           - name: notify
-            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
             restartPolicy: Always
             command: [sh, -c]
             args:

--- a/manifests/claude-code/verify-skip-wft.yaml
+++ b/manifests/claude-code/verify-skip-wft.yaml
@@ -33,7 +33,7 @@ spec:
           - name: repo
           - name: branch
       script:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh]
         source: |
           printf '%s' pass > /tmp/verdict.txt

--- a/manifests/claude-code/weekly-inventory-cwf.yaml
+++ b/manifests/claude-code/weekly-inventory-cwf.yaml
@@ -27,7 +27,7 @@ spec:
           runAsGroup: 65532
           fsGroup: 65532
         container:
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/wf-creator-wft.yaml
+++ b/manifests/claude-code/wf-creator-wft.yaml
@@ -56,8 +56,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya-HC/home-cluster"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/claude-code/wf-creator-wft.yaml
+++ b/manifests/claude-code/wf-creator-wft.yaml
@@ -51,7 +51,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -77,7 +77,7 @@ spec:
             limits:
               memory: 64Mi
         - name: setup
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/wf-improver-wft.yaml
+++ b/manifests/claude-code/wf-improver-wft.yaml
@@ -53,7 +53,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -79,7 +79,7 @@ spec:
             limits:
               memory: 64Mi
         - name: setup
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/wf-improver-wft.yaml
+++ b/manifests/claude-code/wf-improver-wft.yaml
@@ -58,8 +58,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya-HC/home-cluster"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/claude-code/workflowtemplate.yaml
+++ b/manifests/claude-code/workflowtemplate.yaml
@@ -116,7 +116,7 @@ spec:
         fsGroup: 65532
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -142,7 +142,7 @@ spec:
             limits:
               memory: 64Mi
         - name: setup
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [sh, -c]
           args:
             - |

--- a/manifests/claude-code/workflowtemplate.yaml
+++ b/manifests/claude-code/workflowtemplate.yaml
@@ -121,8 +121,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/home-rss"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -109,8 +109,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "{{=sprig.trimPrefix('github.com/', workflow.parameters['repo-url'])}}"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/image-build/workflowtemplate-single-repo.yaml
+++ b/manifests/image-build/workflowtemplate-single-repo.yaml
@@ -104,7 +104,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -332,7 +332,7 @@ spec:
             limits:
               memory: 64Mi
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |
@@ -433,7 +433,7 @@ spec:
             limits:
               memory: 64Mi
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |

--- a/manifests/image-build/workflowtemplate.yaml
+++ b/manifests/image-build/workflowtemplate.yaml
@@ -70,8 +70,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/images"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -205,8 +205,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/images"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true

--- a/manifests/image-build/workflowtemplate.yaml
+++ b/manifests/image-build/workflowtemplate.yaml
@@ -65,7 +65,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -200,7 +200,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -416,7 +416,7 @@ spec:
             limits:
               memory: 64Mi
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -116,7 +116,7 @@ spec:
         - name: tmp
           emptyDir: {}
       container:
-        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
         command: [sh, -c]
         args:
           - |
@@ -173,7 +173,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -311,7 +311,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID
@@ -485,7 +485,7 @@ spec:
             secretName: github-app-private-key
       initContainers:
         - name: github-auth
-          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5309221e4c5721f9b7c091195db1a592320b88390734bb745f8eb69041ddf3ed
+          image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:5e9b27dfa5042f7d9a3518c305283c1e665ebca44645d740fb592b48fedca627
           command: [github-auth.sh]
           env:
             - name: GITHUB_APP_ID

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -178,8 +178,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/talos-custom-build"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -316,8 +316,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/talos-custom-build"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -490,8 +490,8 @@ spec:
           env:
             - name: GITHUB_APP_ID
               value: "2998228"
-            - name: GITHUB_APP_INSTALLATION_ID
-              value: "113765957"
+            - name: GITHUB_REPO
+              value: "Tsuguya/talos-custom-build"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true


### PR DESCRIPTION
home-cluster now lives under the Tsuguya-HC organization, which is a separate app installation (`157474973`) from the personal account (`113765957`). Every workflow pinned the personal id, so anything touching home-cluster (renovate, pluto-check, aqua-checksum, wf-creator / wf-improver / cnp-doc-audit) was minting a token that cannot see it. Verified: the personal installation's repository list no longer contains home-cluster.

- `github-auth.sh` (images#40, digest bumped here) takes `GITHUB_REPO=owner/name` and resolves the installation via `GET /repos/{owner}/{repo}/installation`; no installation id remains in `manifests/`
- Fixed-target templates name their repo; parameterised ones (`claude-code-generic`, `implement`, `horenso-verify`, `aqua-checksum`, `image-build-single-repo`) derive it from their argument
- `task-executor-write` gains a `repo` parameter (default `Tsuguya-HC/home-cluster`)
- `pluto-check` carries its own inline JWT flow; same lookup added there
- Renovate: one token covers one account, so the periodic run is split into `renovate-periodic` (org) and `renovate-periodic-personal`; the template mutex serialises them. Webhook sensor runs were already single-repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S