### PR TITLE
Follow home-actions and digest-cooldown to Tsuguya-HC; admit the new home-rss URL

### DIFF
--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write   # store first-seen instants in a PR comment
       contents: read         # read the diff
     steps:
-      - uses: Tsuguya/digest-cooldown@8cef1af948c0b09c5b1fd900deeb65bb3a7c8ba8 # v1.0.0
+      - uses: Tsuguya-HC/digest-cooldown@8cef1af948c0b09c5b1fd900deeb65bb3a7c8ba8 # v1.0.0
         with:
           cooldown-days: 3
           # First-party registries: their digests are built and signed by our

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -205,7 +205,7 @@ jobs:
   lint-workflows:
     needs: detect
     if: ${{ needs.detect.outputs.workflows == 'true' }}
-    uses: Tsuguya/home-actions/.github/workflows/lint-workflows.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
+    uses: Tsuguya-HC/home-actions/.github/workflows/lint-workflows.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
     permissions:
       contents: read
 
@@ -215,7 +215,7 @@ jobs:
   lint-renovate:
     needs: detect
     if: ${{ needs.detect.outputs.renovate == 'true' }}
-    uses: Tsuguya/home-actions/.github/workflows/lint-renovate.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
+    uses: Tsuguya-HC/home-actions/.github/workflows/lint-renovate.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
     permissions:
       contents: read
 
@@ -226,7 +226,7 @@ jobs:
   lint-aqua:
     needs: detect
     if: ${{ needs.detect.outputs.aqua == 'true' }}
-    uses: Tsuguya/home-actions/.github/workflows/lint-aqua.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
+    uses: Tsuguya-HC/home-actions/.github/workflows/lint-aqua.yml@10834ead7a2c2ca71677a6b818cd066d329eacbb # v1.2.0
     permissions:
       contents: read
 

--- a/manifests/argocd/appproject-argo.yaml
+++ b/manifests/argocd/appproject-argo.yaml
@@ -9,6 +9,7 @@ spec:
     - https://argoproj.github.io/argo-helm
     - https://github.com/Tsuguya-HC/home-cluster.git
     - https://github.com/Tsuguya/home-rss.git
+    - https://github.com/Tsuguya-HC/home-rss.git
   destinations:
     - server: https://kubernetes.default.svc
       namespace: argo


### PR DESCRIPTION
Reusable workflow references (`uses: Tsuguya/home-actions/...`) are not redirected when the owning repository moves — a rerun of Lint failed at startup — so every reference now names `Tsuguya-HC`. Composite/JS actions (`Tsuguya/digest-cooldown@sha`) do resolve through the redirect, but are updated for consistency. The argo AppProject admits the new home-rss URL next to the old one so the Application can switch in a later PR (see the AppProject/repoURL ordering lesson from #722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S