### PR TITLE
Drop the request timeout that was stopping kubectl from finding the cluster

### DIFF
--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -54,27 +54,43 @@ data:
           | select(.image | test("ghcr\\.io/tsuguya/imager")) | {name, image, args}]
          | sort_by(.name)'
 
-    ALL=$(kubectl --request-timeout=10s -n talos-build get workflow -o json) \
+    # `--request-timeout` は付けない。**このフラグは kubectl の in-cluster 設定の解決を
+    # 壊す** —— 付けると kubeconfig も SA トークンも env も揃っているのに localhost:8080 へ
+    # フォールバックして必ず失敗する（2026-09-07 に実 Argo Pod で A/B 確認。フラグ以外は
+    # 同一の呼び出しで、無ければ workflow を一覧でき、有れば connection refused）。
+    # このスクリプトはそれで毎回 build 側へ倒れ、仕掛けが本番で 2 回空振りした。
+    #
+    # クライアント側のタイムアウトはそもそも要らない。このテンプレートには
+    # activeDeadlineSeconds が付いていて、`maxDuration` を設定していないので 1 試行ごとに
+    # 効く。kubectl が何をしようと Pod が切られるので、mutex を握り続ける窓は retry 込みで
+    # 数分に収まる。**同じ懸念に二重に手当てして、片方が機構を殺していた。**
+    ALL=$(kubectl -n talos-build get workflow -o json) \
       || build "Workflow を一覧できなかった"
 
     # 前回成功した run。version はその run の resolve-version が出力した値。
+    #
+    # **「直近の成功 run」ではなく「材料が揃っている直近の成功 run」を選ぶ。** 同じ
+    # WorkflowTemplate を entrypoint 指定で部分実行すると（診断で実際にやった）、
+    # resolve-version を通らないので版を持たない Succeeded な run がラベル付きで残る。
+    # 単に最新を取ると、その 1 件が居るだけで比較が成立しなくなり、GC されるまで
+    # 焼き続ける。materials が揃っているものだけに絞ってから最新を取る。
     LAST=$(printf '%s' "$ALL" | jq -c "
       [ .items[]
         | select(.status.phase == \"Succeeded\")
         | select(.metadata.labels[\"workflows.argoproj.io/workflow-template\"] == \"talos-secureboot-build\")
         | select(.metadata.name != \"${WORKFLOW_NAME}\")
-      ]
-      | sort_by(.status.finishedAt) | last
-      | if . == null then null else
-          { version: ([ .status.nodes[]?
+        | { finishedAt: .status.finishedAt
+          , version: ([ .status.nodes[]?
                         | select(.templateName == \"resolve-version\")
                         | .outputs.parameters[]? | select(.name == \"version\") | .value ] | first)
           , imager: ($SEL) }
-        end") || build "前回の run を読めなかった"
+        | select(.version != null and (.imager | length) > 0)
+      ]
+      | sort_by(.finishedAt) | last
+      | if . == null then null else { version: .version, imager: .imager } end") \
+      || build "前回の run を読めなかった"
 
-    case "$LAST" in ''|null) build "比較できる成功 run が無い" ;; esac
-    printf '%s' "$LAST" | jq -e '.version != null and (.imager | length) > 0' >/dev/null \
-      || build "前回の run から版か imager 入力を取り出せなかった"
+    case "$LAST" in ''|null) build "材料の揃った成功 run が無い" ;; esac
 
     # 今回の run。焼くのはこの凍結 spec なので、比較もこれで行う。
     NOW=$(printf '%s' "$ALL" | jq -c "

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -173,10 +173,14 @@ spec:
             memory: 64Mi
 
     - name: plan-build
-      # kubectl は 1 回（--request-timeout=10s）呼ぶだけで、結果を jq で 2 回（前回 run・
-      # 今回 run の抽出）使い回している。ここでハングすると spec.synchronization.mutexes
-      # を握ったまま後続の run を全部詰まらせるので、workflow 全体の 7200 秒ではなく
-      # 短い上限を自前で持つ。
+      # kubectl は 1 回呼ぶだけで、結果を jq で 2 回（前回 run・今回 run の抽出）使い回して
+      # いる。ここでハングすると spec.synchronization.mutexes を握ったまま後続の run を
+      # 全部詰まらせるので、workflow 全体の 7200 秒ではなく短い上限を自前で持つ。
+      #
+      # **クライアント側のタイムアウトはここが代わりに担っている。** `maxDuration` を
+      # 設定していないのでこの deadline は 1 試行ごとに効き、kubectl が何をしようと Pod が
+      # 60 秒で切られる。kubectl に `--request-timeout` を足してはいけない —— あれは
+      # in-cluster 設定の解決を壊し、必ず localhost:8080 へ落ちる（scripts.yaml 側に実測）。
       #
       # apiserver への依存はこのステップで新設したもの。apiserver に到達できないと
       # build 側へ倒れて焼き直すだけで壊れはしないが、retry を使い切って Failed になると


### PR DESCRIPTION
#830 / #833 の続き。**この機構はマージ以降ずっと毎回 build 側に倒れていた。** その原因。

## 原因

`--request-timeout=10s` を付けると **kubectl が in-cluster 設定の解決をやめて `http://localhost:8080` にフォールバックする**。SA トークンも ca.crt も `KUBERNETES_SERVICE_HOST` も揃っているのに、そこへは一切行かない。list が必ず失敗するので、スクリプトは「クラスタが見えないときの動作」＝焼く、を毎回選んでいた。

実 Argo Pod・同じ SA・同じ CNP ラベルで、**フラグの有無だけが違う A/B**:

```
kubectl get workflow -o name                        → workflow.argoproj.io/talos-extension-rebuild-v9qgq
kubectl --request-timeout=10s get workflow -o name  → The connection to the server localhost:8080 was refused
```

名前空間・SA・イメージ・kubectl のバージョン（1.36.4 / 1.37.0 / bitnami）・uid・`HOME`・`readOnlyRootFilesystem`・CNP はいずれも無関係と確認済み。

## このフラグは最初から要らなかった

`plan-build` には既に `activeDeadlineSeconds` があり、`maxDuration` を設定していないので **1 試行ごとに**効く。kubectl が何をしようと Pod が切られるので、指摘が心配していた「mutex を 2 時間握る」にはならない。**1 つの懸念に二重に手当てして、片方が対象そのものを殺していた。**

コメントに「なぜクライアント側のタイムアウトを付けないか」を書いた。書かないと、また同じ指摘から同じフラグが足される。

## あわせて: 部分実行された run に引っかからないように

「直近の成功 run」ではなく「**材料が揃っている**直近の成功 run」を選ぶ。この WorkflowTemplate を entrypoint 指定で部分実行すると（調査で実際にやった）、`resolve-version` を通らず版を持たない Succeeded な run がラベル付きで残る。それが 1 件あるだけで比較が成立しなくなり、GC されるまで焼き続ける。

## 検証（今回はスタブを使っていない）

修正後のスクリプトを**実 Argo Pod に投げて**確認した。2 回のマージでこれを見落としたのは、ローカル検証で毎回 `kubectl` をスタブに差し替えていて、フラグの影響を一度も通らなかったため。

| ケース | 結果 |
|---|---|
| 同じ入力 | `=> skip: 前回成功した run と版・imager 入力が同じ` |
| 版が違う | `=> build: 版か imager 入力が前回と違う` |
| VERSION 空 | `=> build: VERSION が空` |
| 実在しない run | `=> build: 今回の run を読めなかった` |

lint-configmap-scripts.py / kubeconform -strict / kubectl apply --dry-run=server も通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH