### PR TITLE
Skip the SecureBoot build when the last successful run had the same inputs

### DIFF
--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -146,6 +146,7 @@
 | discord-notify | send (curl) | 10m / 16Mi | 64Mi |
 | node-shutdown | resolve-nodes | 10m / 16Mi | 64Mi |
 | node-shutdown | shutdown-nodes (talosctl) | 10m / 32Mi | 64Mi |
+| talos-secureboot-build | plan-build | 10m / 64Mi | 128Mi |
 | talos-secureboot-build | run-imager | 100m / 512Mi | 2Gi |
 | talos-secureboot-build | push-installer | 50m / 256Mi | 1Gi |
 | talos-secureboot-build | push-iso | 50m / 256Mi | 1Gi |

--- a/docs/secureboot.md
+++ b/docs/secureboot.md
@@ -79,8 +79,14 @@ talos-build アプリを同期したときに `talos-extension-bump` Sensor が�
 
 比較材料は、run ごとに Argo が `status.storedTemplates` へ凍結する imager の引数（拡張の digest
 とカーネル引数）と、`resolve-version` が出した版。**署名鍵のローテーションと、同じ版のまま
-installer-base / imager を焼き直した場合は見ていない。** どちらも手動操作のときだけ起きるので、
-そのときは version を明示して手動で回すこと。
+installer-base / imager を焼き直した場合は見ていない。** どちらも判定材料（版・imager 引数）が
+変わらないので、前回成功 run と一致して skip される。署名鍵のローテーションは `manifests/secrets/`
+配下の変更で、`talos-build` app とは別 app（reconcile が隔離されている）のため、**ローテーション
+だけでは `talos-build` の sync も plan-build の再判定も自動では起きない。**
+
+比較できる前回成功 run が見つからないときは焼く側へ倒れる。成功した Workflow CR は
+`spec.ttlStrategy.secondsAfterSuccess: 2592000`（30日、クラスタ既定の 24時間を上書き）まで残す
+——実際の変更間隔は 1〜6日・2日が最頻で、24時間だとほとんど比較できずに終わるため。
 
 ### カーネル引数
 

--- a/docs/secureboot.md
+++ b/docs/secureboot.md
@@ -9,10 +9,10 @@
 ```
 GHA (talos-custom-build)              Argo Workflows (talos-build namespace)
 ┌────────────────────────┐            ┌──────────────────────────────────────┐
-│ kernel (UFS config)    │            │ build-and-push-installer (Pod 1)    │
-│ installer-base         │            │  imager (initContainer) → crane push│
-│ imager                 │──webhook──→│ build-and-push-iso (Pod 2, 並列)    │
-│ Pre-release 作成       │            │  imager×2 (initContainer) → gh upload│
+│ kernel (UFS config)    │            │ plan-build (前回成功 run と比較)     │
+│ installer-base         │            │  入力が同じなら次の 2 つを skip     │
+│ imager                 │──webhook──→│ build-and-push-installer (Pod 1)    │
+│ Pre-release 作成       │            │ build-and-push-iso (Pod 2, 並列)    │
 └────────────────────────┘            │ finalize-release (pre→release)      │
                                       └──────────────────────────────────────┘
 ```
@@ -54,7 +54,8 @@ ExternalSecret: `manifests/secrets/talos-build-secureboot-signing-keys.yaml`
 | ファイル | 内容 |
 |----------|------|
 | `manifests/talos-build/workflowtemplate.yaml` | WorkflowTemplate + SA + RBAC |
-| `manifests/talos-build/scripts.yaml` | push-installer.sh, push-iso.sh, finalize-release.sh |
+| `manifests/talos-build/scripts.yaml` | plan-build.sh, push-installer.sh, push-iso.sh, finalize-release.sh |
+| `manifests/argo/talos-extension-bump-sensor.yaml` | Sensor (ArgoCD app-deployed → WF trigger、version 未指定) |
 | `manifests/argo/talos-build-sensor.yaml` | Sensor (release webhook → WF trigger) |
 | `manifests/secrets/talos-build-ghcr-pat.yaml` | GHCR push 用 PAT (ExternalSecret) |
 
@@ -63,9 +64,23 @@ ExternalSecret: `manifests/secrets/talos-build-secureboot-signing-keys.yaml`
 1. GHA が `talos-custom-build` で imager + installer-base をビルド → GHCR push
 2. GHA が pre-release 作成 → GitHub webhook
 3. Argo Events Sensor が `prerelease: true` のリリースをフィルタ
-4. Argo WF が imager コンテナで SecureBoot installer/ISO をビルド
-5. GHCR に installer push、GitHub Release に ISO + PXE assets upload
-6. Release を pre-release → release に更新
+4. `plan-build` が前回成功した run と比較し、**版と imager への入力が同じなら 5 を skip する**
+5. Argo WF が imager コンテナで SecureBoot installer/ISO をビルド → GHCR に installer push、
+   GitHub Release に ISO + PXE assets upload
+6. Release を pre-release → release に更新（skip した回も走る。`gh release edit` は冪等）
+
+トリガーは 2 経路ある。上が release webhook 経由（version 指定あり）で、もう 1 本は ArgoCD が
+talos-build アプリを同期したときに `talos-extension-bump` Sensor が起動する経路（version 未指定
+＝最新 release を解決）。後者は `manifests/talos-build/` が変われば発火するので、拡張の digest
+更新だけでなく argo-tools の digest bump のような無関係な変更でも走る。焼き直すと
+`installer:<version>` が同じタグに上書きされ、talconfig の talosVersion を追う Renovate の
+`minimumReleaseAge` がイメージの created から測るためリセットされる——`plan-build` はこれを
+止めるために居る。
+
+比較材料は、run ごとに Argo が `status.storedTemplates` へ凍結する imager の引数（拡張の digest
+とカーネル引数）と、`resolve-version` が出した版。**署名鍵のローテーションと、同じ版のまま
+installer-base / imager を焼き直した場合は見ていない。** どちらも手動操作のときだけ起きるので、
+そのときは version を明示して手動で回すこと。
 
 ### カーネル引数
 

--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -4,6 +4,86 @@ metadata:
   name: talos-build-scripts
   namespace: talos-build
 data:
+  plan-build.sh: |
+    #!/bin/sh
+    # 前回成功した run と入力が同じなら焼かない。
+    #
+    # このワークフローは ArgoCD が talos-build アプリを同期するたびに走る。同期は
+    # manifests/talos-build/ が変われば起きるので、argo-tools の digest bump のように
+    # イメージの中身と何の関係も無い変更でも、16 分×2 のビルドが丸ごと走り直して
+    # installer:<version> が同じタグに上書きされていた。上書きするとイメージの created が
+    # 動き、talconfig.yaml の talosVersion を追う Renovate は minimumReleaseAge をそこから
+    # 測るので、無関係な変更が 3 日より短い間隔で入る限り Talos の更新 PR が出てこない。
+    #
+    # 判定材料は「前回成功した run 自身」から取る。Argo は run ごとに参照先 WorkflowTemplate
+    # の全テンプレートを status.storedTemplates に凍結して持っており（実測: 2 テンプレートしか
+    # 実行せず Error で終わった run にも未実行分が入っている）、そこに imager へ渡す引数
+    # ——拡張の digest とカーネル引数——がそのまま残っている。だからレジストリに目印を足す
+    # 必要も、指紋を持ち回る必要もない。
+    #
+    # 判定に要るものが 1 つでも取れなければ焼く。初回・Argo が古い run を GC した後・
+    # apiserver 不通は全部そちらに倒れる。逆に倒すと「焼くべきものを焼かないまま緑」になる。
+    #
+    # 見ないもの（どちらも手動操作のときだけ起きるので、そのときは version を明示して
+    # workflow_dispatch で回す）:
+    #   * 署名鍵のローテーション —— 前回 run の spec は同じままなので差が出ない
+    #   * 同じ版のまま CI が installer-base / imager を焼き直した場合
+    set -euo pipefail
+
+    build() {
+      echo "=> build: $1" >&2
+      printf 'true' > /tmp/build.txt
+      exit 0
+    }
+
+    [ -n "${VERSION:-}" ] || build "VERSION が空"
+    [ -n "${WORKFLOW_NAME:-}" ] || build "WORKFLOW_NAME が空"
+
+    # imager を使う initContainer だけを名前順に取る。同じファイルに載っている
+    # argo-tools や alpine の digest は入らない——そこが「無関係な変更で焼き直さない」の要。
+    SEL='[.status.storedTemplates | to_entries[] | .value | .initContainers[]?
+          | select(.image | test("ghcr\\.io/tsuguya/imager")) | {name, image, args}]
+         | sort_by(.name)'
+
+    ALL=$(kubectl --request-timeout=10s -n talos-build get workflow -o json) \
+      || build "Workflow を一覧できなかった"
+
+    # 前回成功した run。version はその run の resolve-version が出力した値。
+    LAST=$(printf '%s' "$ALL" | jq -c "
+      [ .items[]
+        | select(.status.phase == \"Succeeded\")
+        | select(.metadata.labels[\"workflows.argoproj.io/workflow-template\"] == \"talos-secureboot-build\")
+        | select(.metadata.name != \"${WORKFLOW_NAME}\")
+      ]
+      | sort_by(.status.finishedAt) | last
+      | if . == null then null else
+          { version: ([ .status.nodes[]?
+                        | select(.templateName == \"resolve-version\")
+                        | .outputs.parameters[]? | select(.name == \"version\") | .value ] | first)
+          , imager: ($SEL) }
+        end") || build "前回の run を読めなかった"
+
+    case "$LAST" in ''|null) build "比較できる成功 run が無い" ;; esac
+    printf '%s' "$LAST" | jq -e '.version != null and (.imager | length) > 0' >/dev/null \
+      || build "前回の run から版か imager 入力を取り出せなかった"
+
+    # 今回の run。焼くのはこの凍結 spec なので、比較もこれで行う。
+    NOW=$(printf '%s' "$ALL" | jq -c "
+      [ .items[] | select(.metadata.name == \"${WORKFLOW_NAME}\") ] | first
+      | if . == null then null else { version: \"${VERSION}\", imager: ($SEL) } end") \
+      || build "今回の run を読めなかった"
+
+    case "$NOW" in ''|null) build "今回の run を読めなかった" ;; esac
+    printf '%s' "$NOW" | jq -e '(.imager | length) > 0' >/dev/null \
+      || build "今回の run から imager 入力を取り出せなかった"
+
+    if [ "$LAST" = "$NOW" ]; then
+      echo "=> skip: 前回成功した run と版・imager 入力が同じ" >&2
+      printf 'false' > /tmp/build.txt
+      exit 0
+    fi
+    build "版か imager 入力が前回と違う"
+
   push-installer.sh: |
     #!/bin/sh
     set -euo pipefail

--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -24,9 +24,12 @@ data:
     # 判定に要るものが 1 つでも取れなければ焼く。初回・Argo が古い run を GC した後・
     # apiserver 不通は全部そちらに倒れる。逆に倒すと「焼くべきものを焼かないまま緑」になる。
     #
-    # 見ないもの（どちらも手動操作のときだけ起きるので、そのときは version を明示して
-    # workflow_dispatch で回す）:
-    #   * 署名鍵のローテーション —— 前回 run の spec は同じままなので差が出ない
+    # 見ないもの（判定材料——版・imager 引数——が変わらないので、前回成功 run と一致して
+    # skip される）:
+    #   * 署名鍵のローテーション —— 前回 run の spec は同じままなので差が出ない。しかも
+    #     ローテーションは manifests/secrets/（app: secrets）の変更で、このワークフローを
+    #     叩く talos-build app とは別 app（reconcile が隔離）のため、自動では sync も
+    #     再判定も起きない
     #   * 同じ版のまま CI が installer-base / imager を焼き直した場合
     set -euo pipefail
 

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -78,14 +78,27 @@ spec:
               parameters:
                 - name: version
                   value: "{{workflow.parameters.version}}"
+        - - name: plan-build
+            template: plan-build
+            arguments:
+              parameters:
+                - name: version
+                  value: "{{steps.resolve-version.outputs.parameters.version}}"
+        # 前回成功した run と入力が同じなら焼かない。`!= 'false'` にしてあるのは、
+        # 出力が空や想定外の値になったときも焼く側へ倒すため（`== 'true'` だと
+        # 空文字が「skip」と評価されて、何も焼かずに緑で終わる）。
+        # finalize-release はゲートしない。`gh release edit` は冪等で、
+        # 前回そこだけ落ちていた回をここで拾い直せる。
         - - name: build-and-push-installer
             template: build-and-push-installer
+            when: "'{{steps.plan-build.outputs.parameters.build}}' != 'false'"
             arguments:
               parameters:
                 - name: version
                   value: "{{steps.resolve-version.outputs.parameters.version}}"
           - name: build-and-push-iso
             template: build-and-push-iso
+            when: "'{{steps.plan-build.outputs.parameters.build}}' != 'false'"
             arguments:
               parameters:
                 - name: version
@@ -151,6 +164,61 @@ spec:
             memory: 32Mi
           limits:
             memory: 64Mi
+
+    - name: plan-build
+      # kubectl 2 回（--request-timeout=10s）で済む。ここでハングすると
+      # spec.synchronization.mutexes を握ったまま後続の run を全部詰まらせるので、
+      # workflow 全体の 7200 秒ではなく短い上限を自前で持つ。
+      activeDeadlineSeconds: 60
+      retryStrategy:
+        limit: 3
+        retryPolicy: Always
+        backoff:
+          duration: 10s
+          factor: 2
+      inputs:
+        parameters:
+          - name: version
+      outputs:
+        parameters:
+          - name: build
+            valueFrom:
+              path: /tmp/build.txt
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      container:
+        image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:0b658d03cee98b3118622d47d07950b5dc5dd8ef73689bab68ff28c00299f296
+        command: [sh, /scripts/plan-build.sh]
+        env:
+          - name: VERSION
+            value: "{{inputs.parameters.version}}"
+          - name: WORKFLOW_NAME
+            value: "{{workflow.name}}"
+          # readOnlyRootFilesystem なので kubectl の既定のキャッシュ先が書けない。
+          - name: HOME
+            value: /tmp
+          - name: KUBECACHEDIR
+            value: /tmp/kubecache
+        securityContext:
+          runAsUser: 65532
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
+        volumeMounts:
+          - name: scripts
+            mountPath: /scripts
+            readOnly: true
+          - name: tmp
+            mountPath: /tmp
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
 
     - name: build-and-push-installer
       # ghcr.io からの extension pull が HTTP/2 PROTOCOL_ERROR で落ちることがある。

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -29,6 +29,13 @@ metadata:
 spec:
   # ビルドテンプレートは最大3回まで再試行するので、その最悪ケースを収める
   activeDeadlineSeconds: 7200
+  # plan-build が見ている前回成功 run は Succeeded の Workflow CR そのものなので、それが GC
+  # されると比較できずに焼く側へ倒れる（fail-safe だが機能が空振りする）。実際の変更間隔は
+  # 1〜6日・2日が最頻なので、クラスタ既定の secondsAfterSuccess: 86400（24h）だと大半が
+  # 比較不能になる。守りたい帯（3日より短い間隔での焼き直し）を十分に覆う 30日に伸ばす。
+  # secondsAfterFailure はクラスタ既定のまま——失敗は見えるうちに消えてよい。
+  ttlStrategy:
+    secondsAfterSuccess: 2592000
   synchronization:
     mutexes:
       - name: talos-secureboot-build
@@ -166,9 +173,15 @@ spec:
             memory: 64Mi
 
     - name: plan-build
-      # kubectl 2 回（--request-timeout=10s）で済む。ここでハングすると
-      # spec.synchronization.mutexes を握ったまま後続の run を全部詰まらせるので、
-      # workflow 全体の 7200 秒ではなく短い上限を自前で持つ。
+      # kubectl は 1 回（--request-timeout=10s）呼ぶだけで、結果を jq で 2 回（前回 run・
+      # 今回 run の抽出）使い回している。ここでハングすると spec.synchronization.mutexes
+      # を握ったまま後続の run を全部詰まらせるので、workflow 全体の 7200 秒ではなく
+      # 短い上限を自前で持つ。
+      #
+      # apiserver への依存はこのステップで新設したもの。apiserver に到達できないと
+      # build 側へ倒れて焼き直すだけで壊れはしないが、retry を使い切って Failed になると
+      # build-and-push-* だけでなく finalize-release まで実行されずワークフロー全体が
+      # 止まる（`gh release edit` が冪等なので再トリガーで復旧はする）。
       activeDeadlineSeconds: 60
       retryStrategy:
         limit: 3


### PR DESCRIPTION
`talos-secureboot-build` は ArgoCD が talos-build アプリを同期するたびに走り、無条件で 16 分×2 のビルドを実行して `installer:<version>` を同じタグに上書きしていた。トリガーは `manifests/talos-build/` の変更なので、**argo-tools の digest bump のようにイメージの中身と無関係な変更でも焼き直していた**（実測: #827 の前後で imager の image+args は byte 一致）。

上書きするとイメージの `created` が動き、talconfig の `talosVersion` を追う Renovate の `minimumReleaseAge`（3 日）がそこから測るためリセットされる。`manifests/talos-build/` の実際の変更間隔は 1〜6 日で 2 日が最頻。つまり Talos の更新 PR が構造的に出てこない状態だった（v1.13.9 は 8/24 に焼かれているのに talconfig は v1.13.8 のまま）。

入口に `plan-build` を 1 ステップ足し、**前回成功した run の凍結 spec（`status.storedTemplates`）から imager 引数と版を取り、今回のそれと同じなら build 2 本を skip する**。レジストリには何も足さない。

## 判定

- 材料は「`resolve-version` が出した版」と「imager を使う initContainer 全部の image と args」（拡張の digest とカーネル引数を含む）
- **判定に必要なものが 1 つでも取れなければ焼く**。初回・GC 後・apiserver 不通・VERSION 空はすべてそちら
- `when:` を `!= 'false'` にしてあるので、出力が空や想定外でも焼く側に倒れる

## `ttlStrategy` を 30 日にしている理由

成功した Workflow CR はクラスタ既定で 24 時間後に GC される。守りたい帯（3 日より短い間隔）の大半で比較対象が消えるため、そのままでは仕掛けが空振りする。この WorkflowTemplate だけ `spec.ttlStrategy.secondsAfterSuccess` を上書きした。`secondsAfterFailure` は未設定でクラスタ既定（3 日）を継承する。

## 意図的に見ていないもの

- 署名鍵のローテーション
- 同じ版のまま installer-base / imager を焼き直した場合

どちらも判定材料が変わらないので skip される。**回復手順は書いていない** — このレビューの中で手順を 4 回書いて 4 回とも実際には機能しなかったため、制約だけを書いて方法はその日のコードを見て決める方針にした。

## 検証

- 実イメージ（argo-tools / busybox ash）で 12 ケース。skip に倒れるのは「前回成功 run と版・imager 入力が完全一致」の 1 つだけ
- `ttlStrategy` の上書きが効くことを 3 者が独立に確認（`TTLStrategy` の 3 フィールドは `*int32` + `omitempty` + `patchStrategy` タグ無しなので再帰マージされる）
- lint-configmap-scripts.py / kubeconform -strict / kubectl apply --dry-run=server / unread-values.py すべて通過

`/infra-review-cycle` を 2 ラウンド。採用 4 / 却下 3（1 件はレビュアー自身が一次情報で撤回）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH