### PR TITLE
taskflow: pick up the TTL cleanup (taskflow #68)

### DIFF
--- a/.github/schemas/flow.tgy.io/task_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/task_v1alpha1.json
@@ -133,6 +133,11 @@
      "type": "object",
      "additionalProperties": false
     },
+    "expiresAt": {
+     "description": "ExpiresAt is when the controller deletes this task, set once it stops.\nThe moment is fixed here rather than derived from the flow's ttl each\ntime, so a task at Escalated keeps its date even after the flow that\nset it is edited or gone — the same reason the reserved phases need no\nflow to be terminal.",
+     "format": "date-time",
+     "type": "string"
+    },
     "history": {
      "items": {
       "description": "HistoryEntry records a completed run. This is the audit trail; the artifacts\nit points at live in object storage, never in etcd.",

--- a/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
@@ -69,12 +69,17 @@
      "type": "string"
     },
     "ttl": {
-     "description": "TTLSpec is how long a finished task sticks around. Cleanup is anchored on\nthe Task and propagates through ownerReferences; Jobs are never given a TTL\nof their own, because a Job that deletes itself takes the verdict with it.",
+     "default": {},
+     "description": "TTLSpec is how long a finished task sticks around. Cleanup is anchored on\nthe Task and propagates through ownerReferences; Jobs are never given a TTL\nof their own, because a Job that deletes itself takes the verdict with it.\n\nBoth fields default rather than stay optional: a task that never goes away\nis a row in etcd that never goes away, and etcd has been lost here twice\n(§10 \"etcd 保護のため必須\"). The defaults are the design's own example.",
      "properties": {
       "failed": {
+       "default": "168h",
+       "description": "Failed applies to a task the framework stopped: Escalated or Failed.\nA human has to look at those, so they wait longer.",
        "type": "string"
       },
       "succeeded": {
+       "default": "1h",
+       "description": "Succeeded applies to a task that stopped at a phase the flow declared\nterminal — one with no binding of its own.",
        "type": "string"
       }
      },

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -6,13 +6,13 @@ kind: Kustomization
 # イメージの差し替えとクラスタ固有の patch だけ（設計 §14: 「どう動くか」は taskflow、
 # 「何ができるか」は home-cluster）。ref は commit SHA で固定し Renovate が追う。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=f96dbf9be674dcfaf803900541f4bbb0c3eea8bf
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=037a2b2ef89b05b7adf968706973e1c9ce697919
 
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
     newTag: latest
-    digest: sha256:9a2db9aa91dbad69ae4090be6bd7e6126d8de73690c38c1bf7a7caac929168db
+    digest: sha256:4dd3ffebf242d704dcfb06db1f2109813582f656445ed1dfd31d9f30a9c0d86d
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）


### PR DESCRIPTION
taskflow #68（Task の TTL 掃除）の反映。remote base ref → 037a2b2、コントローラ image digest → 同 commit のビルド、`.github/schemas/flow.tgy.io/` を CRD から再生成（旧 CRD から既存 JSON がバイト一致で再現できる生成器で作成）。

反映後: 既存の 2 Task（cnp-check-jlvxn 完了 / cnp-check-qfs5c Escalated）が backfill で expiresAt を得て、それぞれ 1h / 168h 後に消えることを見届ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYfJpGkyGbFWK5kkMnBCui