### PR TITLE
Report CI Gate and digest-cooldown on merge-group commits

### DIFF
--- a/.github/workflows/_unread-values.yml
+++ b/.github/workflows/_unread-values.yml
@@ -50,11 +50,11 @@ jobs:
 
       - name: Check for values keys no chart reads
         env:
-          # オーケストレーターは pull_request でしか起動しないので、実際には
-          # 常に base SHA が入る。空になる経路（= 全チャート検査）は、将来
+          # オーケストレーターは pull_request と merge_group でしか起動しないので、
+          # 実際には常に base SHA が入る。空になる経路（= 全チャート検査）は、将来
           # workflow_dispatch や push を足したときのためにそのまま残してある。
           # 式を run の中に展開しないのは、ref をスクリプトに補間させないため。
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          BASE_SHA: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || (github.event_name == 'merge_group' && github.event.merge_group.base_sha) || '' }}
         run: |
           set -euo pipefail
           if [ -n "${BASE_SHA}" ]; then

--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -17,11 +17,15 @@ on: # zizmor: ignore[dangerous-triggers]
   schedule:
     - cron: "23 * * * *"
   workflow_dispatch:
+  # マージキューの一時 commit にも digest-cooldown を報告する。action は
+  # merge_group では diff を再評価せず、PR head で確定済みの status を転記する
+  # （キューに入れた時点で head は success 済み、group の digest はその head のもの）。
+  merge_group:
 
 permissions: {}
 
 concurrency:
-  group: digest-cooldown-${{ github.event.pull_request.number || 'scan' }}
+  group: digest-cooldown-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && github.ref) || 'scan' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write   # store first-seen instants in a PR comment
       contents: read         # read the diff
     steps:
-      - uses: Tsuguya-HC/digest-cooldown@8cef1af948c0b09c5b1fd900deeb65bb3a7c8ba8 # v1.0.0
+      - uses: Tsuguya-HC/digest-cooldown@242603d25ecfe604ed55f095b057c0e75d7e4ef0 # v1.1.0
         with:
           cooldown-days: 3
           # First-party registries: their digests are built and signed by our

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,6 +34,12 @@ on:
     # 必須チェックに流用できてしまう。leaf の実行要否を base 差分で決める以上、
     # これは fail-open になる。
     types: [opened, synchronize, reopened, edited]
+  # マージキューは main に対する一時 commit（gh-readonly-queue/main/pr-N-<sha>）
+  # の上で必須チェックを取り直す。ここで報告しないとキューの entry は永久に
+  # 待つ。detect の dorny/paths-filter は merge_group を解釈して
+  # base_sha..head_sha の git diff で判定するので、leaf の実行要否は PR と同じ
+  # 基準で決まる。
+  merge_group:
 
 # Nothing here needs the token by default. Each job names its own scope, so a
 # new job added below starts with no permissions rather than inheriting write
@@ -46,7 +52,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  # merge_group には event.number が無いので ref（キューの一時ブランチ）で分ける。
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Prerequisite for enabling a merge queue on main. Both required contexts must be reported on the queue's temporary commit:

- `Lint` subscribes to `merge_group`; dorny/paths-filter handles the event natively (`base_sha..head_sha`), `_unread-values` takes the same base; concurrency keys on `github.ref` when there is no PR number
- `digest-cooldown` subscribes to `merge_group` and moves to v1.1.0 (Tsuguya-HC/digest-cooldown#18), which mirrors the PR head's verdict onto the merge-group head, fail-closed
- `claude-fix-ci` already ignores non-`pull_request` workflow_run events

The `merge_queue` ruleset rule is added after this merges; the queue is then exercised with a real PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D99PTjghL42vwQPDFUe9S