### PR TITLE
Update digest-cooldown to v1.2.0

### DIFF
--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write   # store first-seen instants in a PR comment
       contents: read         # read the diff
     steps:
-      - uses: Tsuguya-HC/digest-cooldown@242603d25ecfe604ed55f095b057c0e75d7e4ef0 # v1.1.0
+      - uses: Tsuguya-HC/digest-cooldown@7c1f020a6dccaf3a8daff6b34fafafe3743a6429 # v1.2.0
         with:
           cooldown-days: 3
           # First-party registries: their digests are built and signed by our


### PR DESCRIPTION
digest-cooldown v1.2.0 へ更新（[リリース](https://github.com/Tsuguya-HC/digest-cooldown/releases/tag/v1.2.0) / [Tsuguya-HC/digest-cooldown#22](https://github.com/Tsuguya-HC/digest-cooldown/pull/22)、issue #21）。

## なぜ

`REF` は 1 行に収まった ref しか取れないので、kustomize の `images:`（`newName:` と `newTag: latest@sha256:…` が別行）や Helm values の `repository`/`tag` 分割では、digest 行から抽出される名前が **tag**（`latest`）になっていた。`skip-registries: registry.infra.tgy.io` を設定していても一致しようがなく、自前でビルドして署名したイメージに「上流 compromise の発覚待ち時間」という本来存在しない前提の冷却が課されていた。taskflow の controller（#784）が 3 日足止めされ、`digest-cooldown-bypass` ラベルで回避したのがその実例。

v1.2.0 は同じマッピングブロックの `newName`/`repository` から名前を再構成し、それに対して `skip-registries` を当てる。判定できなかったものは従来どおり gate しつつ、PR コメントとログに「判定不能」として出るようになった。

## 影響

- **1 行形式の ref は挙動が変わらない**。このリポの実 PR 40 本を含む 60 本の diff で修正前後を比較し、変化したのは分割形式の 2 件（#780 / #784）だけであることを実測済み
- `kustomize/taskflow/kustomization.yaml` の controller が今後 gate されなくなる（agent-sidecar は 1 行形式なので元から skip されていた）

## 検証

- upstream の CI 全緑（テスト 333 checks）
- レビューは `/code-review-cycle` 3 ラウンド。CRITICAL 5 / HIGH 8 / MEDIUM 6 / LOW 5 を採用・修正、うちゲートを素通りする fail-open が 5 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VA39Gmq4sDrftq83AjDLy