### PR TITLE
Bring the taskflow controller back under Renovate, and gate it with its CRDs

### DIFF
--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -4,15 +4,40 @@ kind: Kustomization
 # taskflow のコントローラ本体は Tsuguya-HC/taskflow リポの config/default（CRD・RBAC・
 # Deployment）をそのまま remote base として取り込む。home-cluster 側が持つのは
 # イメージの差し替えとクラスタ固有の patch だけ（設計 §14: 「どう動くか」は taskflow、
-# 「何ができるか」は home-cluster）。ref は commit SHA で固定し Renovate が追う。
+# 「何ができるか」は home-cluster）。
+#
+# ref は commit SHA でのピン。git-refs で main の HEAD を追わせると CRD だけがイメージより
+# 先に進む（ビルド完了前に digest が動く）ため、CRD / RBAC が変わったときに、下の images の
+# digest と同じ commit へ人が揃えて上げる。両者が同じ commit を指しているかの検証は #687。
+#
+# 逆方向（イメージが CRD/RBAC より先に進む）のドリフトも構造的に起こりうる。Argo のビルドは
+# *.go 等の変更でのみ発火し config/ 単独では発火しないが、kubebuilder では CRD/RBAC が Go の
+# マーカーから make manifests で生成されるため、Go 変更と config/default 変更は同一コミットに
+# 同居しやすい。つまりコードが変わってイメージだけ自動マージされると、新しいコントローラ
+# バイナリが古い CRD/RBAC のまま動く（forbidden エラーに直結する）。対策として renovate.jsonc
+# で controller / agent-sidecar の両イメージも automerge: false にし、?ref= と一緒に人が
+# 上げる運用にしている（検証は #687）。
+#
+# この ref は Renovate の kustomize manager に github-tags dep として抽出される（commit SHA
+# でも currentValue にそのまま入る＝manager が見ていないから安全、ではない）。GITHUB_COM_TOKEN
+# 付きで lookup まで走らせても updates: [] にはなる（実測済み）が、その理由は確定していない —
+# 実測時点で upstream (Tsuguya-HC/taskflow) に tag/release が 0 件であることと、versioning が
+# semver-coerced で 40 桁の生 SHA を比較可能なバージョンとして解釈できないこと、両方の観測が
+# ある。どちらの条件が崩れたとき（タグが増えた時／versioning が変わった時）に何が起きるかは
+# 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
+# enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=187f5adbd2bcf9e0adfe2f1cb0ffb27b745011ec
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=eb0d61ffc08e776a689db25e4a22d207cd096afe
 
+# newTag と digest を分けて併記すると、Renovate の kustomize manager が
+# invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
+# （2026-08-30 のビルドに 3 日間据え置かれた実例あり）。newTag: tag@digest の
+# 1 フィールド形式は Renovate 自身が warning で案内している書き方で、レンダリング
+# 結果は併記時と同一。
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest
-    digest: sha256:25b531d9e9dcef30a08fde9e52c34df0cf4b3ef6284ac2fb452f8a91c3105d83
+    newTag: latest@sha256:a34ca06f5d754625539369ca35e7201b868c368cf82c80f1495545f8676a1e32
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -208,6 +208,22 @@
     },
     {
       "description": [
+        "kustomize/taskflow/kustomization.yaml の remote base ?ref= は commit SHA ピンで、",
+        "人が images の digest と同じ commit へ揃えて上げる運用（検証は home-cluster#687）。",
+        "Renovate の kustomize manager は commit SHA の ref も github-tags として抽出する",
+        "（manager が見ていないから安全、ではない）。lookup まで走らせても updates: [] には",
+        "なる（実測済み）が理由は確定していない — 実測時点で upstream にタグ/リリースが 0 件",
+        "であることと、versioning が semver-coerced で生の SHA を解釈できないこと、両方の観測",
+        "がある。どちらの条件が崩れたときに何が起きるかは実測していないため、CRD/RBAC が",
+        "コントローラのイメージより先に進むレースを避けるべく、その不確実性に依存せず",
+        "明示的に無効化する。"
+      ],
+      "matchDatasources": ["github-tags"],
+      "matchDepNames": ["Tsuguya-HC/taskflow"],
+      "enabled": false
+    },
+    {
+      "description": [
         "Lock file maintenance refreshes transitive versions; there is no single",
         "release to age, so the gate can never be satisfied. horenso#66 was stuck",
         "pending on it with automerge enabled, which means it would never have",
@@ -252,6 +268,27 @@
     {
       "description": "Do not automerge critical infrastructure",
       "matchPackageNames": ["cilium", "tetragon", "https://github.com/kubernetes-sigs/gateway-api.git"],
+      "automerge": false
+    },
+    {
+      "description": [
+        "taskflow は Tsuguya-HC/taskflow 1 リポジトリから 3 つの成果物を出す: remote base の",
+        "?ref=、controller image、agent-sidecar image。この 3 つは同じ commit を指している",
+        "必要がある（検証は home-cluster#687）。?ref= 側は上の github-tags ルールで自動更新を",
+        "止めてあるが、イメージだけを patch/digest 自動マージのままにすると、その skew が",
+        "毎回・自動で起きる: Argo のビルドは *.go 等の変更でのみ発火し config/ 単独では",
+        "発火しないが、kubebuilder では CRD/RBAC が Go のマーカーから make manifests で",
+        "生成されるため、Go 変更と config/default 変更は同一コミットに同居しやすい。つまり",
+        "コードが変わってイメージだけ自動マージされると、新しいバイナリが古い CRD/RBAC の",
+        "まま動く（forbidden エラーに直結する）。3 つが揃っているかを人が保証できるまでの",
+        "手動ゲートとして、この 2 イメージだけ automerge を止める。enabled: false ではなく",
+        "automerge: false なのは、digest が動いたこと自体は PR で知りたいため。"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.infra.tgy.io/tools/taskflow",
+        "registry.infra.tgy.io/tools/agent-sidecar"
+      ],
       "automerge": false
     },
     {


### PR DESCRIPTION
The taskflow controller had been sitting on its 2026-08-30 build for three days
while the sidecar it injects kept moving with every push. Harbor had the image
for `eb0d61f` since 2026-09-01; nothing was going to pick it up, because
**Renovate never saw the controller image at all**.

## Why it was stuck

The `kubernetes` manager only reads `image:` fields. Kustomize's own manager
*did* see the `images:` block — and threw the extraction away:

```
DEBUG: Kustomize ignores newTag when digest is provided.
       Pick one, or use `newTag: tag@digest`
```

`newTag: latest` and `digest:` written side by side make `extractImage()` return
`skipReason: "invalid-dependency-specification"`. Renovate had been saying so in
a debug line nobody was reading. The entry now uses the single
`newTag: latest@sha256:...` form that warning recommends — the built-in manager
extracts it cleanly (`currentValue: latest` / `currentDigest: sha256:a34ca06f…`,
no skipReason), and it renders **byte-for-byte the same image reference** as the
two-field form.

## What lands on the cluster

`?ref=` and the image digest both move to `eb0d61f`, so the CRDs, the RBAC and
the binary come from one commit. That brings in ADR-0002/0003 — the per-task
workspace PVC and the run-view/sweep rules — and the `persistentvolumeclaims`
verbs (`create`/`get`/`list`/`watch`, no `delete`) the controller needs for them.

**No PVC gets created by this.** None of the three flows (cnp-check, pr-review,
smoke) declares `spec.workspace`, and `checkWorkspace()` only takes the new path
when a handler names the reserved `flow-workspace` volume. This lays the pipe;
the flows move over separately.

It also drags the embedded PodSpec schema in the TaskHandler CRD up a
controller-gen generation (gRPC probe `mode`/`protocol`, image volume
`bindMountOptions`). Additive only — **zero field removals**, verified by
diffing the old and new renders.

## Keeping the three artefacts together

One repository ships three things that have to agree: the `?ref=`, the
controller image and the sidecar image. Two changes keep them that way.

**`?ref=` is disabled explicitly.** Renovate *does* extract the commit SHA as a
`github-tags` dep — the earlier claim that "the manager only looks at tags" was
simply wrong. It yields no updates today, but the reason is not settled:
upstream has no tags *and* `semver-coerced` cannot read a raw 40-character SHA.
Both hold at once, and removing the rule to test it still cannot separate them.
That is an accident to rely on, not a guarantee, so it is switched off by name.

**The images no longer automerge.** `matchUpdateTypes: [patch, digest,
pinDigest] → automerge: true` has no filter, and Harbor builds skip the
digest-cooldown soak, so a digest bump merged itself. With `?ref=` now manual,
that asymmetry bites in the direction the comment had not considered: the Argo
build fires on `*.go` but not on `config/` alone, while kubebuilder generates
CRDs and RBAC *from markers in that same Go source*. A single commit would ship
a new binary automatically and leave the CRDs and RBAC behind it — a controller
asking for permissions its ClusterRole does not have yet. **This very PR is an
instance**: the PVC verbs come from a marker in `task_controller.go`.

Checking that the three actually agree belongs to #687, which this makes more
worth doing.

## Verification

| check | result |
|---|---|
| `kubectl kustomize` vs. previous render | byte-identical |
| old-ref vs. new-ref render | 4 resources change, exactly as described |
| `kubeconform -strict` | 23 resources — Valid 20 / Invalid 0 / Skipped 3 |
| `kubectl apply --server-side --dry-run=server` | 23/23 applied |
| `renovate-config-validator --strict` | passes |
| `renovate --dry-run=lookup` (with token) | `Tsuguya-HC/taskflow` → `skipReason: disabled`; controller and sidecar docker deps alive |
| `unread-values.py` (full scan) | 31 files, no unread keys |

**Not proven:** `automerge: false` taking effect. `--platform=local` stops at
branchify and never resolves per-branch automerge, even with an update candidate
forced by rolling the digest back in a scratch copy. Judged on rule ordering,
exact-match scoping, and the identical pattern already in use for
cilium/tetragon. **Worth watching on the first real Renovate run.**

One aside worth recording: `npx --yes --package renovate` resolves
non-deterministically here, and 37.440.7 does not list `renovate.jsonc` in
`configFileNames` — it validates "successfully" without ever reading the config.
Every check above pinned `renovate@44.52.1`.

Reviewed across three rounds by `/infra-review-cycle`; the first two versions of
this fix were wrong and were overturned by measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VA39Gmq4sDrftq83AjDLy
