### PR TITLE
Prove the workspace PVC plumbing with a smoke flow of its own

### DIFF
--- a/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
@@ -97,6 +97,184 @@
      },
      "type": "object",
      "additionalProperties": false
+    },
+    "workspace": {
+     "description": "Workspace, when set, backs the flow's workspace with one claim per\ntask, created by the controller and deleted with the task. A handler\njoins by naming the reserved volume flow-workspace; a flow that leaves\nthis out keeps today's arrangement, where each handler's template\nbrings its own volume and nothing crosses a phase.",
+     "properties": {
+      "volumeClaimTemplate": {
+       "default": {
+        "accessModes": [
+         "ReadWriteMany"
+        ],
+        "resources": {
+         "requests": {
+          "storage": "1Gi"
+         }
+        }
+       },
+       "description": "VolumeClaimTemplate is the claim's spec, and only its spec — the\ncontroller owns the claim's name and ownership, and a whole\nPersistentVolumeClaim here would let a flow fight it over both (and\ncarries name, merge-key and serialization problems its users have\ndocumented). It is the standard type: storageClassName, accessModes,\nresources, even volumeName for a hand-made PV all mean exactly what\nthey mean on any claim. Left out entirely, it defaults to a small\nReadWriteMany scratch claim on the cluster's default StorageClass;\nwritten at all, it is taken as written — the default is a whole\ntemplate, not a base to merge into.\n\nChanging it affects tasks created afterwards. Claims that already\nexist are never rewritten to match.",
+       "properties": {
+        "accessModes": {
+         "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+         "items": {
+          "type": "string"
+         },
+         "type": "array"
+        },
+        "dataSource": {
+         "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\ndataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be\ncopied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+         "properties": {
+          "apiGroup": {
+           "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+           "type": "string"
+          },
+          "kind": {
+           "description": "Kind is the type of resource being referenced",
+           "type": "string"
+          },
+          "name": {
+           "description": "Name is the name of resource being referenced",
+           "type": "string"
+          }
+         },
+         "required": [
+          "kind",
+          "name"
+         ],
+         "type": "object",
+         "additionalProperties": false
+        },
+        "dataSourceRef": {
+         "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+         "properties": {
+          "apiGroup": {
+           "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+           "type": "string"
+          },
+          "kind": {
+           "description": "Kind is the type of resource being referenced",
+           "type": "string"
+          },
+          "name": {
+           "description": "Name is the name of resource being referenced",
+           "type": "string"
+          },
+          "namespace": {
+           "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+           "type": "string"
+          }
+         },
+         "required": [
+          "kind",
+          "name"
+         ],
+         "type": "object",
+         "additionalProperties": false
+        },
+        "resources": {
+         "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+         "properties": {
+          "limits": {
+           "additionalProperties": {
+            "anyOf": [
+             {
+              "type": "integer"
+             },
+             {
+              "type": "string"
+             }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+           },
+           "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+           "type": "object"
+          },
+          "requests": {
+           "additionalProperties": {
+            "anyOf": [
+             {
+              "type": "integer"
+             },
+             {
+              "type": "string"
+             }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+           },
+           "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+           "type": "object"
+          }
+         },
+         "type": "object",
+         "additionalProperties": false
+        },
+        "selector": {
+         "description": "selector is a label query over volumes to consider for binding.",
+         "properties": {
+          "matchExpressions": {
+           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+           "items": {
+            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+            "properties": {
+             "key": {
+              "description": "key is the label key that the selector applies to.",
+              "type": "string"
+             },
+             "operator": {
+              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+              "type": "string"
+             },
+             "values": {
+              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+              "items": {
+               "type": "string"
+              },
+              "type": "array"
+             }
+            },
+            "required": [
+             "key",
+             "operator"
+            ],
+            "type": "object",
+            "additionalProperties": false
+           },
+           "type": "array"
+          },
+          "matchLabels": {
+           "additionalProperties": {
+            "type": "string"
+           },
+           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+           "type": "object"
+          }
+         },
+         "type": "object",
+         "additionalProperties": false
+        },
+        "storageClassName": {
+         "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+         "type": "string"
+        },
+        "volumeAttributesClassName": {
+         "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+         "type": "string"
+        },
+        "volumeMode": {
+         "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+         "type": "string"
+        },
+        "volumeName": {
+         "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+         "type": "string"
+        }
+       },
+       "type": "object",
+       "additionalProperties": false
+      }
+     },
+     "type": "object",
+     "additionalProperties": false
     }
    },
    "required": [

--- a/.github/schemas/flow.tgy.io/taskhandler_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskhandler_v1alpha1.json
@@ -827,7 +827,7 @@
                    "description": "Selects a key of a ConfigMap.",
                    "properties": {
                     "key": {
-                     "description": "The key to select.",
+                     "description": "The key to select from the ConfigMap's Data field.\nKeys in the BinaryData field are not currently propagated to container env vars.",
                      "type": "string"
                     },
                     "name": {
@@ -1079,6 +1079,10 @@
                     ],
                     "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
                    },
+                   "protocol": {
+                    "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                    "type": "string"
+                   },
                    "scheme": {
                     "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                     "type": "string"
@@ -1196,6 +1200,10 @@
                     ],
                     "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
                    },
+                   "protocol": {
+                    "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                    "type": "string"
+                   },
                    "scheme": {
                     "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                     "type": "string"
@@ -1284,6 +1292,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -1345,6 +1357,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -1477,6 +1493,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -1538,6 +1558,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -1897,6 +1921,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -1958,6 +1986,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -2072,8 +2104,15 @@
               "items": {
                "description": "VolumeMount describes a mounting of a Volume within a container.",
                "properties": {
+                "bindMountOptions": {
+                 "description": "bindMountOptions is the list of additional bind mount options to apply when\nmounting this volume into the container. Allowed values are noexec,\nnodev, and nosuid. These are Linux mount options and have no effect on\nWindows nodes.\nThis field is not supported with image volumes.\nThis is an alpha field and requires enabling the VolumeBindMountOptions feature gate.",
+                 "items": {
+                  "type": "string"
+                 },
+                 "type": "array"
+                },
                 "mountPath": {
-                 "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                 "description": "Path within the container at which the volume should be mounted.",
                  "type": "string"
                 },
                 "mountPropagation": {
@@ -2210,7 +2249,7 @@
                    "description": "Selects a key of a ConfigMap.",
                    "properties": {
                     "key": {
-                     "description": "The key to select.",
+                     "description": "The key to select from the ConfigMap's Data field.\nKeys in the BinaryData field are not currently propagated to container env vars.",
                      "type": "string"
                     },
                     "name": {
@@ -2462,6 +2501,10 @@
                     ],
                     "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
                    },
+                   "protocol": {
+                    "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                    "type": "string"
+                   },
                    "scheme": {
                     "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                     "type": "string"
@@ -2579,6 +2622,10 @@
                     ],
                     "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
                    },
+                   "protocol": {
+                    "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                    "type": "string"
+                   },
                    "scheme": {
                     "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                     "type": "string"
@@ -2667,6 +2714,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -2728,6 +2779,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -2860,6 +2915,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -2921,6 +2980,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -3280,6 +3343,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -3341,6 +3408,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -3459,8 +3530,15 @@
               "items": {
                "description": "VolumeMount describes a mounting of a Volume within a container.",
                "properties": {
+                "bindMountOptions": {
+                 "description": "bindMountOptions is the list of additional bind mount options to apply when\nmounting this volume into the container. Allowed values are noexec,\nnodev, and nosuid. These are Linux mount options and have no effect on\nWindows nodes.\nThis field is not supported with image volumes.\nThis is an alpha field and requires enabling the VolumeBindMountOptions feature gate.",
+                 "items": {
+                  "type": "string"
+                 },
+                 "type": "array"
+                },
                 "mountPath": {
-                 "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                 "description": "Path within the container at which the volume should be mounted.",
                  "type": "string"
                 },
                 "mountPropagation": {
@@ -3504,6 +3582,30 @@
             },
             "required": [
              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+           },
+           "type": "array"
+          },
+          "evictionResponders": {
+           "description": "evictionResponders reference responders that react to Evictions based on EvictionRequests.\nResponders should observe and communicate through the Eviction Resource API to help with\nthe graceful termination of a pod. The responders are selected sequentially, according to\ntheir specified priority.\n\nResponders should periodically report on an eviction progress by updating the\n.status.responders[].heartbeatTime field of the Eviction object. If this field is not updated\nwithin the heartbeat deadline defined by the Eviction API (currently 20 minutes), the eviction\nis passed over to the next responder with a lower priority. If there is no other responder,\nthe last default imperative-eviction.k8s.io/evictor responder with a priority of 100 will\nevict the pod using the imperative Eviction API (pods/<name>/eviction subresource).\n\nThe maximum length of the responders list is 10.\nResponders are not supported when the pod is part of a PodGroup (.spec.schedulingGroup is set).\nThis field can only be set on creation and is immutable afterwards.",
+           "items": {
+            "description": "EvictionResponder allows you to specify the responder reacting to an Eviction.\nResponders should observe and communicate through the Eviction Resource API to help with\nthe graceful eviction of a target (e.g. termination of a pod).",
+            "properties": {
+             "name": {
+              "description": "name allows you to identify the responder responding to the Eviction.\n\nIt must be a valid domain-prefixed key (such as \"acme.io/foo\").\nDomain names *.k8s.io and *.kubernetes.io are reserved.\nThis field must be unique for each responder.\nThis field is required.",
+              "type": "string"
+             },
+             "priority": {
+              "description": "priority for this responder. Higher priorities are selected first by the evictionrequest-controller.\nIf there are responders with the same priority, the responder whose domain name comes first in the\nalphabetical higher domain order, will be picked. This means that the top domain labels are compared\nalphabetically first, followed by the lower domain labels. The key is compared last.\n\nThe responder that is the managing controller of the pod should set the value of\nthis field to 10000 to allow both for preemption or fallback registration by other\nresponders.\n\nThe minimum value is 0 and the maximum value is 100000.\nThe interval 0-999 is reserved for responders with *.k8s.io suffix.\nThis field is required.",
+              "format": "int32",
+              "type": "integer"
+             }
+            },
+            "required": [
+             "name",
+             "priority"
             ],
             "type": "object",
             "additionalProperties": false
@@ -3556,7 +3658,7 @@
            "type": "string"
           },
           "hostnameOverride": {
-           "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.\nThis field only specifies the pod's hostname and does not affect its DNS records.\nWhen this field is set to a non-empty string:\n- It takes precedence over the values set in `hostname` and `subdomain`.\n- The Pod's hostname will be set to this value.\n- `setHostnameAsFQDN` must be nil or set to false.\n- `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.\nRequires the HostnameOverride feature gate to be enabled.",
+           "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.\nThis field only specifies the pod's hostname and does not affect its DNS records.\nWhen this field is set to a non-empty string:\n- It takes precedence over the values set in `hostname` and `subdomain`.\n- The Pod's hostname will be set to this value.\n- `setHostnameAsFQDN` must be nil or set to false.\n- `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.",
            "type": "string"
           },
           "imagePullSecrets": {
@@ -3614,7 +3716,7 @@
                    "description": "Selects a key of a ConfigMap.",
                    "properties": {
                     "key": {
-                     "description": "The key to select.",
+                     "description": "The key to select from the ConfigMap's Data field.\nKeys in the BinaryData field are not currently propagated to container env vars.",
                      "type": "string"
                     },
                     "name": {
@@ -3866,6 +3968,10 @@
                     ],
                     "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
                    },
+                   "protocol": {
+                    "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                    "type": "string"
+                   },
                    "scheme": {
                     "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                     "type": "string"
@@ -3983,6 +4089,10 @@
                     ],
                     "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
                    },
+                   "protocol": {
+                    "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                    "type": "string"
+                   },
                    "scheme": {
                     "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                     "type": "string"
@@ -4071,6 +4181,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -4132,6 +4246,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -4264,6 +4382,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -4325,6 +4447,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -4684,6 +4810,10 @@
                "grpc": {
                 "description": "GRPC specifies a GRPC HealthCheckRequest.",
                 "properties": {
+                 "mode": {
+                  "description": "mode specifies the connection mode for the gRPC health probe.\nSet to \"TLS\" to use TLS without certificate verification.\nSet to \"Plaintext\" to use a plaintext (insecure) connection explicitly.\nIf not specified, the probe uses a plaintext (insecure) connection.",
+                  "type": "string"
+                 },
                  "port": {
                   "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
                   "format": "int32",
@@ -4745,6 +4875,10 @@
                    }
                   ],
                   "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME."
+                 },
+                 "protocol": {
+                  "description": "Protocol selects the wire protocol for the probe connection.\nNil defaults to HTTP/1.1.",
+                  "type": "string"
                  },
                  "scheme": {
                   "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
@@ -4859,8 +4993,15 @@
               "items": {
                "description": "VolumeMount describes a mounting of a Volume within a container.",
                "properties": {
+                "bindMountOptions": {
+                 "description": "bindMountOptions is the list of additional bind mount options to apply when\nmounting this volume into the container. Allowed values are noexec,\nnodev, and nosuid. These are Linux mount options and have no effect on\nWindows nodes.\nThis field is not supported with image volumes.\nThis is an alpha field and requires enabling the VolumeBindMountOptions feature gate.",
+                 "items": {
+                  "type": "string"
+                 },
+                 "type": "array"
+                },
                 "mountPath": {
-                 "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                 "description": "Path within the container at which the volume should be mounted.",
                  "type": "string"
                 },
                 "mountPropagation": {
@@ -4951,7 +5092,7 @@
            "type": "object"
           },
           "preemptionPolicy": {
-           "description": "PreemptionPolicy is the Policy for preempting pods with lower priority.\nOne of Never, PreemptLowerPriority.\nDefaults to PreemptLowerPriority if unset.",
+           "description": "PreemptionPolicy is the Policy for preempting pods with lower priority.\nOne of Never, PreemptLowerPriority.\nWhen Priority Admission Controller is enabled, it prevents users from setting\nthis field. The admission controller populates this field from PriorityClassName.\nDefaults to PreemptLowerPriority if unset.",
            "type": "string"
           },
           "priority": {
@@ -5152,7 +5293,7 @@
              "type": "integer"
             },
             "seLinuxChangePolicy": {
-             "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+             "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\nIf not specified, \"MountOption\" is used.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
              "type": "string"
             },
             "seLinuxOptions": {
@@ -5587,6 +5728,11 @@
                 "format": "int32",
                 "type": "integer"
                },
+               "defaultUser": {
+                "description": "defaultUser is Optional: The owner UID of the created files by default.\nThe defaultUser field is only used as a fallback when the item-level user field is unset.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                "format": "int64",
+                "type": "integer"
+               },
                "items": {
                 "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                 "items": {
@@ -5604,6 +5750,11 @@
                   "path": {
                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                    "type": "string"
+                  },
+                  "user": {
+                   "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                   "format": "int64",
+                   "type": "integer"
                   }
                  },
                  "required": [
@@ -5677,6 +5828,11 @@
                 "format": "int32",
                 "type": "integer"
                },
+               "defaultUser": {
+                "description": "defaultUser is Optional: The owner UID of the created files by default.\nThe defaultUser field is only used as a fallback when the item-level user field is unset.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                "format": "int64",
+                "type": "integer"
+               },
                "items": {
                 "description": "Items is a list of downward API volume file",
                 "items": {
@@ -5738,6 +5894,11 @@
                    ],
                    "type": "object",
                    "additionalProperties": false
+                  },
+                  "user": {
+                   "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                   "format": "int64",
+                   "type": "integer"
                   }
                  },
                  "required": [
@@ -5758,6 +5919,11 @@
                "medium": {
                 "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                 "type": "string"
+               },
+               "mode": {
+                "description": "mode specifies the permission bits for the emptyDir directory, in numeric\nnotation (e.g., 0755, 01777). Must be a value between 0000 and 01777.\nIf not specified, defaults to 0777.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup. If fsGroup is specified, the fsGroup permissions\nwill override the mode specified here.\nThis field has no effect on Windows.\nThis field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.",
+                "format": "int32",
+                "type": "integer"
                },
                "sizeLimit": {
                 "anyOf": [
@@ -5796,7 +5962,7 @@
                     "type": "array"
                    },
                    "dataSource": {
-                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\ndataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be\ncopied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
                     "properties": {
                      "apiGroup": {
                       "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
@@ -5819,7 +5985,7 @@
                     "additionalProperties": false
                    },
                    "dataSourceRef": {
-                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                     "properties": {
                      "apiGroup": {
                       "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
@@ -6314,6 +6480,11 @@
                 "format": "int32",
                 "type": "integer"
                },
+               "defaultUser": {
+                "description": "defaultUser is Optional: The owner UID of the created files by default.\nThe defaultUser field is only used as a fallback when the item-level user field is unset.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                "format": "int64",
+                "type": "integer"
+               },
                "sources": {
                 "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                 "items": {
@@ -6381,6 +6552,11 @@
                     "signerName": {
                      "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
                      "type": "string"
+                    },
+                    "user": {
+                     "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                     "format": "int64",
+                     "type": "integer"
                     }
                    },
                    "required": [
@@ -6409,6 +6585,11 @@
                        "path": {
                         "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                         "type": "string"
+                       },
+                       "user": {
+                        "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                        "format": "int64",
+                        "type": "integer"
                        }
                       },
                       "required": [
@@ -6497,6 +6678,11 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                       },
+                       "user": {
+                        "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                        "format": "int64",
+                        "type": "integer"
                        }
                       },
                       "required": [
@@ -6539,6 +6725,11 @@
                      "description": "Kubelet's generated CSRs will be addressed to this signer.",
                      "type": "string"
                     },
+                    "user": {
+                     "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                     "format": "int64",
+                     "type": "integer"
+                    },
                     "userAnnotations": {
                      "additionalProperties": {
                       "type": "string"
@@ -6574,6 +6765,11 @@
                        "path": {
                         "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                         "type": "string"
+                       },
+                       "user": {
+                        "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                        "format": "int64",
+                        "type": "integer"
                        }
                       },
                       "required": [
@@ -6613,6 +6809,11 @@
                     "path": {
                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
                      "type": "string"
+                    },
+                    "user": {
+                     "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                     "format": "int64",
+                     "type": "integer"
                     }
                    },
                    "required": [
@@ -6793,6 +6994,11 @@
                 "format": "int32",
                 "type": "integer"
                },
+               "defaultUser": {
+                "description": "defaultUser is Optional: The owner UID of the created files by default.\nThe defaultUser field is only used as a fallback when the item-level user field is unset.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                "format": "int64",
+                "type": "integer"
+               },
                "items": {
                 "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                 "items": {
@@ -6810,6 +7016,11 @@
                   "path": {
                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                    "type": "string"
+                  },
+                  "user": {
+                   "description": "user is Optional: The owner UID of the created file.\nIf specified, the item-level user field takes precedence over defaultUser.\n(Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.",
+                   "format": "int64",
+                   "type": "integer"
                   }
                  },
                  "required": [
@@ -7050,5 +7261,7 @@
    "additionalProperties": false
   }
  },
- "type": "object"
+ "type": "object",
+ "additionalProperties": false,
+ "$schema": "http://json-schema.org/schema#"
 }

--- a/manifests/claude-code/taskflow-smoke-workspace.yaml
+++ b/manifests/claude-code/taskflow-smoke-workspace.yaml
@@ -1,0 +1,208 @@
+# flow workspace（per-Task PVC）の配管を通すスモーク flow。LLM も Kata も通信も無し。
+#
+# taskflow-smoke.yaml が emptyDir 経路（handler が自分で持ち込むボリューム）を確かめるのに対し、
+# こちらは taskflow ADR-0002 / ADR-0003 の経路 — flow が volumeClaimTemplate を持ち、
+# コントローラが Task ごとに PVC を作り、書き込みは work/<runID> に pin され、
+# publish が封印後に results/<runID> へ rename する — を 2 フェーズで一周させる。
+#
+# cnp-check を 2 フェーズ化する前の予行演習でもある。ここで通らないものは本番でも通らない。
+#
+# 投げ方（cron は付けない。手動のスモーク）:
+#   kubectl -n claude-code create -f - <<EOF
+#   apiVersion: flow.tgy.io/v1alpha1
+#   kind: Task
+#   metadata: {generateName: smoke-ws-, namespace: claude-code}
+#   spec: {flow: smoke-workspace}
+#   EOF
+#
+# 期待: Task が 完了 (Success)。読み出し フェーズが 書き込み フェーズの report.md を
+# results/ 越しに読めて、中身の task uid が一致する。終わったら PVC が Task と一緒に消える。
+#
+# 確かめていること:
+#   - flow が spec.workspace を持つと PVC が実際に作られ、既定 {RWX, 1Gi} が default SC に落ちる
+#   - 予約名 flow-workspace のマウントに、subPath を書かなければ work/<runID> が焼かれる
+#   - prepare が out/ を 0555 で閉じるのは PVC 上でも同じ（宣言外のディレクトリを作れない）
+#   - publish の rename が qnap-nfs 上で成立し、results/<runID> に現れる
+#   - out/ を閉じた 0555 が rename を越えて棚の上でも保たれる（NFS 越しの権限保持は実測が要る）
+#   - 後続フェーズが subPath: results で「棚」を読める（自分の run ではなく前の run が見える）
+#
+# 棚のレイアウトは results/<runID>/out/<宣言ディレクトリ>/report.md。
+# out/ の1階層を忘れやすい（初版で踏んだ）。prepare は work/ を1階層上でマウントして
+# <runID>/out/ を作り、publish は <runID> ごと rename するので、out/ は棚に移っても残る。
+---
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskHandler
+metadata:
+  name: smoke-writer
+  namespace: claude-code
+spec:
+  phase: 書き込み
+  runner:
+    type: Job
+  timeout: 3m
+  maxInfraRetries: 1
+  # 予約名。コントローラがこの名前で PVC 由来のボリュームを差し込む。
+  # jobTemplate 側でこの名前のボリュームを定義すると checkWorkspace に拒否される。
+  workspace:
+    volume: flow-workspace
+    mountPath: /workspace
+  jobTemplate:
+    template:
+      metadata:
+        labels:
+          # taskflow-smoke.yaml と同じ扱い（この名前の CNP は無い = 全遮断）。通信は要らない。
+          taskflow-smoke: "true"
+      spec:
+        restartPolicy: Never
+        # taskflow-smoke.yaml が定義する ServiceAccount を再利用（ここでは定義しない）。
+        # 権限ゼロ・automountServiceAccountToken: false が一致しているので使い回して問題ない。
+        serviceAccountName: taskflow-smoke
+        automountServiceAccountToken: false
+        # runAsUser は必須。コントローラはこれと違う uid で out/ を閉じる。
+        securityContext:
+          runAsUser: 65533
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: handler
+            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:d5db59cac14b23a4ef85a456754522463267324e8ed3a84e795a2eba829c8f05
+            command: [sh, -c]
+            args:
+              - |
+                set -eu
+                echo "FLOW_DIRECTORIES=$FLOW_DIRECTORIES phase=$FLOW_PHASE"
+                ls -ld /workspace/out /workspace/out/*
+                # 宣言に無いディレクトリは作れないはず（emptyDir と同じ性質が PVC 上でも成り立つか）
+                if mkdir /workspace/out/evil 2>/dev/null; then echo "out/ is not closed"; exit 1; fi
+                # 読み出し フェーズが results/ 越しに拾って照合するマーカー
+                echo "$FLOW_TASK_UID" > /workspace/out/ok/report.md
+                echo "wrote marker $FLOW_TASK_UID"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+            volumeMounts:
+              # subPath を書かない = この run（work/<runID>）が見える。ADR-0003 決定1。
+              - name: flow-workspace
+                mountPath: /workspace
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+---
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskHandler
+metadata:
+  name: smoke-reader
+  namespace: claude-code
+spec:
+  phase: 読み出し
+  runner:
+    type: Job
+  timeout: 3m
+  maxInfraRetries: 1
+  workspace:
+    volume: flow-workspace
+    mountPath: /workspace
+  jobTemplate:
+    template:
+      metadata:
+        labels:
+          taskflow-smoke: "true"
+      spec:
+        restartPolicy: Never
+        # taskflow-smoke.yaml が定義する ServiceAccount を再利用（ここでは定義しない）。
+        # 権限ゼロ・automountServiceAccountToken: false が一致しているので使い回して問題ない。
+        serviceAccountName: taskflow-smoke
+        automountServiceAccountToken: false
+        securityContext:
+          runAsUser: 65533
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: handler
+            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:d5db59cac14b23a4ef85a456754522463267324e8ed3a84e795a2eba829c8f05
+            command: [sh, -c]
+            args:
+              - |
+                set -eu
+                echo "FLOW_DIRECTORIES=$FLOW_DIRECTORIES phase=$FLOW_PHASE"
+                # /shelf は封印済み run の棚。最大番号が直前の run（= 書き込み フェーズ）。
+                latest=$(ls /shelf | sort -n | tail -1)
+                echo "shelf: $(ls /shelf | tr '\n' ' ') -> latest=$latest"
+                # 棚のレイアウトは results/<runID>/out/<宣言ディレクトリ>/。
+                # prepare が work/ を1階層上でマウントして <runID>/out/ を作り、publish が
+                # <runID> ごと rename するので、out/ の階層は棚に移っても残る。
+                marker=$(cat "/shelf/$latest/out/ok/report.md")
+                # /shelf は readOnly マウントなので書き込み系の検査はマウントで潰れて何も
+                # 確かめられない（vacuous）。prepare が out/ を 0555 (dr-xr-xr-x) へ chmod
+                # した状態が publish の rename を越えて qnap-nfs 上でも保たれているかを、
+                # 読むだけで効く stat のモード確認で見る（sidecar.go の Prepare/modeOut）。
+                # 見たいのは下3桁の許可ビットで、setuid/setgid/sticky の有無ではない。
+                # NFS の構成次第では親ディレクトリの setgid が子に継承され stat -c %a が
+                # 2555 のような4桁を返しうる（実イメージで確認済み）。それは封印が緩んで
+                # いるわけではないので、末尾3桁の一致だけを見る。755 や 777 のような
+                # 封印の緩みはこれでも従来どおり落ちる。
+                outmode=$(stat -c %a "/shelf/$latest/out")
+                case "$outmode" in
+                  *555) ;;
+                  *)
+                    echo "shelf out/ is not sealed: mode=$outmode (want *555)"
+                    exit 1
+                    ;;
+                esac
+                # 自分の run は自分の out/ に書く（こちらは subPath 無しのマウント）
+                echo "read $marker from run $latest" > /workspace/out/ok/report.md
+                # 同じ Task の中なので、書き込み フェーズが残したマーカーと一致するはず
+                test "$marker" = "$FLOW_TASK_UID"
+                echo "marker matches: $marker"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+            volumeMounts:
+              # 自分の run（subPath 無し → work/<runID> が焼かれる）
+              - name: flow-workspace
+                mountPath: /workspace
+              # 棚（subPath を明示したので pin されない）。ADR-0002 決定5 の読み側推奨形。
+              - name: flow-workspace
+                mountPath: /shelf
+                subPath: results
+                readOnly: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+---
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskFlow
+metadata:
+  name: smoke-workspace
+  namespace: claude-code
+spec:
+  profile: investigate
+  # 中身を書かない = CRD の struct default {RWX, 1Gi} が admission で実体化される。
+  # storageClassName も書かないのでクラスタの default SC（qnap-nfs）に落ちる。
+  # 既定がそのまま使えることの確認も兼ねているので、ここは意図的に空。
+  workspace: {}
+  start: 書き込み
+  bindings:
+    書き込み:
+      handler: smoke-writer
+      next:
+        読み出し: ok
+    読み出し:
+      handler: smoke-reader
+      next:
+        完了: ok
+  terminals:
+    完了: Success
+  reworkBudget: 0


### PR DESCRIPTION
`taskflow-smoke.yaml` walks the emptyDir path — the one where a handler brings
its own volume. The path that matters now is the other one: a flow that
declares a workspace, a PVC made per task, writes pinned under `work/<runID>`,
and a rename onto the `results/` shelf once publish has sealed. **None of that
had ever run outside envtest**, and the thing that would have found out is
cnp-check — twenty-five minutes and a real API bill per attempt.

This walks it in **seven seconds** with a shell script. Two phases: one writes a
marker into `out/ok`, the other reads it back off the shelf and checks it
matches. Between them sits everything ADR-0002 and ADR-0003 decided — the
reserved `flow-workspace` name, the subPath the controller burns in when a mount
stays quiet about it, the explicit `subPath: results` that asks for the shelf
instead, the rename that moves a whole run directory across it.

## It earned its keep before it was committed

The first version of the read phase looked for `report.md` one directory too
high — `/shelf/<n>/ok/` instead of `/shelf/<n>/out/ok/`. prepare lays out
`<runID>/out/` and publish renames `<runID>`, so `out/` survives the move onto
the shelf.

That cost a `NoAnswer` and a pod log to find. **It is exactly the mistake anyone
writing cnp-check's reporting phase would make** — filed as taskflow#91 (the
shelf has no reference model; readers are left to find their own run) and #92
(the `out/` layer itself), along with #90 for the `ReadWriteMany` default nobody
wrote a reason for.

## Review found something worse

Asking whether the shelf is writable *by trying to write to it* proves nothing
when the mount is `readOnly`. The kubelet's ro bind refuses the write whatever
the directory's mode says, so the check would have **stayed green through a
controller that had stopped closing `out/` entirely** — a vacuous pass sitting
inside the very flow meant to catch that class of failure.

It reads the mode instead now, which a read-only mount is happy to answer:

```sh
outmode=$(stat -c %a "/shelf/$latest/out")
case "$outmode" in
  *555) ;;
  *) echo "shelf out/ is not sealed: mode=$outmode (want *555)"; exit 1 ;;
esac
```

The comparison matches on the **last three digits** rather than the whole
string. A setgid inherited from a parent directory would make `stat` say `2555`
without anything having come loose, and that misfire would land as an Escalated
task on **every run**. Write bits still cannot hide: no mode containing an octal
`2` matches `*555`, so `755` and `777` fail exactly as before.

## Measured on the cluster

Run to `完了 (Success)`, both phases `Declared`, twice — once before review and
once after, with the mode check in place.

| | |
|---|---|
| PVC | `1Gi` / **RWX** / **qnap-nfs**, Bound, `ownerRef=Task controller=true` |
| CRD default | `spec.workspace: {}` → `accessModes: [ReadWriteMany]`, `storage: 1Gi` materialised at admission |
| The shelf, on NFS | `dr-xr-xr-x` owned by prepare's uid, `out/ok` left at `0777` underneath |
| GC | PVC gone with the task, **no `pvc-protection` finalizer left behind** |
| Sealing | handler cannot `mkdir` inside `out/`; marker matches across phases |

**No setgid today**, then — the mask is there for the day the NAS is configured
differently, which is not a file in any of these repositories (qnap-nfs runs
`nfs-subdir-external-provisioner`; the export and ACL settings live on the NAS
itself).

## Not proven

Nothing here claims cnp-check will migrate cleanly. It claims the plumbing
carries a marker from one phase to the next on this cluster's storage. The flow
declares no `spec.workspace` for cnp-check, pr-review or smoke, so **this changes
nothing about how they run today** — it only makes the next change loud when it
breaks.

Reviewed across three rounds by `/infra-review-cycle`; the sealing check was
vacuous in the version that had already been "verified working" on the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VA39Gmq4sDrftq83AjDLy
