### PR TITLE
Follow taskflow to where status stopped pointing

### DIFF
--- a/.github/schemas/flow.tgy.io/task_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/task_v1alpha1.json
@@ -13,7 +13,7 @@
    "type": "object"
   },
   "spec": {
-   "description": "TaskSpec is the whole instance. Four fields, three of them optional: whoever\ncreates a task — a cron, an event, an agent — does not have to know the\ngraph, and the graph can change without them changing.\n\nThe spec is immutable after creation. Editing what a running task was asked\nto do would leave its history describing a question nobody asked.",
+   "description": "TaskSpec is the whole instance. Four fields, three of them optional: whoever\ncreates a task — a cron, an event, an agent — does not have to know the\ngraph, and the graph can change without them changing.\n\nThe spec is immutable after creation. Editing what a running task was asked\nto do would leave its history describing a question nobody asked.\n\nThe rule covers input as well, which is not obvious: input is\nx-kubernetes-preserve-unknown-fields, and CEL cannot address what is inside\nit. Comparing the whole spec still works — measured, with the rule removed\nas a control, in api_shapes_test.go.",
    "properties": {
     "dedupKey": {
      "description": "DedupKey suppresses creation while another task with the same key is\nstill running. Useful when the producer is an event source that may\ndeliver twice.",
@@ -35,17 +35,8 @@
    "additionalProperties": false
   },
   "status": {
-   "description": "TaskStatus holds control state only. Logs, reports and results are\nreferences — etcd has been lost twice here, and a design that puts payloads\nin it turns that from an outage into data loss.",
+   "description": "TaskStatus holds control state only. Logs, reports and results are not here\n— etcd has been lost twice here, and a design that puts payloads in it turns\nthat from an outage into data loss. Nor are pointers to them: where a run's\noutput was put is the deployment's arrangement, and this status is written\nby a controller that has no part in it (ADR-0008).",
    "properties": {
-    "artifacts": {
-     "properties": {
-      "store": {
-       "type": "string"
-      }
-     },
-     "type": "object",
-     "additionalProperties": false
-    },
     "conditions": {
      "items": {
       "description": "Condition contains details for one aspect of the current state of this API Resource.",
@@ -102,7 +93,7 @@
      "type": "array"
     },
     "currentRun": {
-     "description": "RunRef identifies one execution of one phase. runID separates the second\nvisit to a phase from the first, so a rework does not read what the previous\nattempt left behind.",
+     "description": "RunRef identifies one execution of one phase. runID separates the second\nvisit to a phase from the first, so a rework does not read what the previous\nrun left behind. It does not separate two attempts at starting one run —\nan infrastructure retry comes back with the same number (ADR-0004), and\ninfraRetries is what tells those apart.\n\nA task's currentRun, when it has one, always names the phase the task is\non. A task that has stopped has no currentRun at all.",
      "properties": {
       "deadline": {
        "format": "date-time",
@@ -114,7 +105,7 @@
        "type": "integer"
       },
       "jobName": {
-       "description": "JobName is derived deterministically from the task, phase and runID, so\na controller restart re-creates the same object instead of a second one.",
+       "description": "JobName is derived deterministically from the task, phase, runID and\nthe count of infrastructure retries, so a controller restart re-creates\nthe same object instead of a second one.",
        "type": "string"
       },
       "phase": {
@@ -140,7 +131,7 @@
     },
     "history": {
      "items": {
-      "description": "HistoryEntry records a completed run. This is the audit trail; the artifacts\nit points at live in object storage, never in etcd.",
+      "description": "HistoryEntry records a completed run. This is the audit trail, and it is\nthe whole of what the framework knows: what the run decided and why. Where\nthe run's output ended up is not here, because the controller never learns\nit — it does not touch the workspace or any store (ADR-0008).",
       "properties": {
        "directory": {
         "description": "Directory the handler wrote into, empty when the run produced no single\nanswer.",
@@ -161,10 +152,6 @@
        "reason": {
         "description": "Reason is the one line a human reads next to Outcome: which edge was\nfollowed, or why no answer counted, or what the handler said after\nnaming its directory. The transition never reads it.",
         "maxLength": 2048,
-        "type": "string"
-       },
-       "ref": {
-        "description": "Ref points at the run's output in the store.",
         "type": "string"
        },
        "runID": {
@@ -192,7 +179,7 @@
      "type": "integer"
     },
     "runID": {
-     "description": "RunID of the current or last run.",
+     "description": "RunID of the current or last run. It counts the runs this task has\ndecided its way through, not the attempts it took to start them: an\ninfrastructure retry leaves it alone, so the numbers on the results/\nshelf run without gaps (ADR-0004).",
      "format": "int32",
      "type": "integer"
     }

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -27,7 +27,7 @@ kind: Kustomization
 # 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
 # enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=df67e629223a07138083aa9eae85b15c65432f18
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=70f34e22dd47e0d03227f05c6d8cde84679ab7ff
 
 # newTag と digest を分けて併記すると、Renovate の kustomize manager が
 # invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
@@ -37,7 +37,7 @@ resources:
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest@sha256:0847b7e3d926e7d74f5dc936842ae37603c15ece13c4ff8d73318b69ec8ff6fc
+    newTag: latest@sha256:858f3f85ef320158784925c17a169ef0baf70e48bb7adbd4605b4604cce4c085
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
@@ -76,7 +76,7 @@ patches:
               - name: manager
                 env:
                   - name: SIDECAR_IMAGE
-                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:22424078be8938e5404c53eb9116e572a75e0278ee378528dba07006a79905d7
+                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:6a4b221fa1820212e5b72f1a715566e0b341f9517d6849da679bdd9b85f04c02
 
   # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。taskflow 側は caBundle を
   # 持たない ValidatingWebhookConfiguration を配るだけなので、埋めるのはこちら —


### PR DESCRIPTION
Tsuguya-HC/taskflow#105 が `status.artifacts` と `status.history[].ref` を落とした（誰も書かないフィールド。コントローラは run の出力がどこへ行ったかを知る道が無いので、埋めようが無かった）。その CRD と、同じコミットからビルドしたコントローラを取り込む。

- `?ref=` → `70f34e2`
- controller / agent-sidecar の digest → 同コミットのビルド（`taskflow-build-2ls6l` / `taskflow-sidecar-build-rz5b4`、両方とも `commit-sha=70f34e2` で Succeeded）
- `.github/schemas/flow.tgy.io/task_v1alpha1.json` を regen

## スキーマミラーが 2 週間ずれていた

このミラーは飾りではなく、`_kubeconform.yml` が `-schema-location '.github/schemas/{{.Group}}/...'` を渡して `manifests/` と `apps/` を `-strict` で検査している。`manifests/claude-code/` の TaskFlow / Task がこれで検証される。

ところが最後に regen されたのは **#733**（taskflow #68 の頃）で、今回の diff には今回の削除だけでなく、ADR-0004 の `infraRetries` や taskflow #98 の spec immutability の説明まで一緒に出てきた。**約 2 週間、デプロイされている CRD より古いスキーマで検査していた**ことになる。

descriptions の差分は実害が無いが、`-strict`（`additionalProperties: false`）なので、フィールドの増減がずれると「新しいフィールドを使った manifest を誤って落とす」「消えたフィールドを使った manifest を誤って通す」が起きる。今回はまさに後者の状態だった。

**この regen を強制する仕組みは無い。** `scripts/crd2schema.py` の冒頭コメントが「taskflow 側で types のコメントを変えただけでもここを再生成する」と書いているだけで、忘れても何も言わない。

## 検証

- `kubectl kustomize kustomize/taskflow` → 25 objects、`replicas: 2` / `maxSurge: 0` / `inject-ca-from` / 新 digest がレンダリング結果に出ている
- レンダリング結果の CRD に `artifacts` は **0 件**
- `kubeconform -strict`（**今回 regen したスキーマを使って**）→ `Valid: 22, Invalid: 0, Errors: 0, Skipped: 3`
- `taskflow_v1alpha1.json` と `taskhandler_v1alpha1.json` は regen してもバイト一致 — #103 の webhook 追加がこの 2 つの CRD を触っていないことの裏付けになっている

CRD からフィールドが消えるロールアウトは両方向とも安全（前 PR #803 のレビューで確認済み）: 「新 CRD × 旧バイナリ」は旧バイナリが書く `""` / `nil` が structural schema pruning で落ちるだけ、「旧 CRD × 新バイナリ」は optional フィールドが埋まらないだけで読み手がいない。

`/lint` は 11 ルールとも該当なしで通過（機密値なし、新規ワークロードなし、CNP 変更なし、helm-values 変更なし）。ref/digest bump + 生成ファイル 1 つなので `/infra-review-cycle` は回していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111MCbUZgFHoup2PvgSdGDd