### PR TITLE
claude-code: let cnp-check say it will not decide, and what its ending means

### DIFF
--- a/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
@@ -68,13 +68,25 @@
      "minLength": 1,
      "type": "string"
     },
+    "terminals": {
+     "additionalProperties": {
+      "description": "TerminalSeverity is what reaching one of a flow's endings means.\n\nThe framework cannot work this out. A status with no binding is where the\nflow stops, and that is all it knows: 失敗 and おわり are equally just names\nits author chose, and neither is spelled in a vocabulary the framework\nowns. So the flow says which of its endings are bad news, and only then can\nthe framework raise its voice about one.",
+      "enum": [
+       "Success",
+       "Failure"
+      ],
+      "type": "string"
+     },
+     "description": "Terminals says what this flow's endings mean. It is keyed by a phase\nnothing binds — one of the places a task stops — and says whether\nstopping there is good news. A Failure ending is the one thing that\nmakes the framework speak up about a task that finished: a warning\nevent, Ready=False, and the longer ttl, so the record is still there\nwhen somebody comes to look.\n\nOptional, and leaving it out is not the same as saying Success. A flow\nthat has not declared keeps exactly the silence it had before this\nfield existed, and its endings are reported as Undeclared rather than\nguessed at (P8). Declaring one ending does not oblige the flow to\ndeclare the rest.",
+     "type": "object"
+    },
     "ttl": {
      "default": {},
      "description": "TTLSpec is how long a finished task sticks around. Cleanup is anchored on\nthe Task and propagates through ownerReferences; Jobs are never given a TTL\nof their own, because a Job that deletes itself takes the verdict with it.\n\nBoth fields default rather than stay optional: a task that never goes away\nis a row in etcd that never goes away, and etcd has been lost here twice\n(§10 \"etcd 保護のため必須\"). The defaults are the design's own example.",
      "properties": {
       "failed": {
        "default": "168h",
-       "description": "Failed applies to a task the framework stopped: Escalated or Failed.\nA human has to look at those, so they wait longer.",
+       "description": "Failed applies to a task that stopped at Escalated or Failed, however\nit got there — the framework forcing a stop or the flow itself\ndeclaring the edge with next. A human has to look at those, so they\nwait longer.",
        "type": "string"
       },
       "succeeded": {

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -6,13 +6,13 @@ kind: Kustomization
 # イメージの差し替えとクラスタ固有の patch だけ（設計 §14: 「どう動くか」は taskflow、
 # 「何ができるか」は home-cluster）。ref は commit SHA で固定し Renovate が追う。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=037a2b2ef89b05b7adf968706973e1c9ce697919
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=a7375405933963bb869219027ab0423f86b22d22
 
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
     newTag: latest
-    digest: sha256:4dd3ffebf242d704dcfb06db1f2109813582f656445ed1dfd31d9f30a9c0d86d
+    digest: sha256:f892f5d971191f26f277436d9d1d206bb171e5c5fa82789ab8b6d50ac0e1d5a8
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）

--- a/manifests/claude-code/taskflow-cnp-check.yaml
+++ b/manifests/claude-code/taskflow-cnp-check.yaml
@@ -6,8 +6,11 @@
 # 人間への報告は 調査 Pod 内の notify サイドカーが担う（設計 §7: publish は利用側の
 # サイドカーの仕事。framework は判定ディレクトリしか見ない）。
 #
-# 語彙は next の宣言 {完了: ok} から来る。エージェントが書けるのは /workspace/out/ok/ だけで、
-# 判定できないときは何も書かない → controller が Escalated にする（設計 §6 の逃げ道）。
+# 語彙は next の宣言から来る。{完了: ok, Escalated: escalate} なので、エージェントが書けるのは
+# /workspace/out/ 下の ok/ と escalate/ の 2 つだけ。「判定できない」は escalate/ に理由を書いて
+# 明示する（taskflow #63）。何も書かなければ従来どおり Escalated だが、そちらは沈黙 — 途中で
+# 死んだのか意図して降りたのかが history から区別できない。
+# terminals で終端の意味も宣言する（taskflow #64）。宣言しないと metric 上は Undeclared のまま。
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,16 +26,21 @@ data:
     | 結論 | すること |
     |---|---|
     | 点検を完了し、報告できる | `/workspace/out/ok/report.md` を書く |
-    | 判定できない・材料が足りない | **何も書かない**（`/workspace/out/` の下に一切ファイルを置かない） |
+    | 判定できない・材料が足りない | `/workspace/out/escalate/report.md` に**理由**を書く |
 
     ## 規則
 
-    - `/workspace/out/ok/` 以外に書き込み先は無い。新しいディレクトリは作れないし、
+    - **書き込み先は `/workspace/out/` の下に実際に存在するディレクトリだけ。**
+      `ls /workspace/out` で確かめられる。新しいディレクトリは作れないし、
       作れなくても異常ではないので回避しようとしないこと
+    - **書くのはどちらか一方だけ。** 両方に書くと「答えが 2 つ」として判定不能になる
     - ファイル名は `report.md` 固定。他のファイルを置いてもよいが、回収側は report.md だけを人間に見せる
-    - 「判定できない」は失敗ではない。無理に報告を書くより、何も書かない方が正しい。
-      その場合は人間に差し戻される
-    - 作業用の一時ファイルは `/tmp` に置く。`/workspace/out/ok/` に置いたものは全部「報告」として扱われる
+    - 「判定できない」は失敗ではない。無理に報告を書くより escalate に降りる方が正しい。
+      **降りるなら黙って終わらず `escalate/report.md` に理由を書くこと** —
+      何が足りなかったのか、どこまでは確かめられたのかが人間の次の一手になる。
+      何も書かずに終わると「途中で死んだ」と区別が付かない
+    - 作業用の一時ファイルは `/tmp` に置く。`/workspace/out/` の下に置いたものは
+      置いた場所がそのまま結論になる（空でないディレクトリが判定そのもの）
     - **ターン数は有限。** 手順の材料が揃った時点で、追加の探索より先に report.md を書く。
       書いた後に余裕があれば追記すればよい。最初の 1 回（run 1）は 40 ターンで打ち切られ、
       report を書く直前で終わって判定不能になった
@@ -124,22 +132,46 @@ spec:
               limits:
                 memory: 64Mi
           # 人間への報告。framework の関心事ではない（設計 §7 / §9）。SIGTERM で
-          # report.md があれば Discord に投げ、無ければ「判定なし」を投げる。
+          # どのディレクトリに report.md があるかを見て、ok / escalate / 沈黙 の
+          # 3 通りを撃ち分ける。escalate と沈黙はどちらも Escalated だが、人間から見ると
+          # 「理由がある差し戻し」と「途中で落ちた疑い」で次の一手が違う。
           - name: notify
             image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:d5db59cac14b23a4ef85a456754522463267324e8ed3a84e795a2eba829c8f05
             restartPolicy: Always
             command: [sh, -c]
             args:
               - |
+                # 判定そのものは framework が出す。ここは同じ規則で読み直すだけで、
+                # 別の規則を持たない — 持つと Discord と Task の status が食い違う。
+                # 規則は「非空の宣言ディレクトリがちょうど 1 つ」。report.md の有無では
+                # なくディレクトリが空かどうかで見るのは、回収側がそう見ているから。
+                nonempty() { [ -d "$1" ] && [ -n "$(ls -A "$1" 2>/dev/null)" ]; }
                 notify() {
-                  REPORT_FILE=/workspace/out/ok/report.md
-                  if [ -s "$REPORT_FILE" ]; then
+                  OK=/workspace/out/ok
+                  ESC=/workspace/out/escalate
+                  REPORT_FILE=""
+                  if nonempty "$OK" && nonempty "$ESC"; then
+                    TITLE="CNP check (taskflow): ambiguous"; COLOR=16711680
+                    REPORT="ok/ と escalate/ の両方に書かれた。非空がちょうど 1 つでないので判定不能（→ Escalated）。kubectl -n claude-code get task で確認。"
+                  elif nonempty "$OK"; then
                     TITLE="CNP check (taskflow): ok"; COLOR=65280
-                    REPORT=$(jq -Rsr --argjson max 3900 \
-                      'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end' < "$REPORT_FILE")
+                    REPORT_FILE="$OK/report.md"
+                  elif nonempty "$ESC"; then
+                    TITLE="CNP check (taskflow): escalated"; COLOR=16753920
+                    REPORT_FILE="$ESC/report.md"
                   else
                     TITLE="CNP check (taskflow): no verdict"; COLOR=16711680
-                    REPORT="エージェントは report を書かなかった（判定不能 → Escalated）。kubectl -n claude-code get task で確認。"
+                    REPORT="エージェントは何も書かずに終わった（沈黙 → Escalated）。意図的な差し戻しなら escalate/ に理由が残るので、これは途中で落ちたか時間切れの疑いが濃い。kubectl -n claude-code get task で確認。"
+                  fi
+                  # ディレクトリは非空でも report.md が無いことはある（framework は
+                  # エントリの存在しか見ない）。その場合も判定は変えず、本文だけ断る。
+                  if [ -n "$REPORT_FILE" ]; then
+                    if [ -s "$REPORT_FILE" ]; then
+                      REPORT=$(jq -Rsr --argjson max 3900 \
+                        'if length > $max then .[0:$max] + "\n\n_(以降を省略)_" else . end' < "$REPORT_FILE")
+                    else
+                      REPORT="判定は出ているが report.md が無い（他のファイルだけが置かれた）。kubectl -n claude-code get task で確認。"
+                    fi
                   fi
                   PAYLOAD=$(jq -n --arg title "$TITLE" --argjson color "$COLOR" --arg report "$REPORT" \
                     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
@@ -227,4 +259,12 @@ spec:
       handler: cnp-planner
       next:
         完了: ok
+        # 「判定できない」を書いて表明する出口（taskflow #63）。宣言すると escalate/ が
+        # 敷かれ、そこに書いた run は outcome Declined として記録される。宣言しなければ
+        # 「何も書かない」= NoAnswer しか無く、途中で死んだのと区別が付かない。
+        Escalated: escalate
+  # 終端の意味は flow が言う（taskflow #64）。framework は 完了 が良い知らせだと知らない。
+  # 宣言しない終端は metric 上 Undeclared のままになる。
+  terminals:
+    完了: Success
   reworkBudget: 0


### PR DESCRIPTION
taskflow の [#63](https://github.com/Tsuguya-HC/taskflow/issues/63) / [#64](https://github.com/Tsuguya-HC/taskflow/issues/64) を実クラスタに入れる。

## 何が変わるか

**`Escalated: escalate` を宣言する。** これまでエージェントが「判定できない」と言う手段は**何も書かない**ことだけで、それは途中で死んだのと区別が付かなかった（run 1 は実際に max-turns 切れで、history からは意図的な差し戻しと同じに見えた）。宣言すると `escalate/` が敷かれ、理由を書いて降りられる。outcome は `NoAnswer` ではなく `Declined` として残る。

**`terminals: {完了: Success}` を宣言する。** framework は `完了` が良い知らせだと知らない。宣言しないと metric 上は `Undeclared` のままになる。`Failure` の終端は今回作らない（何を「要対処」とするかの基準をプロンプトに書く必要があり、基準が緩いとノイズになるため別途）。

**notify サイドカーを framework と同じ規則に揃える。** ここが今回いちばん実質的な直し:

- 以前は `ok/report.md` を先に見ていたので、**両方に書かれた run を緑で「ok」と報告**していた。framework は「非空がちょうど 1 つ」でないので Escalated にするから、Discord と Task の status が食い違う
- framework が見るのは**ディレクトリが非空か**であって `report.md` の有無ではない。`escalate/notes.txt` だけ置かれた run は framework が escalate と判定するのに、notify は「沈黙」と報告していた

判定を 2 箇所に持たせない。notify は同じ規則で読み直すだけにした。

## 動作確認

notify のシェル片をマニフェストから抜き出し、5 通りのディレクトリ状態で実行して framework の判定と一致することを確認した:

| 状態 | Discord の見出し |
|---|---|
| `ok/report.md` あり | `ok`（緑） |
| `escalate/report.md` あり | `escalated`（橙）+ 理由 |
| 両方 | `ambiguous`（赤）— 判定不能である旨 |
| どちらも空 | `no verdict`（赤）— 沈黙なので落ちた疑い |
| `escalate/notes.txt` だけ | `escalated`（橙）+「report.md が無い」 |

## その他

- `kustomize/taskflow`: remote base の ref を taskflow `a737540`（#62/#63/#64 を含む main）へ、コントローラの digest を `sha256:f892f5d9…` へ。ArgoCD は `ServerSideApply=true` 済みなので 642KB の CRD もそのまま入る
- `.github/schemas/flow.tgy.io/taskflow_v1alpha1.json` を新しい CRD から再生成（`terminals` が入らないと kubeconform が strict で落ちる）。生成器の正しさは、**変更の無い `task` と `taskhandler` を再生成して既存ファイルとバイト一致すること**で確認した
- `/lint` は 3 ファイル 11 ルール通過

## 残り

**metric は今のクラスタでは誰も取っていない。** コントローラは `--metrics-bind-address=:8443` で出しているが、ServiceMonitor が無く、CNP も Prometheus からの :8443 ingress を開けていない。#64 が出す 4 つのうち Event・`Ready=False`・`ttl.failed` は配線不要でこの PR から効くが、metric だけ別途 ServiceMonitor + CNP + RBAC が要る。08-26 にコントローラを載せたときからの穴で、この PR が作った退行ではない。直後に別 PR で塞ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYfJpGkyGbFWK5kkMnBCui