### PR TITLE
taskflow: let Prometheus reach the controller's metrics

### DIFF
--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -158,7 +158,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **prometheus** | grafana, tempo, claude-code (claude-code), kube-apiserver/remote-node (service proxy, RBAC services/proxy で制御) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, cert-manager controller/webhook/cainjector (cert-manager):9402, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
+| **prometheus** | grafana, tempo, claude-code (claude-code), kube-apiserver/remote-node (service proxy, RBAC services/proxy で制御) → 9090 | kube-apiserver, alertmanager:9093/8080, kube-state-metrics:8080, operator:10250, grafana:3000, smartctl-exporter:9633, argo-workflows-controller (argo):9090, taskflow-controller (taskflow-system):8443, cert-manager controller/webhook/cainjector (cert-manager):9402, tempo:3200 (scrape), coredns (kube-system):9153, tetragon-operator (kube-system):2113, seaweedfs (seaweedfs):9327, trivy-operator (trivy-system):8080, harbor (harbor):8001, host/remote-node:10250/9100/9115/2379/2381/10257/10259/9965/2112 |
 | **alertmanager** | prometheus → 9093/8080 | discord.com:443, discordapp.com:443, alertmanager-eventsource (argo):12001 |
 | **grafana** | ingress → 3000 (L7 HTTP); prometheus → 3000 | kube-apiserver, prometheus:9090, loki-gateway:8080, tempo:3200, shared-pg (database):5432, kanidm (kanidm):8443 |
 | **kube-state-metrics** | prometheus → 8080 | kube-apiserver |
@@ -361,4 +361,4 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **taskflow-controller** | host/remote-node → 8081 (probes) | kube-apiserver |
+| **taskflow-controller** | host/remote-node → 8081 (probes); prometheus (monitoring) → 8443 (metrics, TLS + authn/authz) | kube-apiserver |

--- a/manifests/monitoring/netpol-prometheus.yaml
+++ b/manifests/monitoring/netpol-prometheus.yaml
@@ -83,6 +83,16 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
+    # taskflow コントローラ。HTTPS + authn/authz 越しの :8443（kubebuilder の既定）。
+    - toEndpoints:
+        - matchLabels:
+            control-plane: controller-manager
+            app.kubernetes.io/name: taskflow
+            io.kubernetes.pod.namespace: taskflow-system
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP
     # chart の ServiceMonitor は 3 コンポーネントとも対象にするので 3 つ書く。
     # matchLabels はラベルを跨いだパターンマッチができないため列挙が必要。
     - toEndpoints:

--- a/manifests/taskflow-system/netpol.yaml
+++ b/manifests/taskflow-system/netpol.yaml
@@ -17,6 +17,16 @@ spec:
         - ports:
             - port: "8081"
               protocol: TCP
+    # Prometheus からの metrics スクレイプ（:8443、HTTPS + authn/authz）。
+    # ここを開けないと ServiceMonitor があっても取れない。
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: prometheus
+            io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP
   egress:
     # コントローラが話す相手は apiserver だけ。Job を作り、Pod の status を読むのみで、
     # ワークスペースにも store にも触らない（設計 §6「2 ホップ」）。DNS は CCNP で共通適用済み。

--- a/manifests/taskflow-system/servicemonitor.yaml
+++ b/manifests/taskflow-system/servicemonitor.yaml
@@ -1,0 +1,45 @@
+# taskflow_task_outcomes_total を Prometheus に届ける。コントローラは kubebuilder の
+# scaffold どおり :8443 で HTTPS + authn/authz フィルタ越しに metrics を出しており、
+# 素の scrape は 401 で弾かれる。Prometheus 自身の SA トークンを Bearer で送り、
+# 下の ClusterRoleBinding でその SA に /metrics の get を与える。
+#
+# 証明書はコントローラの自己署名（cert-manager を挟んでいない）なので
+# insecureSkipVerify。同じ形が manifests/argo/servicemonitor-workflow-controller.yaml
+# にもある。
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: taskflow-controller
+  namespace: taskflow-system
+  labels:
+    release: kube-prometheus-stack
+spec:
+  endpoints:
+    - port: https
+      path: /metrics
+      scheme: https
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: taskflow
+---
+# metrics-reader ClusterRole（nonResourceURLs: /metrics の get）は taskflow の
+# config/rbac が持っているが、誰にも束縛されていない。認可の相手を決めるのは
+# 利用側なので、束縛はここで書く（設計 §8: SA / RBAC は framework の外）。
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: taskflow-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: kube-prometheus-stack-prometheus
+    namespace: monitoring


### PR DESCRIPTION
[#740](https://github.com/Tsuguya-HC/home-cluster/pull/740) で taskflow の `terminals` を入れたときに見つけた穴を塞ぐ。

## 何が起きていたか

`taskflow_task_outcomes_total` は**コントローラのメモリの中で数えられているだけ**だった。

- コントローラは kubebuilder の scaffold どおり `--metrics-bind-address=:8443` で metrics を出している（08-26 にコントローラを載せたときから）
- しかし **ServiceMonitor が無い**
- `manifests/taskflow-system/netpol.yaml` の ingress は kubelet の probe（:8081）だけで、**:8443 が開いていない**
- scaffold が持つ `metrics-reader` ClusterRole（`nonResourceURLs: /metrics` の get）は**誰にも束縛されていない**ので、束縛しても 401 で弾かれる

3 つ全部が要る。1 つでも欠けると「設定は書いてあるが取れていない」になる。

## 入れるもの

- `manifests/taskflow-system/servicemonitor.yaml` — ServiceMonitor（`release: kube-prometheus-stack`、`scheme: https`、Prometheus 自身の SA トークンを Bearer で送る、自己署名なので `insecureSkipVerify`）と、`metrics-reader` → `kube-prometheus-stack-prometheus` の ClusterRoleBinding
- `manifests/taskflow-system/netpol.yaml` — Prometheus からの :8443 ingress
- `manifests/monitoring/netpol-prometheus.yaml` — **Prometheus 側の egress**
- `docs/network-policies.md` — 両側の行を更新

**egress が忘れやすい半分**: Prometheus の CNP は宛先を 1 つずつ列挙する形なので、コントローラ側の ingress だけ開けても drop する。しかも**両方のポリシーは単体では正しく見える**。

ClusterRoleBinding を taskflow 側ではなくここに書いたのは、**誰が metrics を読んでよいかは利用側の判断**だから（設計 §8: SA / RBAC は framework の外）。`ai` AppProject の `clusterResourceWhitelist` は `ClusterRoleBinding` を既に許可している。

## 確認

- ServiceMonitor のセレクタ（`control-plane: controller-manager` / `app.kubernetes.io/name: taskflow`）と CNP の `toEndpoints` が、実際の Pod ラベルと一致することを `kubectl get pod -o jsonpath='{.items[0].metadata.labels}'` で突き合わせた
- 反映後に Prometheus のターゲットが `up` になり、`taskflow_task_outcomes_total` が引けることを見届ける

## この metric で見えるようになるもの

`severity` は終端の意味をそのまま出す（`Success` / `Failure` / `Escalated` / `Failed` / `Undeclared`）。`Undeclared` が残っている flow は **`terminals` をまだ宣言していない flow**なので、ダッシュボードから見つけられる。`flow` ラベルは実在する TaskFlow の名前か、参照先が存在しなかったことを表す `<unresolved>` のどちらかで、実行時入力では増えない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYfJpGkyGbFWK5kkMnBCui