### PR TITLE
Match the plan-gate merge author on user id, not login

### DIFF
--- a/manifests/argo/tofu-cloudflare.yaml
+++ b/manifests/argo/tofu-cloudflare.yaml
@@ -171,7 +171,7 @@ spec:
     parameters:
       - name: pr-number
       - name: branch
-      - name: author
+      - name: author-id
         default: ""
   templates:
     - name: main
@@ -288,8 +288,18 @@ spec:
               --arg output "$PLAN_OUTPUT" \
               '{body: ("### " + $title + "\n" + $msg + "\n\n<details>\n<summary>Plan Output</summary>\n\n```\n" + $output + "\n```\n\n</details>")}')
             echo "$BODY" | gh api "repos/$REPO/issues/$PR/comments" --input -
-            AUTHOR="{{workflow.parameters.author}}"
-            if [ "$EXIT_CODE" = "0" ] && [ "$AUTHOR" = "renovate[bot]" ]; then
+            # Matched on the PR author's numeric user id, not the login:
+            # a login can be released and re-registered, and the previous
+            # `AUTHOR = "renovate[bot]"` silently stopped matching when
+            # Renovate moved to the self-hosted App (tsuguya-home-cluster[bot])
+            # -- no unattended merge had fired since.
+            # Both first-party Renovate bot ids are accepted everywhere so a
+            # Mend <-> self-host move cannot silently disarm the gate again;
+            # which bot actually appears varies per repo.
+            #   29139614  renovate[bot]              (Mend-hosted)
+            #   265309552 tsuguya-home-cluster[bot]  (self-hosted App)
+            AUTHOR_ID="{{workflow.parameters.author-id}}"
+            if [ "$EXIT_CODE" = "0" ] && { [ "$AUTHOR_ID" = "29139614" ] || [ "$AUTHOR_ID" = "265309552" ]; }; then
               gh api "repos/$REPO/pulls/$PR/merge" --method PUT -f merge_method=squash
             fi
         volumeMounts:

--- a/manifests/argo/tofu-eventsource.yaml
+++ b/manifests/argo/tofu-eventsource.yaml
@@ -353,7 +353,7 @@ spec:
                       value: ""
                     - name: branch
                       value: ""
-                    - name: author
+                    - name: author-id
                       value: ""
           parameters:
             - src:
@@ -366,7 +366,7 @@ spec:
               dest: spec.arguments.parameters.1.value
             - src:
                 dependencyName: pull-request
-                dataKey: body.pull_request.user.login
+                dataKey: body.pull_request.user.id
               dest: spec.arguments.parameters.2.value
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -434,7 +434,7 @@ spec:
                       value: ""
                     - name: sha
                       value: ""
-                    - name: author
+                    - name: author-id
                       value: ""
           parameters:
             - src:
@@ -451,7 +451,7 @@ spec:
               dest: spec.arguments.parameters.2.value
             - src:
                 dependencyName: pull-request
-                dataKey: body.pull_request.user.login
+                dataKey: body.pull_request.user.id
               dest: spec.arguments.parameters.3.value
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -551,7 +551,7 @@ spec:
                       value: ""
                     - name: branch
                       value: ""
-                    - name: author
+                    - name: author-id
                       value: ""
           parameters:
             - src:
@@ -564,5 +564,5 @@ spec:
               dest: spec.arguments.parameters.1.value
             - src:
                 dependencyName: pull-request
-                dataKey: body.pull_request.user.login
+                dataKey: body.pull_request.user.id
               dest: spec.arguments.parameters.2.value

--- a/manifests/argo/tofu-harbor.yaml
+++ b/manifests/argo/tofu-harbor.yaml
@@ -134,7 +134,7 @@ spec:
     parameters:
       - name: pr-number
       - name: branch
-      - name: author
+      - name: author-id
         default: ""
   templates:
     - name: main
@@ -251,8 +251,10 @@ spec:
               --arg output "$PLAN_OUTPUT" \
               '{body: ("### " + $title + "\n" + $msg + "\n\n<details>\n<summary>Plan Output</summary>\n\n```\n" + $output + "\n```\n\n</details>")}')
             echo "$BODY" | gh api "repos/$REPO/issues/$PR/comments" --input -
-            AUTHOR="{{workflow.parameters.author}}"
-            if [ "$EXIT_CODE" = "0" ] && [ "$AUTHOR" = "renovate[bot]" ]; then
+            # See tofu-cloudflare-plan for why the author is matched on
+            # numeric user id rather than login.
+            AUTHOR_ID="{{workflow.parameters.author-id}}"
+            if [ "$EXIT_CODE" = "0" ] && { [ "$AUTHOR_ID" = "29139614" ] || [ "$AUTHOR_ID" = "265309552" ]; }; then
               gh api "repos/$REPO/pulls/$PR/merge" --method PUT -f merge_method=squash
             fi
         volumeMounts:

--- a/manifests/argo/tofu-unifi.yaml
+++ b/manifests/argo/tofu-unifi.yaml
@@ -13,7 +13,7 @@ spec:
       - name: pr-number
       - name: branch
       - name: sha
-      - name: author
+      - name: author-id
         default: ""
   templates:
     - name: main
@@ -112,7 +112,7 @@ spec:
             REPO="Tsuguya-HC/home-unifi"
             PR="{{workflow.parameters.pr-number}}"
             SHA="{{workflow.parameters.sha}}"
-            AUTHOR="{{workflow.parameters.author}}"
+            AUTHOR_ID="{{workflow.parameters.author-id}}"
             RUN_URL="https://argo.infra.tgy.io/workflows/argo/{{workflow.name}}"
 
             # The commit status is the merge gate, so it is posted as pending
@@ -176,7 +176,9 @@ spec:
             # until it settles. Without the retry the PR just sits there green
             # and unmerged, which reads as "automerge is broken" rather than as
             # a race.
-            if [ "$DESC" = "No changes" ] && [ "$AUTHOR" = "renovate[bot]" ]; then
+            # See tofu-cloudflare-plan for why the author is matched on
+            # numeric user id rather than login.
+            if [ "$DESC" = "No changes" ] && { [ "$AUTHOR_ID" = "29139614" ] || [ "$AUTHOR_ID" = "265309552" ]; }; then
               for attempt in 1 2 3 4 5; do
                 if gh api "repos/$REPO/pulls/$PR/merge" --method PUT -f merge_method=squash; then
                   break


### PR DESCRIPTION
The tofu plan gates merge a Renovate PR unattended when the plan shows
no changes, but the author check compared the login string renovate[bot]
— which silently stopped matching for home-cloudflare when Renovate
moved to the self-hosted App (tsuguya-home-cluster[bot]). Compare the
webhook's numeric user id instead: a login can be released and
re-registered, an id cannot. Both first-party bot ids are accepted in
all three gates so a Mend <-> self-host move cannot disarm a gate
silently again; the sensors now carry user.id in place of user.login,
and the unread author (login) plumbing is gone.

Reviewed by infra-review-cycle (2 rounds, all clear): parameter index
wiring re-verified against simulated webhook payloads, dry-run=server
on all four files, fail-closed on missing or foreign ids confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dtpi7rWfuFnCHGRSS3ZWU8