### PR TITLE
Expose shared-pg on the LAN through a TLS passthrough Gateway (pg.infra.tgy.io)

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -186,3 +186,11 @@ kubectl get validatingwebhookconfiguration taskflow-validating-webhook-configura
   -o jsonpath='{.webhooks[0].clientConfig.caBundle}'   # 空なら caBundle 未注入
 hubble observe --to-namespace taskflow-system --verdict DROPPED
 ```
+
+## CoreDNS: `.:53` の hosts に足した `*.infra.tgy.io` 名は template に先取りされる（クラスタ内解決に限る）
+
+**クラスタ内 CoreDNS からの解決に限る話。** `.:53` サーバブロックは `template IN A infra.tgy.io`（plugin.cfg の順で `hosts` より先）が `*.infra.tgy.io` にマッチする全クエリに answer を返し `fallthrough` する。`fallthrough` は **regex 不一致時のみ** hosts に流すので、`.:53` の hosts に個別 IP を足しても template が先に答えて握りつぶす。既存の `192.168.10.191 argocd.infra.tgy.io` の hosts 行もこの理由でクラスタ内 CoreDNS には効いていない（2026-09-07 rendering レビューで実測）。
+
+LAN / 外部クライアントはクラスタ内 CoreDNS を引かず Cloudflare の公開レコード（external-dns 管理）を引くので、`argocd.infra.tgy.io` はワイルドカード（.190）ではなく individual レコード（.191）に正しく解決される。クラスタ内 Pod がこれらの `*.infra.tgy.io` 名を引く用途は現状無い（各サービスは `*.svc.cluster.local` を使う）。
+
+infra.tgy.io 配下で個別 IP を返すのは external-dns の個別レコード（HTTPRoute / TLSRoute の hostname から生成）の役目であり、CoreDNS の hosts に足しても LAN / 外部クライアントには効かない。CoreDNS 側で専用サーバブロック（`example.infra.tgy.io:53 { hosts { ... } }`）を切れば template を経由せず直接応答させる手段としては可能だが、クラスタ内解決にしか効かないため通常はこちらを使う理由がない。

--- a/docs/network-policies.md
+++ b/docs/network-policies.md
@@ -256,7 +256,7 @@ apiserver・Loki・Discord・GitHub・npm・crates・SeaweedFS・Prometheus・ho
 
 | Component | Ingress | Egress |
 |---|---|---|
-| **shared-pg** | grafana (monitoring), argo-workflows-controller (argo), argo-workflows-server (argo), nextcloud (nextcloud), harbor-core (harbor), harbor-exporter (harbor), harbor-jobservice (harbor), seaweedfs-filer (seaweedfs), horenso (horenso), trading (collector), trading (reporter) → 5432; self → 5432/8000 (replication); cloudnative-pg (cnpg-system), host → 8000 (probes) | kube-apiserver, self:5432/8000, *.r2.cloudflarestorage.com:443 (backup) |
+| **shared-pg** | grafana (monitoring), argo-workflows-controller (argo), argo-workflows-server (argo), nextcloud (nextcloud), harbor-core (harbor), harbor-exporter (harbor), harbor-jobservice (harbor), seaweedfs-filer (seaweedfs), horenso (horenso), trading (collector), trading (reporter) → 5432; ingress (pg-gateway: pg.infra.tgy.io TLS passthrough, 192.168.10.193:443 → shared-pg-rw:5432, direct-TLS clients only。**注意**: `pg_hba` の既定は `host all all all scram-sha-256` で、Envoy 中継のためクライアントの送信元 IP が見えず経路を区別できない。この ingress ルールは shared-pg の全ロール（grafana / argo / nextcloud / seaweedfs / horenso / trading / app）に到達可能にする。段階 2（クライアント証明書）までの暫定であり、反映後に `pg_stat_activity.client_addr` で Envoy 側の送信元アドレスを実測し、`pg_hba` で経路を分けられるか確認すること) → 5432; self → 5432/8000 (replication); cloudnative-pg (cnpg-system), host → 8000 (probes) | kube-apiserver, self:5432/8000, *.r2.cloudflarestorage.com:443 (backup) |
 
 ## cert-manager (4 policies)
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -23,6 +23,7 @@ ArgoCD のみ TLS Passthrough（専用 argocd-gateway、ArgoCD 自身が TLS 終
 |---|---|---|
 | PostgreSQL (RW) | shared-pg-rw.database.svc:5432 | CNPG 管理、2 インスタンス |
 | PostgreSQL (RO) | shared-pg-ro.database.svc:5432 | リードレプリカ |
+| PostgreSQL (LAN 直結、trading 台帳の手元作業用) | pg.infra.tgy.io:443 | Passthrough (pg-gateway) → shared-pg-rw:5432。external-dns が Cloudflare に A レコード（LAN のプライベート IP 192.168.10.193）を作る。argocd.infra.tgy.io と同じ扱いで、公開 DNS に載るがインターネットからは到達不能。(a) direct TLS 必須（libpq 17+ `sslnegotiation=direct`）、(b) `sslmode=verify-full` + pg-ca-issuer の CA を信頼する必要あり。到達できない場合のフォールバックは home-trading の `scripts/pg_tunnel.sh`（kubectl port-forward） |
 | Loki | loki-gateway.monitoring.svc:80 | ログ集約 |
 | Tempo (HTTP API) | tempo.monitoring.svc:3200 | 分散トレーシング（クエリ） |
 | Tempo (OTLP gRPC) | tempo.monitoring.svc:4317 | トレース取り込み |

--- a/manifests/database/netpol-shared-pg.yaml
+++ b/manifests/database/netpol-shared-pg.yaml
@@ -75,6 +75,14 @@ spec:
         - ports:
             - port: "8000"
               protocol: TCP
+    # pg.infra.tgy.io（pg-gateway、TLS パススルー）からの流入。Envoy が中継するので送信元は
+    # reserved:ingress になり、クライアントの IP はここでは見えない。
+    - fromEntities:
+        - ingress
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
   egress:
     - toEntities:
         - kube-apiserver

--- a/manifests/database/pg-certificates.yaml
+++ b/manifests/database/pg-certificates.yaml
@@ -21,6 +21,7 @@ spec:
     - shared-pg-ro.database
     - shared-pg-ro.database.svc
     - shared-pg-ro.database.svc.cluster.local
+    - pg.infra.tgy.io
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/manifests/database/pg-gateway.yaml
+++ b/manifests/database/pg-gateway.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: pg-gateway
+  namespace: database
+spec:
+  gatewayClassName: cilium
+  # external-dns が TLSRoute の hostname からこの IP の A レコードを公開 DNS に作る
+  # （argocd.infra.tgy.io と同じ）。LB-IPAM の割り当てに任せず指名して、レコードが動かないようにする。
+  addresses:
+    - type: IPAddress
+      value: 192.168.10.193
+  listeners:
+    - name: passthrough
+      hostname: pg.infra.tgy.io
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        kinds:
+          - group: gateway.networking.k8s.io
+            kind: TLSRoute
+        namespaces:
+          from: Same

--- a/manifests/database/pg-tlsroute.yaml
+++ b/manifests/database/pg-tlsroute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: shared-pg
+  namespace: database
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: pg-gateway
+      namespace: database
+      sectionName: passthrough
+  hostnames:
+    - pg.infra.tgy.io
+  # SNI で振り分けるので、クライアントは最初のバイトから TLS で話す必要がある
+  # （libpq 17+ の sslnegotiation=direct、サーバは PostgreSQL 17+）。通常の PG ハンドシェイクは
+  # 平文の SSLRequest から始まり SNI が見えないため、この経路では繋がらない。
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: shared-pg-rw
+          port: 5432
+          weight: 1


### PR DESCRIPTION
## What

- `manifests/database/pg-gateway.yaml` / `pg-tlsroute.yaml` — 専用 Gateway（`spec.addresses` 192.168.10.193、TLS Passthrough）+ TLSRoute → `shared-pg-rw:5432`。kanidm / argocd と同型
- `netpol-shared-pg.yaml` — `fromEntities: ingress` → 5432
- `pg-certificates.yaml` — dnsNames に `pg.infra.tgy.io`（`sslmode=verify-full` 用）
- docs: services.md（内部サービス節）、network-policies.md（暫定リスク: Envoy 中継で送信元が見えず、pg_hba が scram 全許可なので全ロールに到達可能。段階 2 のクライアント証明書まで）、known-issues.md（クラスタ内 CoreDNS の hosts が template に先取りされる）

## Why

台帳の手元作業（run_trial / ledger_stats / psql）が 2〜3 日に一度 PG に繋ぐが、kubectl port-forward はクライアント切断ごとに再起動し同時接続が落ちる（home-trading #170 の経緯）。LAN から直接、TLS + scram で繋げる入口を作る。

## DNS の経路（レビューで一度設計が変わった）

当初は CoreDNS の hosts + external-dns から除外にしていたが、(1) CoreDNS は `template` が `hosts` より先に走るので hosts が効かない（実バイナリで再現）、(2) そもそも LAN クライアントは公開 DNS を引いており `*.infra.tgy.io` のワイルドカードが .190 を返す、の 2 点で崩れた。**argocd.infra.tgy.io と同じ**「external-dns が TLSRoute の hostname から Cloudflare にプライベート IP の A レコードを作る」方式に揃えた（argocd の TXT 所有権レコード `resource=tlsroute/argocd/argocd-server` で実証）。CoreDNS と external-dns の values は変更なし。

## 制約

- クライアントは direct TLS（libpq 17+ `sslnegotiation=direct`）必須。psql 16 以前は不可
- home-trading 側（`collectors/pg.py` に sslnegotiation / verify-full / CA）は別 PR

## 反映後の確認

Gateway の PROGRAMMED と ADDRESS=.193 / 公開 DNS の A レコード / 証明書の SAN 再発行 / この PC から verify-full で接続 / `pg_stat_activity.client_addr` で Envoy 側の送信元を実測（段階 2 の材料）

## Review

/infra-review-cycle 3 ラウンド、採用 8 件（rendering CRITICAL: CoreDNS の先取り / consistency CRITICAL: LAN は公開 DNS / 証明書 SAN（3 名一致）ほか）。Round 3 全員 CLEAR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH
