### PR TITLE
Read the spec the run froze, not the templates it has resolved so far

### DIFF
--- a/docs/secureboot.md
+++ b/docs/secureboot.md
@@ -77,7 +77,7 @@ talos-build アプリを同期したときに `talos-extension-bump` Sensor が�
 `minimumReleaseAge` がイメージの created から測るためリセットされる——`plan-build` はこれを
 止めるために居る。
 
-比較材料は、run ごとに Argo が `status.storedTemplates` へ凍結する imager の引数（拡張の digest
+比較材料は、run ごとに Argo が `status.storedWorkflowTemplateSpec` へ凍結する imager の引数（拡張の digest
 とカーネル引数）と、`resolve-version` が出した版。**署名鍵のローテーションと、同じ版のまま
 installer-base / imager を焼き直した場合は見ていない。** どちらも判定材料（版・imager 引数）が
 変わらないので、前回成功 run と一致して skip される。署名鍵のローテーションは `manifests/secrets/`

--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -16,10 +16,16 @@ data:
     # 測るので、無関係な変更が 3 日より短い間隔で入る限り Talos の更新 PR が出てこない。
     #
     # 判定材料は「前回成功した run 自身」から取る。Argo は run ごとに参照先 WorkflowTemplate
-    # の全テンプレートを status.storedTemplates に凍結して持っており（実測: 2 テンプレートしか
-    # 実行せず Error で終わった run にも未実行分が入っている）、そこに imager へ渡す引数
-    # ——拡張の digest とカーネル引数——がそのまま残っている。だからレジストリに目印を足す
-    # 必要も、指紋を持ち回る必要もない。
+    # の全テンプレートを status.storedWorkflowTemplateSpec に凍結して持っており、そこに
+    # imager へ渡す引数——拡張の digest とカーネル引数——がそのまま残っている。だから
+    # レジストリに目印を足す必要も、指紋を持ち回る必要もない。
+    #
+    # **`status.storedTemplates` ではない。** そちらはコントローラが解決したテンプレートを
+    # 順に足していく器で、このステップが走る時点（2 番目）では build 系がまだ入っていない。
+    # 完了した run を見ると全部入っているので揃っているように見えるが、それは完了後の姿。
+    # 2026-09-07 に実際に storedTemplates で書いて本番に出し、今回の run の imager 入力を
+    # 取り出せず build 側へ倒れて 1 回余分に焼いた。storedWorkflowTemplateSpec は
+    # setStoredWfSpec が run の最初に一度だけ書くので、どのステップから見ても揃っている。
     #
     # 判定に要るものが 1 つでも取れなければ焼く。初回・Argo が古い run を GC した後・
     # apiserver 不通は全部そちらに倒れる。逆に倒すと「焼くべきものを焼かないまま緑」になる。
@@ -44,7 +50,7 @@ data:
 
     # imager を使う initContainer だけを名前順に取る。同じファイルに載っている
     # argo-tools や alpine の digest は入らない——そこが「無関係な変更で焼き直さない」の要。
-    SEL='[.status.storedTemplates | to_entries[] | .value | .initContainers[]?
+    SEL='[.status.storedWorkflowTemplateSpec.templates[]? | .initContainers[]?
           | select(.image | test("ghcr\\.io/tsuguya/imager")) | {name, image, args}]
          | sort_by(.name)'
 


### PR DESCRIPTION
#830 の続き。**本番で 1 回焼いてしまった分の修正。**

## 何が起きたか

#830 をマージ → ArgoCD が同期 → `talos-extension-bump` sensor が発火して run が立ち、**skip されるはずが焼いた**（`plan-build` の出力が `build=true`）。版も imager 引数も前回成功 run と完全に一致していたのに。

## 原因

比較材料を `status.storedTemplates` から取っていた。これは**コントローラがテンプレートを解決するたびに足していく器**で、`plan-build` は 2 番目のステップなので、その時点では後続の build 系がまだ入っていない。結果 imager 引数を取り出せず、`build()` へ倒れた（安全側ではあるが、狙った動作ではない）。

`status.storedWorkflowTemplateSpec` が正しいフィールド。`setStoredWfSpec` が run の最初に一度だけ書くので、どのステップから見ても全テンプレートが揃っている。

## なぜレビューで捕まらなかったか

根拠にした実測が**完了した run** だった。完了後は `storedTemplates` にも未実行のテンプレートまで全部入るので、外から見ると常に揃っているように見える。`image-build/image-build-nh9bz`（2 テンプレートしか実行せず Error）が未実行の 3 つを持っていたのを「起動時に一括凍結される証拠」と読んだが、それは終わった後の姿だった。**実行中の run を見ないと確かめられない性質**で、レビュアー 6 名も同じ証拠を見て同じ結論に達していた。

出して動かして初めて分かった。

## 検証

- 両フィールドから同じセレクタで同じ 3 件・同じハッシュ（`1d9a0e0deb0c`）が取れることを実 run 2 本で確認
- **本番で失敗したのと同じ状態を再現**（`storedTemplates` が `main` / `resolve-version` / `plan-build` だけの途中状態）して `build=false`（skip）になることを実イメージで確認
- 版違い → 焼く / `WORKFLOW_NAME` が実在しない → 焼く も退行なし
- lint-configmap-scripts.py / kubeconform -strict / kubectl apply --dry-run=server 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH