### PR TITLE
Move taskflow's ref and both images to the same commit

### DIFF
--- a/.github/schemas/flow.tgy.io/taskhandler_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskhandler_v1alpha1.json
@@ -16,7 +16,7 @@
    "description": "TaskHandlerSpec is the box that fills one phase.\n\nThere is no field here for a prompt, a model, an API key, a store or a\nnotification target, and that absence is the design: the controller's\nvocabulary is phases, Jobs and verdicts, and everything an LLM needs lives\nin the pod spec its author writes. The same shape therefore accepts a\nlinter, a test suite or a shell script — from the controller's side there is\nno difference between those and an agent.",
    "properties": {
     "jobTemplate": {
-     "description": "JobTemplate is handed to the runner as written. The controller does not\nadd labels, service accounts or images to it: what a pod must carry to\nbe selected by a network policy is a property of the cluster it runs in,\nnot something a framework may decide. What the framework provides is one\nplace to say it — a pod template as CronJob users know it, but with only\ntemplate and no job-level spec (no backoffLimit, no completions, no\nparallelism) — rather than the two locations with differing semantics\nthat Argo requires.\n\nRequired when runner.type is Job; ignored when it is External.",
+     "description": "JobTemplate is handed to the runner as written. The controller does not\nadd labels, service accounts or images to it: what a pod must carry to\nbe selected by a network policy is a property of the cluster it runs in,\nnot something a framework may decide. What the framework provides is one\nplace to say it — a pod template as CronJob users know it, but with only\ntemplate and no job-level spec (no backoffLimit, no completions, no\nparallelism) — rather than the two locations with differing semantics\nthat a workflow engine's own template would ask for.\n\nRequired when runner.type is Job; ignored when it is External.",
      "properties": {
       "template": {
        "description": "PodTemplate is the pod a run consists of.",
@@ -7153,7 +7153,7 @@
      "properties": {
       "type": {
        "default": "Job",
-       "description": "RunnerType selects how a phase is executed.\n\nArgo Workflows is deliberately absent. Multi-step work fits in one pod with\nshared volumes, so an Argo runner would buy only the reuse of existing\nWorkflowTemplates — not worth the dependency, and a single pod structurally\navoids the \"emptyDir is not shared between steps\" trap that cost a day.",
+       "description": "RunnerType selects how a phase is executed.\n\nA workflow engine is deliberately absent. Multi-step work fits in one pod\nwith shared volumes, so an engine-backed runner would buy only the reuse of\ndefinitions already written for it — not worth the dependency, and a single\npod structurally avoids the class of trap where a volume the steps are meant\nto share turns out to be scoped to one pod.",
        "enum": [
         "Job",
         "External"

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -39,7 +39,7 @@ kind: Kustomization
 # 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
 # enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=70f34e22dd47e0d03227f05c6d8cde84679ab7ff
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=18c3377e1d3d38d83878818bc3895933cc66d327
 
 # newTag と digest を分けて併記すると、Renovate の kustomize manager が
 # invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
@@ -49,7 +49,7 @@ resources:
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest@sha256:858f3f85ef320158784925c17a169ef0baf70e48bb7adbd4605b4604cce4c085
+    newTag: latest@sha256:c2f827a821e4149e185301fa1a9e6a10c9be6b0a5895851483be7db3d18c1318
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
@@ -88,7 +88,7 @@ patches:
               - name: manager
                 env:
                   - name: SIDECAR_IMAGE
-                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:6a4b221fa1820212e5b72f1a715566e0b341f9517d6849da679bdd9b85f04c02
+                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:76f5e49abbab02bb508db3ded2ea5af4e4b7795950397ddcf92da753aa7cdfc3
 
   # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。taskflow 側は caBundle を
   # 持たない ValidatingWebhookConfiguration を配るだけなので、埋めるのはこちら —


### PR DESCRIPTION
`?ref=` と controller / agent-sidecar の 2 イメージを taskflow `18c3377` に揃える。

Renovate はイメージ欄しか見えないので #801 / #802 が別々に立った。どちらか単独で
マージすると `resources:` 上のコメントが警告しているドリフトそのものになる —
今回は 70f34e2..18c3377 で `taskhandlers` の CRD が動いているので実害が出る側。

- `?ref=` 70f34e2 → 18c3377
- controller `858f3f85` → `c2f827a8`（Harbor 上のタグで 18c3377 と確認）
- agent-sidecar `6a4b221f` → `76f5e49a`（同上）
- `.github/schemas/flow.tgy.io/*.json` を同じ commit から再生成（`taskhandler` の description のみ変化）

`kustomize build kustomize/taskflow` でレンダリング確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH