### PR TITLE
Follow the remaining transferred repositories to Tsuguya-HC

### DIFF
--- a/docs/secureboot.md
+++ b/docs/secureboot.md
@@ -163,7 +163,7 @@ Setup Mode でありさえすれば systemd-boot が登録してくれる。2026
 逆（Setup Mode だけにして Secure Boot は Enabled のまま）だと、**USB 自体が Secure Boot Violation で弾かれて
 enroll 画面に到達できない**。仕様上 Setup Mode では署名検証しないはずだが、この AMI 実装は弾く。
 
-0. **ISO を焼く前に中身を検証**（[GitHub Release](https://github.com/Tsuguya/talos-custom-build/releases) の `metal-amd64-secureboot.iso`）:
+0. **ISO を焼く前に中身を検証**（[GitHub Release](https://github.com/Tsuguya-HC/talos-custom-build/releases) の `metal-amd64-secureboot.iso`）:
    ```bash
    # ESP をマウントして確認（ISO 内のパーティション2）
    sbverify --list EFI/Linux/Talos-*.efi   # → issuer: /O=Test UKI Signing Key なら署名済み

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# taskflow のコントローラ本体は Tsuguya/taskflow リポの config/default（CRD・RBAC・
+# taskflow のコントローラ本体は Tsuguya-HC/taskflow リポの config/default（CRD・RBAC・
 # Deployment）をそのまま remote base として取り込む。home-cluster 側が持つのは
 # イメージの差し替えとクラスタ固有の patch だけ（設計 §14: 「どう動くか」は taskflow、
 # 「何ができるか」は home-cluster）。ref は commit SHA で固定し Renovate が追う。
 resources:
-  - https://github.com/Tsuguya/taskflow//config/default?ref=f96dbf9be674dcfaf803900541f4bbb0c3eea8bf
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=f96dbf9be674dcfaf803900541f4bbb0c3eea8bf
 
 images:
   - name: controller

--- a/manifests/argo/pxe-sync.yaml
+++ b/manifests/argo/pxe-sync.yaml
@@ -131,16 +131,16 @@ spec:
           - |
             set -euo pipefail
 
-            echo "=== Fetching latest release from Tsuguya/talos-custom-build ==="
-            TAG=$(wget -qO- https://api.github.com/repos/Tsuguya/talos-custom-build/releases/latest | grep -o '"tag_name":[^,]*' | grep -o '"[^"]*"$' | tr -d '"')
+            echo "=== Fetching latest release from Tsuguya-HC/talos-custom-build ==="
+            TAG=$(wget -qO- https://api.github.com/repos/Tsuguya-HC/talos-custom-build/releases/latest | grep -o '"tag_name":[^,]*' | grep -o '"[^"]*"$' | tr -d '"')
             echo "Latest release: ${TAG}"
 
             ASSETS_DIR=/pxe/assets
             echo "=== Downloading vmlinuz-amd64 ==="
-            wget -qO "${ASSETS_DIR}/vmlinuz.tmp" "https://github.com/Tsuguya/talos-custom-build/releases/download/${TAG}/vmlinuz-amd64"
+            wget -qO "${ASSETS_DIR}/vmlinuz.tmp" "https://github.com/Tsuguya-HC/talos-custom-build/releases/download/${TAG}/vmlinuz-amd64"
 
             echo "=== Downloading initramfs-amd64.xz ==="
-            wget -qO "${ASSETS_DIR}/initramfs.xz.tmp" "https://github.com/Tsuguya/talos-custom-build/releases/download/${TAG}/initramfs-amd64.xz"
+            wget -qO "${ASSETS_DIR}/initramfs.xz.tmp" "https://github.com/Tsuguya-HC/talos-custom-build/releases/download/${TAG}/initramfs-amd64.xz"
 
             echo "=== Atomic replace ==="
             mv "${ASSETS_DIR}/vmlinuz.tmp" "${ASSETS_DIR}/vmlinuz"
@@ -164,7 +164,7 @@ spec:
         - name: git-clone
           image: alpine/git:v2.54.0@sha256:6f8eae2205a85c51106a9650e574a37fb1d5e4f645e5f6ea57cb57b9462cd4cf
           command: [git, clone, --depth, "1"]
-          args: ["https://github.com/Tsuguya/home-infra.git", /workspace]
+          args: ["https://github.com/Tsuguya-HC/home-infra.git", /workspace]
           volumeMounts:
             - name: workspace
               mountPath: /workspace

--- a/manifests/argo/renovate-webhook-sensor.yaml
+++ b/manifests/argo/renovate-webhook-sensor.yaml
@@ -124,7 +124,7 @@ spec:
                 arguments:
                   parameters:
                     - name: repositories
-                      value: '["Tsuguya/home-infra"]'
+                      value: '["Tsuguya-HC/home-infra"]'
     - template:
         name: renovate-home-cloudflare
         conditions: "home-cloudflare"

--- a/manifests/argo/renovate.yaml
+++ b/manifests/argo/renovate.yaml
@@ -27,7 +27,7 @@ spec:
   arguments:
     parameters:
       - name: repositories
-        value: '["Tsuguya-HC/home-cluster"]'
+        value: '["Tsuguya-HC/home-cluster","Tsuguya-HC/home-infra"]'
   synchronization:
     mutexes:
       - name: renovate
@@ -177,4 +177,4 @@ spec:
     arguments:
       parameters:
         - name: repositories
-          value: '["Tsuguya/home-infra","Tsuguya/home-cloudflare","Tsuguya/home-trading"]'
+          value: '["Tsuguya/home-cloudflare","Tsuguya/home-trading"]'

--- a/manifests/argo/single-repo-build-sensor.yaml
+++ b/manifests/argo/single-repo-build-sensor.yaml
@@ -120,7 +120,7 @@ spec:
                 arguments:
                   parameters:
                     - name: repo-url
-                      value: github.com/Tsuguya/memory
+                      value: github.com/Tsuguya-HC/memory
                     - name: image-name
                       value: memory
                     - name: commit-sha
@@ -151,7 +151,7 @@ spec:
                 arguments:
                   parameters:
                     - name: repo-url
-                      value: github.com/Tsuguya/horenso
+                      value: github.com/Tsuguya-HC/horenso
                     - name: image-name
                       value: horenso
                     - name: commit-sha
@@ -219,7 +219,7 @@ spec:
                 arguments:
                   parameters:
                     - name: repo-url
-                      value: github.com/Tsuguya/taskflow
+                      value: github.com/Tsuguya-HC/taskflow
                     - name: image-name
                       value: taskflow
                     - name: commit-sha
@@ -250,7 +250,7 @@ spec:
                 arguments:
                   parameters:
                     - name: repo-url
-                      value: github.com/Tsuguya/taskflow
+                      value: github.com/Tsuguya-HC/taskflow
                     - name: image-name
                       value: agent-sidecar
                     - name: commit-sha

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -45,7 +45,7 @@ spec:
       active: false
       contentType: json
     talos-build:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: talos-custom-build
       webhook:
         endpoint: /talos-build
@@ -59,7 +59,7 @@ spec:
       active: false
       contentType: json
     home-infra:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: home-infra
       webhook:
         endpoint: /home-infra
@@ -73,7 +73,7 @@ spec:
       active: false
       contentType: json
     images:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: images
       webhook:
         endpoint: /images
@@ -87,7 +87,7 @@ spec:
       active: false
       contentType: json
     memory:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: memory
       webhook:
         endpoint: /memory
@@ -101,7 +101,7 @@ spec:
       active: false
       contentType: json
     horenso:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: horenso
       webhook:
         endpoint: /horenso
@@ -136,7 +136,7 @@ spec:
       active: false
       contentType: json
     home-rss:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: home-rss
       webhook:
         endpoint: /home-rss
@@ -150,7 +150,7 @@ spec:
       active: false
       contentType: json
     home-actions:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: home-actions
       webhook:
         endpoint: /home-actions
@@ -164,7 +164,7 @@ spec:
       active: false
       contentType: json
     taskflow:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: taskflow
       webhook:
         endpoint: /taskflow
@@ -195,7 +195,7 @@ spec:
       active: false
       contentType: json
     renovate-home-infra:
-      owner: Tsuguya
+      owner: Tsuguya-HC
       repository: home-infra
       webhook:
         endpoint: /renovate-home-infra

--- a/manifests/argo/upgrade-k8s.yaml
+++ b/manifests/argo/upgrade-k8s.yaml
@@ -142,7 +142,7 @@ spec:
 
             echo "=== Fetching diff ${BEFORE}...${AFTER} ==="
             DIFF=$(curl -fsSL -H "Accept: application/vnd.github.v3.diff" \
-              "https://api.github.com/repos/Tsuguya/home-infra/compare/${BEFORE}...${AFTER}")
+              "https://api.github.com/repos/Tsuguya-HC/home-infra/compare/${BEFORE}...${AFTER}")
 
             OLD_VER=$(echo "$DIFF" | grep '^-kubernetesVersion:' | sed 's/^-kubernetesVersion: *//' | tr -d '"v' | head -1 || true)
             NEW_VER=$(echo "$DIFF" | grep '^+kubernetesVersion:' | sed 's/^+kubernetesVersion: *//' | tr -d '"v' | head -1 || true)
@@ -174,7 +174,7 @@ spec:
             fi
 
             echo "=== Fetching talconfig.yaml at ${AFTER} ==="
-            TALCONFIG=$(curl -fsSL "https://api.github.com/repos/Tsuguya/home-infra/contents/talconfig.yaml?ref=${AFTER}" \
+            TALCONFIG=$(curl -fsSL "https://api.github.com/repos/Tsuguya-HC/home-infra/contents/talconfig.yaml?ref=${AFTER}" \
               | jq -r '.content' | base64 -d)
 
             TALOS_VER=$(echo "$TALCONFIG" | yq '.talosVersion')

--- a/manifests/argocd/appproject-argo.yaml
+++ b/manifests/argocd/appproject-argo.yaml
@@ -8,7 +8,7 @@ spec:
   sourceRepos:
     - https://argoproj.github.io/argo-helm
     - https://github.com/Tsuguya-HC/home-cluster.git
-    - https://github.com/Tsuguya/home-rss.git
+    - https://github.com/Tsuguya-HC/home-rss.git
     - https://github.com/Tsuguya-HC/home-rss.git
   destinations:
     - server: https://kubernetes.default.svc

--- a/manifests/claude-code/workflowtemplate.yaml
+++ b/manifests/claude-code/workflowtemplate.yaml
@@ -122,7 +122,7 @@ spec:
             - name: GITHUB_APP_ID
               value: "2998228"
             - name: GITHUB_REPO
-              value: "Tsuguya/home-rss"
+              value: "Tsuguya-HC/home-rss"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -148,14 +148,14 @@ spec:
             - |
               export GITHUB_TOKEN=$(cat /github-token/token)
               git config --global --add safe.directory /workspace
-              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/home-rss.git" /workspace
+              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya-HC/home-rss.git" /workspace
               cd /workspace
               git checkout -b "issue-${ISSUE_NUMBER}"
               git config user.name "tgy-cluster-bot[bot]"
               git config user.email "tgy-cluster-bot[bot]@users.noreply.github.com"
               mkdir -p /workspace/.bin
               cp /usr/local/bin/github-signed-commit.sh /workspace/.bin/
-              curl -sf -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/Tsuguya/home-rss/issues/${ISSUE_NUMBER}" | jq -r '"# Issue #\(.number): \(.title)\n\n\(.body)"' > /workspace/ISSUE.md
+              curl -sf -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/Tsuguya-HC/home-rss/issues/${ISSUE_NUMBER}" | jq -r '"# Issue #\(.number): \(.title)\n\n\(.body)"' > /workspace/ISSUE.md
               cp -R /workspace/k8s/.claude /claude-home/
           env:
             - name: HOME
@@ -196,7 +196,7 @@ spec:
             ## Git コミット（署名付き）
             git commit + git push の代わりに、github-signed-commit.sh を使うこと。
             1. git add でファイルをステージ
-            2. /workspace/.bin/github-signed-commit.sh -r Tsuguya/home-rss -m 'コミットメッセージ' を実行
+            2. /workspace/.bin/github-signed-commit.sh -r Tsuguya-HC/home-rss -m 'コミットメッセージ' を実行
             これにより GitHub API 経由で署名付きコミットが作成され、ローカルも同期される。
             PR 作成は署名コミット後に gh pr create で行う。"
             fi

--- a/manifests/image-build/workflowtemplate.yaml
+++ b/manifests/image-build/workflowtemplate.yaml
@@ -71,7 +71,7 @@ spec:
             - name: GITHUB_APP_ID
               value: "2998228"
             - name: GITHUB_REPO
-              value: "Tsuguya/images"
+              value: "Tsuguya-HC/images"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -97,7 +97,7 @@ spec:
           - |
             GITHUB_TOKEN=$(cat /github-token/token)
             cd /tmp
-            git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/images.git" repo
+            git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya-HC/images.git" repo
             cd repo
             # Every directory that holds a Dockerfile is an image.
             find . -name Dockerfile -not -path './.git/*' \
@@ -206,7 +206,7 @@ spec:
             - name: GITHUB_APP_ID
               value: "2998228"
             - name: GITHUB_REPO
-              value: "Tsuguya/images"
+              value: "Tsuguya-HC/images"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -232,7 +232,7 @@ spec:
             - |
               GITHUB_TOKEN=$(cat /github-token/token)
               git config --global --add safe.directory /workspace
-              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya/images.git" /workspace
+              git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/Tsuguya-HC/images.git" /workspace
               cd /workspace && git checkout "$COMMIT_SHA"
           env:
             - name: HOME

--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -49,7 +49,7 @@ data:
       "${SB_ISO}" \
       /tmp/vmlinuz-amd64 \
       /tmp/initramfs-amd64.xz \
-      --repo Tsuguya/talos-custom-build \
+      --repo Tsuguya-HC/talos-custom-build \
       --clobber
     echo "=== Done ==="
 
@@ -64,7 +64,7 @@ data:
     export PATH="/tmp:$PATH"
 
     gh release edit "${VERSION}" \
-      --repo Tsuguya/talos-custom-build \
+      --repo Tsuguya-HC/talos-custom-build \
       --prerelease=false \
       --notes "Custom Talos build with UFS + SecureBoot.
 

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -123,7 +123,7 @@ spec:
             set -u
             VERSION="{{inputs.parameters.version}}"
             if [ -z "$VERSION" ]; then
-              RESPONSE=$(curl -sf -m 10 https://api.github.com/repos/Tsuguya/talos-custom-build/releases/latest) || {
+              RESPONSE=$(curl -sf -m 10 https://api.github.com/repos/Tsuguya-HC/talos-custom-build/releases/latest) || {
                 echo "ERROR: GitHub API request failed" >&2
                 exit 1
               }
@@ -179,7 +179,7 @@ spec:
             - name: GITHUB_APP_ID
               value: "2998228"
             - name: GITHUB_REPO
-              value: "Tsuguya/talos-custom-build"
+              value: "Tsuguya-HC/talos-custom-build"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -317,7 +317,7 @@ spec:
             - name: GITHUB_APP_ID
               value: "2998228"
             - name: GITHUB_REPO
-              value: "Tsuguya/talos-custom-build"
+              value: "Tsuguya-HC/talos-custom-build"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true
@@ -491,7 +491,7 @@ spec:
             - name: GITHUB_APP_ID
               value: "2998228"
             - name: GITHUB_REPO
-              value: "Tsuguya/talos-custom-build"
+              value: "Tsuguya-HC/talos-custom-build"
           securityContext:
             runAsUser: 65532
             runAsNonRoot: true


### PR DESCRIPTION
images / horenso / memory / home-rss / taskflow / home-infra / talos-custom-build were transferred. EventSource `owner`, build and renovate sensors, workflow clone/API URLs, the home-rss Application + AppProject (old URL removed; new one was admitted in #725), and the Renovate crons (home-infra → org list) follow. Only the private repos (home-cloudflare / home-harbor / home-unifi / home-trading) remain under the personal account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S