### PR TITLE
Keep ./ for the local workflow calls zizmor 1.30 will flag

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -153,28 +153,34 @@ jobs:
   kubeconform:
     needs: detect
     if: ${{ needs.detect.outputs.kubeconform == 'true' }}
-    uses: ./.github/workflows/_kubeconform.yml
+    # zizmor 1.30 の self-repository は `./` を `$/` にしろと言う。従わないのは、
+    # `$/` にすると actionlint が呼び出しを解決できなくなり、reusable workflow の
+    # input 検証（必須の欠落・存在しない input 名）がまるごと消えるから（実測）。
+    # audit の根拠である「前段ステップが clone したものを掴む」も、job レベルの
+    # 呼び出しには当たらない — GitHub が同じ commit から解決し FS を見ない。
+    # ignore は行単位。ステップの `uses: ./my-action` は今も検出される。
+    uses: ./.github/workflows/_kubeconform.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   helm-template:
     needs: detect
     if: ${{ needs.detect.outputs.charts == 'true' }}
-    uses: ./.github/workflows/_helm-template.yml
+    uses: ./.github/workflows/_helm-template.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   unread-values:
     needs: detect
     if: ${{ needs.detect.outputs.unread == 'true' }}
-    uses: ./.github/workflows/_unread-values.yml
+    uses: ./.github/workflows/_unread-values.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   image-existence:
     needs: detect
     if: ${{ needs.detect.outputs.images == 'true' }}
-    uses: ./.github/workflows/_image-existence.yml
+    uses: ./.github/workflows/_image-existence.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
       # leaf 側が GHCR の private パッケージ (home-rss) を読む。reusable では
@@ -185,21 +191,21 @@ jobs:
   argo-lint:
     needs: detect
     if: ${{ needs.detect.outputs.argo == 'true' }}
-    uses: ./.github/workflows/_argo-lint.yml
+    uses: ./.github/workflows/_argo-lint.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   mcp:
     needs: detect
     if: ${{ needs.detect.outputs.mcp == 'true' }}
-    uses: ./.github/workflows/_mcp.yml
+    uses: ./.github/workflows/_mcp.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   configmap-scripts:
     needs: detect
     if: ${{ needs.detect.outputs.cmscripts == 'true' }}
-    uses: ./.github/workflows/_configmap-scripts.yml
+    uses: ./.github/workflows/_configmap-scripts.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 


### PR DESCRIPTION
home-actions が共有 lint を zizmor 1.30 に上げる（Tsuguya-HC/home-actions#19）。
1.30 の新 audit `self-repository` は `uses: ./...` を全部 `$/...` にしろと言うが、
このリポの該当箇所は全部 job レベルの reusable workflow 呼び出しで、GitHub が
同じ commit から解決する（FS を見ない）ため audit の根拠が当たらない。

`$/` にした場合の代償は実測済み — actionlint が `$/` を解決できず、reusable
workflow の input 検証（必須 input の欠落・存在しない input 名）がまるごと
素通りになる（rhysd/actionlint#711、最終リリース 2026-03 で作者 inactive）。

そこで `./` を維持し、行単位で ignore する。ファイル単位の設定にしないのは、
将来ステップに `uses: ./my-action` を足したときに黙って見逃さないため
（実測: 行単位なら step の `./` は今も検出される）。

共有ワークフローのピンが動く前に入れておくと、その bump PR が緑のまま通る。

検証: actionlint 1.7.12 exit 0 / zizmor 1.30 pedantic 指摘ゼロ / zizmor 1.29 でも exit 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH