### PR TITLE
Let the apiserver reach taskflow's admission webhook, and survive a drain

### DIFF
--- a/docs/argocd-projects.md
+++ b/docs/argocd-projects.md
@@ -13,6 +13,7 @@ ArgoCD AppProject でアプリケーションをドメインごとに分離し�
 | security | Secret 管理・セキュリティ (ESO, OAuth2 Proxy, Kanidm, Trivy, Kyverno) | `*` | 8 |
 | apps | ユーザー向けアプリケーション (Nextcloud, Harbor) | nextcloud, harbor | 2 |
 | storage | ストレージ (SeaweedFS, CNPG, QNAP CSI, NFS) | cnpg-system, database, nfs-provisioner, seaweedfs, trident | 6 |
+| ai | AI/ML インフラ (Qdrant, Ollama, TaskFlow) | qdrant, ollama, taskflow-system | 3 |
 
 ## クラスタスコープリソースの許可 (clusterResourceWhitelist)
 
@@ -64,6 +65,7 @@ ArgoCD AppProject でアプリケーションをドメインごとに分離し�
 | storage | PersistentVolume | core | ストレージ |
 | storage | CSIDriver | `*` | QNAP CSI |
 | storage | TridentOrchestrator | `*` | QNAP Trident |
+| ai | ValidatingWebhookConfiguration | admissionregistration.k8s.io | taskflow の TaskFlow 構造検査 webhook |
 
 ## 新しいサービスを追加するとき
 
@@ -99,5 +101,6 @@ manifests/argocd/
 ├── appproject-monitoring.yaml
 ├── appproject-argo.yaml
 ├── appproject-security.yaml
-└── appproject-storage.yaml
+├── appproject-storage.yaml
+└── appproject-ai.yaml
 ```

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -162,3 +162,27 @@ ping -c3 -I <PREFIX>:4::1 <HGW の LAN GUA>          # → 0/3
 **構成の詳細**: [IPv6](ipv6.md) を参照。
 
 **検知**: `blackbox-exporter` + `Probe/ipv6-egress` で監視している（`Ipv6EgressDown`）。ノードの VLAN 10 GUA を送信元にした HTTPS 疎通を見ているため、この障害を検知できる。`ip_protocol_fallback: false` を外すと v4 にフォールバックして常に成功扱いになるので変更しないこと。
+
+## TaskFlow 構造検査 webhook: caBundle 注入レース / コントローラ不在時の書き込み拒否
+
+TaskFlow の ValidatingWebhookConfiguration（taskflow #17 / ADR-0006）は `failurePolicy: Fail`。以下 2 つの窓で TaskFlow の CREATE/UPDATE が一時的に拒否されうる。
+
+1. **cainjector の caBundle 注入レース**: `cert-manager.io/inject-ca-from`（`kustomize/taskflow/kustomization.yaml`）は cainjector の非同期パッチで、ArgoCD の sync-wave はこれを待たない（VWC の生成完了 ≠ caBundle が埋まったこと。ArgoCD に VWC の health check は無い）。sync 直後や Certificate の定期更新直後の**数秒間**、caBundle が空のまま webhook が有効になり、apiserver が TLS を検証できず拒否されることがある。**実害の長さは未実測**
+2. **コントローラ不在**: rollout や ノード drain（Talos アップグレード）中も同様に拒否されうる。`replicas: 2` + PDB（`manifests/taskflow-system/pdb.yaml`）で緩和したが、**ゼロにはならない**（2 replica 同時に落ちる窓は残る）
+
+sync-wave をこれ以上早める手段は無く（cainjector の反応速度に依存する構造）、根治はできない。
+
+**症状の見分け方**:
+
+| 観測 | 結果 |
+|---|---|
+| TaskFlow の apply | `failed calling webhook "..."` 系のエラーで失敗 |
+| ArgoCD の taskflow app | sync が進まず止まる |
+
+**切り分け**:
+
+```sh
+kubectl get validatingwebhookconfiguration taskflow-validating-webhook-configuration \
+  -o jsonpath='{.webhooks[0].clientConfig.caBundle}'   # 空なら caBundle 未注入
+hubble observe --to-namespace taskflow-system --verdict DROPPED
+```

--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -53,6 +53,7 @@ All regular pods can reach kube-dns for DNS resolution. Individual CNPs below do
 | Prometheus (monitoring) | Harbor (harbor) | 8001 | Metrics scrape |
 | Prometheus (monitoring) | cert-manager controller/webhook/cainjector (cert-manager) | 9402 | Metrics scrape |
 | Prometheus (monitoring) | taskflow-controller (taskflow-system) | 8443 | Metrics scrape |
+| kube-apiserver | taskflow-controller (taskflow-system) | 9443 | TaskFlow admission webhook (failurePolicy: Fail) |
 | Grafana (monitoring) | Kanidm (kanidm) | 8443 | OIDC token exchange (direct, via CoreDNS rewrite) |
 | ArgoCD server (argocd) | Kanidm (kanidm) | 8443 | OIDC token exchange (direct, via CoreDNS rewrite) |
 | Argo Workflows server (argo) | Kanidm (kanidm) | 8443 | OIDC token exchange (direct, via CoreDNS rewrite) |
@@ -398,4 +399,11 @@ apiserver・Loki・Discord・GitHub・npm・crates・SeaweedFS・Prometheus・ho
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **taskflow-controller** | host/remote-node → 8081 (probes); prometheus (monitoring) → 8443 (metrics, TLS + authn/authz) | kube-apiserver |
+| **taskflow-controller** | host/remote-node → 8081 (probes); kube-apiserver/host/remote-node → 9443 (TaskFlow admission webhook); prometheus (monitoring) → 8443 (metrics, TLS + authn/authz) | kube-apiserver |
+
+9443 は TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。`fromEntities` に
+`kube-apiserver` / `host` / `remote-node` の 3 つを並べているのは、このクラスタの他の
+admission webhook（kyverno / cnpg / spin-operator、いずれも 9443）と同じ書き方に揃えているため。
+実際にどの identity で届くかはこのクラスタでは未実測。この webhook は `failurePolicy: Fail` なので、
+**ここを閉じると TaskFlow の作成・更新が全部拒否され、ArgoCD の sync が止まる**。絞るなら先に
+`hubble observe --to-namespace taskflow-system --verdict DROPPED` で実測してから。

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -27,7 +27,7 @@ kind: Kustomization
 # 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
 # enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=1b5603e6527f1fc5b7fb461a7a560af322f2bf4f
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=df67e629223a07138083aa9eae85b15c65432f18
 
 # newTag と digest を分けて併記すると、Renovate の kustomize manager が
 # invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
@@ -37,7 +37,7 @@ resources:
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest@sha256:63dad962c78d546c1d6ef4783aa6fcbcabb797c1b7925f351bbe7f28d906586a
+    newTag: latest@sha256:0847b7e3d926e7d74f5dc936842ae37603c15ece13c4ff8d73318b69ec8ff6fc
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
@@ -76,4 +76,61 @@ patches:
               - name: manager
                 env:
                   - name: SIDECAR_IMAGE
-                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:88f491e85d054dd50f4691b37bc87ec179f8d4ada10f77fc9d13c2d69ba78cba
+                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:22424078be8938e5404c53eb9116e572a75e0278ee378528dba07006a79905d7
+
+  # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。taskflow 側は caBundle を
+  # 持たない ValidatingWebhookConfiguration を配るだけなので、埋めるのはこちら —
+  # cainjector が manifests/taskflow-system/webhook-cert.yaml の Certificate から
+  # CA を読んで caBundle に書き込む。home-cluster で inject-ca-from を使うのはここが
+  # 初めてで、cainjector 自体は cert-manager 同梱で既に動いている。
+  #
+  # sync-wave 1: caBundle が空のまま webhook が有効になると、apiserver が証明書を
+  # 検証できず failurePolicy: Fail で TaskFlow の書き込みが全部落ちる。Certificate
+  # （wave -4）と Deployment（wave 0）の後に出す。
+  - target:
+      kind: ValidatingWebhookConfiguration
+      name: taskflow-validating-webhook-configuration
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          cert-manager.io/inject-ca-from: taskflow-system/taskflow-serving-cert
+          argocd.argoproj.io/sync-wave: "1"
+
+  # webhook が failurePolicy: Fail になった (taskflow #17 / ADR-0006) ことで、コントローラが
+  # 落ちている間は reconcile が遅れるだけでなく TaskFlow の CREATE/UPDATE が拒否される。
+  # Deployment には既に --leader-elect が付いており HA 化前提の作りなので replicas を
+  # 2 に上げる。メモリは 29Mi/128Mi と余裕があり、ワーカーは 3 台あるので podAntiAffinity
+  # (required) で 2 replica を別ノードに分散できる。
+  #
+  # rollout 戦略も明示する。既定の maxSurge: 25% は replicas 2 では 1 に切り上がり、
+  # required な podAntiAffinity と合わさると rollout 中に旧2 + 新1 = 3 Pod が同時に
+  # 別ホストを要求する瞬間ができる。ワーカーは 3 台しかないので、Talos のノード drain と
+  # rollout が重なると surge Pod が 0/3 nodes are available で Pending になり rollout が
+  # 止まる（サービス断ではない — maxUnavailable: 0 なので旧 Pod は残り、PDB が守る
+  # 最低 1 replica が webhook に応答し続ける）。maxSurge: 0 にすれば要求は常に既存
+  # replica 数（2 台）以下に収まり、3 台目を要求する場面自体が無くなる。
+  - target:
+      kind: Deployment
+      name: taskflow-controller-manager
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: taskflow
+                    control-plane: controller-manager
+                topologyKey: kubernetes.io/hostname
+      - op: add
+        path: /spec/strategy
+        value:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 0
+            maxUnavailable: 1

--- a/manifests/argocd/appproject-ai.yaml
+++ b/manifests/argocd/appproject-ai.yaml
@@ -19,6 +19,11 @@ spec:
   clusterResourceWhitelist:
     - group: '*'
       kind: CustomResourceDefinition
+    # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。cluster-scoped なので
+    # ここに無いと ArgoCD が「resource not permitted in project」で apply を拒む。
+    # group を '*' にせず絞れるのは、これを出す chart / base が 1 つしかないため。
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
     - group: '*'
       kind: ClusterRole
     - group: '*'

--- a/manifests/taskflow-system/netpol.yaml
+++ b/manifests/taskflow-system/netpol.yaml
@@ -17,6 +17,23 @@ spec:
         - ports:
             - port: "8081"
               protocol: TCP
+    # apiserver からの admission リクエスト（:9443）。TaskFlow の構造検査 webhook は
+    # failurePolicy: Fail なので、ここが開いていないと apiserver が webhook に届かず
+    # **TaskFlow の作成・更新が全部拒否される**（ArgoCD の sync が通らなくなる）。
+    #
+    # kube-apiserver / host / remote-node の 3 つを並べるのは、このクラスタの他の
+    # admission webhook（kyverno / cnpg / spin-operator、いずれも 9443）と同じ書き方に
+    # 揃えているため。実際にどの identity で届くかはこのクラスタでは未実測 —
+    # failurePolicy: Fail で外すと TaskFlow の書き込みが全部落ちるので、絞るなら先に
+    # `hubble observe --to-namespace taskflow-system --verdict DROPPED` で実測してから。
+    - fromEntities:
+        - kube-apiserver
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
     # Prometheus からの metrics スクレイプ（:8443、HTTPS + authn/authz）。
     # ここを開けないと ServiceMonitor があっても取れない。
     - fromEndpoints:

--- a/manifests/taskflow-system/pdb.yaml
+++ b/manifests/taskflow-system/pdb.yaml
@@ -1,0 +1,15 @@
+# webhook が failurePolicy: Fail (taskflow #17 / ADR-0006) になったことで、コントローラが
+# 落ちている間は TaskFlow の CREATE/UPDATE が拒否される。replicas 2 (kustomize/taskflow/
+# kustomization.yaml) だけでは、ノード drain (Talos アップグレード) で猶予なく両方 evict
+# されうる。minAvailable: 1 で drain 中も最低 1 replica を残す。
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: taskflow-controller
+  namespace: taskflow-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: taskflow

--- a/manifests/taskflow-system/webhook-cert.yaml
+++ b/manifests/taskflow-system/webhook-cert.yaml
@@ -1,0 +1,45 @@
+# TaskFlow の構造検査 webhook が使うサーバー証明書。
+#
+# taskflow 自身は cert-manager を知らない（ADR-0006 決定3）。配る
+# ValidatingWebhookConfiguration は caBundle を持たず、コントローラは
+# --webhook-cert-path の下のファイルを読むだけで、どこから来た証明書かを問わない。
+# 「どう動くか」は taskflow、「何ができるか」は home-cluster という §14 の分担が
+# 証明書にもそのまま当てはまるので、供給はこちらの裁量で決める。
+#
+# 自己署名で足りる。この証明書を検証するのは apiserver 1 者だけで、その apiserver は
+# caBundle を cainjector から受け取る。外から来る誰かに見せるものではないので、
+# letsencrypt-prod も pg-ca-issuer も要らない。
+#
+# sync-wave: Deployment（wave 0）が Secret webhook-server-cert を必須マウントするので、
+# 証明書が先に立っていないと manager Pod が起動しない。
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: taskflow-webhook-selfsigned
+  namespace: taskflow-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: taskflow-serving-cert
+  namespace: taskflow-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+spec:
+  # ValidatingWebhookConfiguration の cert-manager.io/inject-ca-from はこの
+  # namespace/name を指す（kustomize/taskflow の patch）。cainjector がここから
+  # CA を読んで caBundle を埋めるので、両者の名前がずれると webhook は
+  # 「証明書を検証できない」で落ち続ける。
+  secretName: webhook-server-cert
+  issuerRef:
+    kind: Issuer
+    name: taskflow-webhook-selfsigned
+  # apiserver が引く名前。Service 名と namespace は taskflow の config/webhook が
+  # 決めており（namePrefix taskflow-）、ここはそれに追従する。
+  dnsNames:
+    - taskflow-webhook-service.taskflow-system.svc
+    - taskflow-webhook-service.taskflow-system.svc.cluster.local


### PR DESCRIPTION
taskflow #17 / [ADR-0006](https://github.com/Tsuguya-HC/taskflow/blob/main/docs/adr/0006-taskflow-admission-webhook.md) で TaskFlow の構造検査 ValidatingAdmissionWebhook が入った（Tsuguya-HC/taskflow#103）。taskflow 側は **caBundle を持たない** WebhookConfiguration を配るだけで、証明書の供給は配置側の裁量（決定3）。**この PR がその配置側**。

## 入れるもの

| ファイル | 内容 |
|---|---|
| `manifests/taskflow-system/webhook-cert.yaml`（新規） | 自己署名 Issuer（wave -5）+ Certificate（wave -4、Secret `webhook-server-cert`） |
| `kustomize/taskflow/kustomization.yaml` | `?ref=` を `df67e62` へ、controller / agent-sidecar の digest を同コミットのビルドへ。VWC に `cert-manager.io/inject-ca-from` + `sync-wave: 1` |
| `manifests/taskflow-system/netpol.yaml` | CNP に 9443 ingress |
| `manifests/argocd/appproject-ai.yaml` | `clusterResourceWhitelist` に `ValidatingWebhookConfiguration` |

証明書は自己署名で足りる。これを検証するのは apiserver 1 者だけで、その apiserver は caBundle を cainjector から受け取る。外に見せるものではないので letsencrypt も pg-ca-issuer も要らない。

sync-wave の順序は必然で、ref を上げると `manager_webhook_patch.yaml` が付いてきて Deployment が Secret `webhook-server-cert` を **必須マウント**する（`optional` ではない）。証明書が先に立っていないと manager Pod が起動しない。

`clusterResourceWhitelist` を忘れると ArgoCD が「resource not permitted in project」で apply 自体を拒む。

## CNP は既存の書き方に揃えた

9443 の `fromEntities` は `kube-apiserver, host, remote-node`。このクラスタの他の admission webhook と同じ組み合わせ:

| CNP | port | fromEntities |
|---|---|---|
| kyverno（admission / cleanup） | 9443 | kube-apiserver, host, remote-node |
| cnpg | 9443 | kube-apiserver, host, remote-node |
| spin-operator | 9443 | kube-apiserver, host, remote-node |
| cert-manager webhook | 10250 | kube-apiserver, remote-node |

**実際にどの identity で届くかは未実測。** 絞るなら `hubble observe --to-namespace taskflow-system --verdict DROPPED` で測ってから。`failurePolicy: Fail` なので、誤って閉じると TaskFlow の作成・更新が全部拒否される。

## コントローラを 2 replica にする

webhook を入れると「controller が落ちる」の意味が変わる。**これまでは reconcile が遅れるだけのソフト障害**だったが、**これからは TaskFlow の CREATE/UPDATE が拒否されるハード障害**になる。ノード drain（Talos アップグレード）・OOM・rollout はいずれも実際に起きる。

- `replicas: 2` + `podAntiAffinity`（required、`kubernetes.io/hostname`）
- `PodDisruptionBudget`（`minAvailable: 1`）
- `strategy.rollingUpdate.maxSurge: 0` / `maxUnavailable: 1`

`maxSurge` を明示するのは、既定の 25% が replicas 2 では **1 に切り上がる**ため。required な anti-affinity と合わさると rollout 中に旧2+新1=3 Pod が別ホストを要求し、**ワーカーは 3 台しかない**ので Talos の drain と重なると surge Pod が Pending で rollout が止まる（サービス断は起きないが余白がゼロになる）。`maxSurge: 0` なら要求は常に既存 replica 数以下に収まる。

`--leader-elect` は既に付いており、reconcile するのは常に 1 replica。ADR-0004（runID は決着した run を数える）の一意性前提とも矛盾しない。

## 残す穴

`cert-manager.io/inject-ca-from` は cainjector の**非同期パッチ**で、ArgoCD の sync-wave はこれを待たない（VWC の生成完了 ≠ caBundle が埋まったこと）。caBundle が空の窓では TaskFlow の書き込みが拒否される。初回だけでなく **Certificate の定期更新のたびに再発しうる**。sync-wave 側で短縮する手段は無いので、`docs/known-issues.md` に症状と切り分けコマンドを書いて残した。**窓の実際の長さは未実測**。

## 検証

`/lint`（11ルール）と `/infra-review-cycle`（3ラウンド、採用6 / 却下2）を通した。

- `kubectl kustomize kustomize/taskflow` → kubeconform `Valid: 22, Invalid: 0`
- `kubectl apply --dry-run=server` 全リソース通過
- `scripts/unread-values.py` → `checked 31 values file(s), no unread keys`
- 旧 ref との差分で増えるオブジェクトは webhook Service と VWC の **ちょうど 2 つ**
- `podAntiAffinity` と PDB の `labelSelector` が rendered Deployment の `spec.selector.matchLabels` と**文字列一致**（ずれると静かに無意味になる）
- 4 つ目の Deployment patch が既存 3 つを壊していないこと（cpu limit が依然として存在しない、`SIDECAR_IMAGE` digest 健在）

レビューで直したもの: CNP の `kube-apiserver` 欠落（`failurePolicy: Fail` で全拒否になりうる CRITICAL）、`docs/argocd-projects.md` の未追従、replica 1 + PDB なし、rollout 戦略。**コメントに書いていた「実測による」という記述は事実無根だったので削除した**（実測していない）。

## 追従

`docs/network-policies.md` / `docs/argocd-projects.md` / `docs/known-issues.md`。taskflow 側 ADR-0006 の「コントローラは replica 1 なので rollout 中は数秒拒否される」という記述はこの PR で古くなるので、別途 taskflow 側で直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111MCbUZgFHoup2PvgSdGDd