### PR TITLE
Put the schema regen where the ref is bumped

### DIFF
--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -10,6 +10,18 @@ kind: Kustomization
 # 先に進む（ビルド完了前に digest が動く）ため、CRD / RBAC が変わったときに、下の images の
 # digest と同じ commit へ人が揃えて上げる。両者が同じ commit を指しているかの検証は #687。
 #
+# **この ref を上げるときは .github/schemas/flow.tgy.io/*.json も同じ commit から再生成する。**
+#
+#   for c in tasks taskflows taskhandlers; do
+#     python3 scripts/crd2schema.py ../taskflow/config/crd/bases/flow.tgy.io_$c.yaml .github/schemas/flow.tgy.io
+#   done
+#
+# あれは飾りではなく、_kubeconform.yml が -schema-location で読み込んで manifests/ と apps/ を
+# -strict で検査している（manifests/claude-code/ の TaskFlow / Task がこれに掛かる）。再生成を
+# 強制する仕組みは無いので、忘れるとミラーだけが古い CRD を語り続ける — 2026-09-05 に実際
+# 2 週間ずれており（最後の再生成が #733）、消えたフィールドを使った manifest を -strict が
+# 誤って通す状態だった。忘れても CI は緑のままなので、気づく手段はこの行しかない。
+#
 # 逆方向（イメージが CRD/RBAC より先に進む）のドリフトも構造的に起こりうる。Argo のビルドは
 # *.go 等の変更でのみ発火し config/ 単独では発火しないが、kubebuilder では CRD/RBAC が Go の
 # マーカーから make manifests で生成されるため、Go 変更と config/default 変更は同一コミットに


### PR DESCRIPTION
`.github/schemas/flow.tgy.io/*.json` の再生成を、**それを忘れる場所**（`kustomize/taskflow/kustomization.yaml` の `?ref=` の隣）に書く。コメント 12 行の追加だけで、レンダリング結果は不変。

## なぜここか

このミラーは飾りではなく、`_kubeconform.yml` が `-schema-location '.github/schemas/{{.Group}}/...'` で読み込んで `manifests/` と `apps/` を `-strict` で検査している（`manifests/claude-code/` の TaskFlow / Task がこれに掛かる）。

再生成を強制する仕組みは無い。`scripts/crd2schema.py` は自分のヘッダに「taskflow 側で types のコメントを変えただけでも再生成する」と書いているが、**動かしていない生成器のコメントは誰も読まない**。

実際 #805 で regen したとき、最後の再生成は **#733** で約 2 週間ずれていた。その間 `-strict`（`additionalProperties: false`）は、デプロイ済みの CRD にもう無いフィールドを使った manifest を素通ししていた。**外から見ると CI は緑**なので、気づく手段が無い。

## 選択肢と判断

1. CI で regen して差分が出たら落とす — 忘れようがなくなるが、home-cluster の CI から `../taskflow` は見えないので、他リポ参照という新しい依存が要る
2. **`?ref=` を上げる手順に組み込む**（これ）— 仕組みは増えず、チェックリスト 1 行で済む
3. 何もしない

ミラーがずれるのは `?ref=` を上げるときだけで、その手順は既に「人が ref と digest を揃えて上げる」と決まっている（同じコメントブロックに書いてある）。守る対象の薄さに対して 1 は依存が重い、という判断で 2 を採った。

**この選択の弱点は明示しておく**: 忘れる余地は残る。忘れたときに鳴るものは無く、次に `?ref=` を触った人がこの行を読むかどうかに掛かっている。1 と違って fail-closed ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111MCbUZgFHoup2PvgSdGDd