### PR TITLE
Match the renovate sensor's senders by numeric id, not login

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -229,3 +229,15 @@ echo | openssl s_client -connect 192.168.10.193:443 -servername pg.infra.tgy.io 
 ```
 
 通常の期限更新（renewBefore による再発行）で同じことが起きるかは未確認。起きるなら `pg.infra.tgy.io` の `verify-full` が期限切れの日に落ちるので、次回の更新日（`kubectl get certificate -n database shared-pg-server-tls`）に確認する。
+
+## Renovate webhook sensor: org 移管でフィルタが黙って false になっていた（解決済み 2026-09-08）
+
+`manifests/argo/renovate-webhook-sensor.yaml` の Lua フィルタは `repo.owner.login ~= sender.login` で認可判定していたが、2026-08-29 の org `Tsuguya-HC` 移管で `repo.owner.login` が `Tsuguya-HC`（Organization）に変わり、`sender.login`（`Tsuguya`, User）と常に不一致になった。移管前は両方 `Tsuguya` で一致していた。
+
+**症状**: Dependency Dashboard issue の "Check this box to trigger a request for Renovate to run again" にチェックを入れても Renovate が起動しない。チェックは issue の body 編集として保存されるため、押した側からは成功したように見える。cron `renovate-periodic`（4h 周期）はこの影響を受けず動き続けるため、「Renovate 自体が止まっている」ようにも見えない。**2026-08-29 の org 移管から 2026-09-08 に発覚するまで誰も気付かなかった。**
+
+**影響範囲**: このフィルタは YAML アンカー `&renovateFilter` で home-cluster / home-infra / home-cloudflare / home-trading の 4 リポの dependency に共有されており、全滅していた。push イベント（`event.body.ref` を見る分岐）はこのフィルタより前で return するため無事だった。
+
+**切り分け**: GitHub 側の webhook 配信自体は生きている（`gh api /repos/<owner>/<repo>/hooks/<id>/deliveries` が `status=200` を返す）。配線が生きていることと Sensor が発火することは別で、フィルタの判定は argo-events と同じ gopher-lua ランタイムでスクリプトを単体実行すれば決定論的に再現できる。
+
+**修正**: 認可を可変な login でなく不変の数値 id（`sender.id`）による比較に変更した。

--- a/manifests/argo/aqua-checksum.yaml
+++ b/manifests/argo/aqua-checksum.yaml
@@ -54,7 +54,7 @@ spec:
       aqua-checksum: "true"
   arguments:
     parameters:
-      - name: repository # Tsuguya/<name>
+      - name: repository # Tsuguya-HC/<name>
       - name: branch # the pull request's head branch
   templates:
     - name: main

--- a/manifests/argo/renovate-webhook-sensor.yaml
+++ b/manifests/argo/renovate-webhook-sensor.yaml
@@ -38,21 +38,37 @@ spec:
           -- checkbox clicks arrive as a body edit; ignore renovate's own edits
           -- (bot unchecking the box) to avoid a self-trigger loop
           if event.body.action ~= "edited" then return false end
-          -- public repos: anyone can open an issue/PR and edit its own body,
-          -- so the edit must come from the repo owner and the issue/PR itself
-          -- must have been authored by the renovate app
+          -- public repos: anyone can open an issue/PR and edit its own body, so
+          -- the edit must come from a sender allowed to trigger a run and the
+          -- issue/PR itself must have been authored by the renovate app.
+          -- The repos are owned by the Tsuguya-HC org, so repo.owner no longer
+          -- names a person and cannot be compared against the sender.
+          -- Matched on the sender's immutable numeric id, not the login: a
+          -- login can be renamed and the old one reclaimed by someone else.
+          -- This filter is shared via the anchor below, so it also applies to
+          -- the private home-trading dependency -- stricter than necessary
+          -- there, but harmless.
+          -- To allow another sender, chain another `and sender.id ~= <id>`
+          -- (not `or`, which would always be true and lock everyone out).
+          -- Do not turn this into a numeric-keyed table: gopher-lua's
+          -- LTable.RawSet puts keys in [0, 2^26) into the array part and
+          -- pads it with nils up to that index, blowing past this pod's
+          -- 64Mi memory limit.
+          --   6055622  Tsuguya
           local sender = event.body.sender
-          local repo = event.body.repository
           if sender == nil or sender.type ~= "User" then return false end
-          if repo == nil or repo.owner == nil or repo.owner.login ~= sender.login then
-            return false
-          end
+          if sender.id ~= 6055622 then return false end
           local function checked(body)
             return body ~= nil and string.find(body, "%[[xX]%]") ~= nil
           end
+          -- Both first-party Renovate bot ids (Mend-hosted and self-hosted
+          -- App) are accepted so a Mend <-> self-host move cannot silently
+          -- disarm this filter again -- a login check already did once.
+          -- See tofu-cloudflare-plan for why the author is matched on
+          -- numeric user id rather than login.
           local function byRenovate(u)
             return u ~= nil and u.type == "Bot"
-              and u.login == "tsuguya-home-cluster[bot]"
+              and (u.id == 29139614 or u.id == 265309552)
           end
           if event.body.issue ~= nil then
             local issue = event.body.issue


### PR DESCRIPTION
## 何が壊れていたか

`renovate-webhook` Sensor の Lua フィルタが、Dependency Dashboard のチェックボックスによる Renovate 即時起動を `repo.owner.login == sender.login` で認可していた。2026-08-29 の org `Tsuguya-HC` 移管で `Tsuguya-HC`（Organization）vs `Tsuguya`（User）となり、**issues 経路が常に false**。チェックは issue に保存されるので押した側からは成功に見え、cron `renovate-periodic` は回り続けるので Renovate が止まっているようにも見えず、2026-09-08 に発覚するまで気付かれなかった。フィルタは YAML アンカーで 4 リポ（home-cluster / home-infra / home-cloudflare / home-trading）に共有されているため全滅。push 経路は先に return するので無事だった。

GitHub 側の webhook 配信は生きていた（直近の delivery はすべて `status=200`）。**配線が生きていることと Sensor が発火することは別。**

## 何を変えたか

- **sender の認可を不変の数値 ID に**。login はリネームと旧 login の再取得が可能なため、手放すと第三者が同じ login を取れる
- **`byRenovate` も同様に数値 ID へ**。`tofu-cloudflare.yaml` に、この種の login 判定が self-host App 移行で silently 壊れた実績が記録されている。first-party bot 2 つ（Mend / self-host）を両方受けるのも同じ理由
- **数値キーの Lua テーブルは使わない**。gopher-lua は 2^26 未満の数値キーを配列パートに入れ、そのインデックスまで nil でパディングする。`{ [6055622] = true }` は 1 評価あたり **414ms / 504MB**（実測）で、この pod の `limits.memory: 64Mi` を超える。この制約はコメントに残した
- `aqua-checksum.yaml` の旧 owner 表記コメントを修正、`docs/known-issues.md` に本障害を記録

## 検証

- **gopher-lua v1.1.2**（実クラスタで動作中の `argo-events:v1.9.11` と同一）に `filterScript`/`mapToTable` を移植した harness で、JSON デコード経路込み **16 ケース**。全ケース期待どおり、**max 208µs / alloc 0MB**
- YAML アンカーの 4 依存先展開が byte-identical
- `kubeconform -strict` / `kubectl apply --dry-run=server` 通過

**未検証**: 実際の GitHub webhook 経由の end-to-end 発火。マージ後に Dependency Dashboard のチェックボックスを実際に押して確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T56xSFQ7d8ty74hTKB2RFH