### PR TITLE
Preserve claude exit code in alert-investigate workflow

### DIFF
--- a/manifests/claude-code/alert-investigate-wft.yaml
+++ b/manifests/claude-code/alert-investigate-wft.yaml
@@ -84,7 +84,10 @@ spec:
             ## アラート概要
             ## 調査結果
             ## 根本原因
-            ## 修正手順" | tee /report/result.txt
+            ## 修正手順" > /report/result.txt 2>&1
+            RC=$?
+            cat /report/result.txt
+            exit $RC
         env:
           - name: HOME
             value: /tmp


### PR DESCRIPTION
`claude -p ... | tee /report/result.txt` の終了ステータスは `tee` のもので常に 0。claude がリミット/認証エラーで落ちても WF は Succeeded、Discord には緑の空レポートが届いていた（リミット対策が必要な局面でこそ発火する vacuous pass）。

exit code を保持して失敗時は WF を Failed にする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYfJpGkyGbFWK5kkMnBCui