### PR TITLE
Let the smoke flow clean up after itself (ADR-0009 in production)

### DIFF
--- a/.github/schemas/flow.tgy.io/task_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/task_v1alpha1.json
@@ -93,7 +93,7 @@
      "type": "array"
     },
     "currentRun": {
-     "description": "RunRef identifies one execution of one phase. runID separates the second\nvisit to a phase from the first, so a rework does not read what the previous\nrun left behind. It does not separate two attempts at starting one run —\nan infrastructure retry comes back with the same number (ADR-0004), and\ninfraRetries is what tells those apart.\n\nA task's currentRun, when it has one, always names the phase the task is\non. A task that has stopped has no currentRun at all.",
+     "description": "RunRef identifies one execution of one phase. runID separates the second\nvisit to a phase from the first, so a rework does not read what the previous\nrun left behind. It does not separate two attempts at starting one run —\nan infrastructure retry comes back with the same number (ADR-0004), and\ninfraRetries is what tells those apart.\n\nA task's currentRun, when it has one, ordinarily names the phase the task\nis on. The one exception is the cleanup run a task that has reached its\nending may carry: there, currentRun.phase is the reserved name Finally\nwhile status.phase stays at the ending itself (ADR-0009), and\ntaskstate.InFinally is the predicate that tells that apart from a task\nmid-flight. A task that has stopped for good, with no cleanup run in\nflight or owed, has no currentRun at all.",
      "properties": {
       "deadline": {
        "format": "date-time",
@@ -109,7 +109,7 @@
        "type": "string"
       },
       "phase": {
-       "description": "Phase is a status name. It is a free string chosen by whoever writes the\nflow: this framework does not know what the work is, so it has no business\nnaming its stages. \"調査\" and \"Planning\" are equally valid.\n\nTwo names are reserved, because they are the framework's own answers rather\nthan anything in the author's domain — see ReservedPhases.",
+       "description": "Phase is a status name. It is a free string chosen by whoever writes the\nflow: this framework does not know what the work is, so it has no business\nnaming its stages. \"調査\" and \"Planning\" are equally valid.\n\nThree names are the framework's rather than the author's. Two of them are\nanswers it decides — see ReservedPhases — and the third is PhaseFinally,\nwhich is not an answer at all but the name a cleanup run is recorded under.",
        "type": "string"
       },
       "runID": {
@@ -146,7 +146,7 @@
         "type": "string"
        },
        "phase": {
-        "description": "Phase is a status name. It is a free string chosen by whoever writes the\nflow: this framework does not know what the work is, so it has no business\nnaming its stages. \"調査\" and \"Planning\" are equally valid.\n\nTwo names are reserved, because they are the framework's own answers rather\nthan anything in the author's domain — see ReservedPhases.",
+        "description": "Phase is a status name. It is a free string chosen by whoever writes the\nflow: this framework does not know what the work is, so it has no business\nnaming its stages. \"調査\" and \"Planning\" are equally valid.\n\nThree names are the framework's rather than the author's. Two of them are\nanswers it decides — see ReservedPhases — and the third is PhaseFinally,\nwhich is not an answer at all but the name a cleanup run is recorded under.",
         "type": "string"
        },
        "reason": {
@@ -170,7 +170,7 @@
      "type": "array"
     },
     "phase": {
-     "description": "Phase is a status name. It is a free string chosen by whoever writes the\nflow: this framework does not know what the work is, so it has no business\nnaming its stages. \"調査\" and \"Planning\" are equally valid.\n\nTwo names are reserved, because they are the framework's own answers rather\nthan anything in the author's domain — see ReservedPhases.",
+     "description": "Phase is a status name. It is a free string chosen by whoever writes the\nflow: this framework does not know what the work is, so it has no business\nnaming its stages. \"調査\" and \"Planning\" are equally valid.\n\nThree names are the framework's rather than the author's. Two of them are\nanswers it decides — see ReservedPhases — and the third is PhaseFinally,\nwhich is not an answer at all but the name a cleanup run is recorded under.",
      "type": "string"
     },
     "reworkBudget": {

--- a/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskflow_v1alpha1.json
@@ -44,6 +44,27 @@
      "minProperties": 1,
      "type": "object"
     },
+    "finally": {
+     "description": "Finally is the one handler that runs after a task of this flow has\nreached its ending, once, whatever that ending was. Adding it changes\nwhat happens to tasks created afterwards; a task already stopped keeps\nthe ending it stopped at and is never handed a cleanup run, the same way\nits deletion date is never recomputed.",
+     "properties": {
+      "done": {
+       "description": "Done is the directory this run writes into to say the task is cleaned\nup. One directory, not the map a binding carries: the several a phase\ndeclares are there to choose an edge, and this run has none to choose\nbetween. The framework wants one bit from it — did it say it was done —\nand a second directory for \"could not\" would buy a line of history at\nthe price of two ways to be unfinished.",
+       "minLength": 1,
+       "type": "string"
+      },
+      "handler": {
+       "description": "Handler names a TaskHandler in the same namespace, resolved the same way\na binding's is and with the same absence of a check that it exists yet.",
+       "minLength": 1,
+       "type": "string"
+      }
+     },
+     "required": [
+      "done",
+      "handler"
+     ],
+     "type": "object",
+     "additionalProperties": false
+    },
     "maxInFlight": {
      "description": "MaxInFlight caps concurrent tasks of this flow.",
      "format": "int32",

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -39,7 +39,7 @@ kind: Kustomization
 # 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
 # enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=18c3377e1d3d38d83878818bc3895933cc66d327
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=5ad396f0d090dae80fd6801fa9ffeb7e94c9ce79
 
 # newTag と digest を分けて併記すると、Renovate の kustomize manager が
 # invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
@@ -49,7 +49,7 @@ resources:
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest@sha256:c2f827a821e4149e185301fa1a9e6a10c9be6b0a5895851483be7db3d18c1318
+    newTag: latest@sha256:a6739157a66acee607ed0f03437d39f32c42fb050e8c0519df789934197d7ae0
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
@@ -88,7 +88,7 @@ patches:
               - name: manager
                 env:
                   - name: SIDECAR_IMAGE
-                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:76f5e49abbab02bb508db3ded2ea5af4e4b7795950397ddcf92da753aa7cdfc3
+                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:0bd0cf148bf4e7253d5e7e8e75abed841562e80889815642e616742ab6b1323e
 
   # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。taskflow 側は caBundle を
   # 持たない ValidatingWebhookConfiguration を配るだけなので、埋めるのはこちら —

--- a/manifests/claude-code/taskflow-smoke.yaml
+++ b/manifests/claude-code/taskflow-smoke.yaml
@@ -11,7 +11,9 @@
 #   metadata: {generateName: smoke-, namespace: claude-code}
 #   spec: {flow: smoke}
 #   EOF
-# 期待: Task が 完了 (Success) に着く。publish の termination message の 1 行目が ok。
+# 期待: Task が 完了 (Success) に着き、そのあと **片付けの run が 1 回だけ走る**（ADR-0009）。
+# history は 2 行 — 確認/1/ok/Declared と Finally/2/cleaned/Declared — で、status.phase は
+# 完了 のまま動かない。expiresAt が焼かれるのは片付けが決着した瞬間で、それまでは空。
 ---
 # トークンも通信も要らない。専用ラベルに CNP を書かないので全遮断（policyEnforcementMode: always）。
 apiVersion: v1
@@ -80,6 +82,87 @@ spec:
               limits:
                 memory: 64Mi
 ---
+# 終端の後に 1 回だけ走る片付け（[ADR-0009](https://github.com/Tsuguya-HC/taskflow/blob/main/docs/adr/0009-finally-after-the-ending.md)）。
+#
+# 片付ける物が実際にあるわけではない — これは「終端が確定した後にもう 1 回 run が立ち、
+# 終端はそれで動かない」という機構そのもののスモークで、実際に外の物を消す flow
+# （PR のコメント、ブランチ、投稿）のための配管を先に通しておくもの。
+#
+# **handler が受け取る 3 値をここで実証する。** 片付けの run にだけ FLOW_ENDING /
+# FLOW_ENDING_PHASE / FLOW_ENDING_OUTCOME が付く（他の run には付かない）。空で来たら
+# 配管が通っていないので、黙って片付いたことにせず非 0 で落とす — そこを NoAnswer に
+# したいのではなく、機構の穴として見えるようにしたい。
+#
+# phase: Finally は framework が許す唯一の予約名の使い方。spec.phase は「この handler は
+# 何のためのものか」を言うフィールドで、flow 側の束縛とは照合されない（ADR-0006 決定4）。
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskHandler
+metadata:
+  name: smoke-cleanup
+  namespace: claude-code
+spec:
+  phase: Finally
+  runner:
+    type: Job
+  timeout: 2m
+  maxInfraRetries: 1
+  workspace:
+    volume: workspace
+    mountPath: /workspace
+  jobTemplate:
+    template:
+      metadata:
+        labels:
+          taskflow-smoke: "true"
+      spec:
+        restartPolicy: Never
+        serviceAccountName: taskflow-smoke
+        automountServiceAccountToken: false
+        securityContext:
+          runAsUser: 65533
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumes:
+          - name: workspace
+            emptyDir: {}
+        containers:
+          - name: handler
+            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:0b658d03cee98b3118622d47d07950b5dc5dd8ef73689bab68ff28c00299f296
+            command: [sh, -c]
+            args:
+              - |
+                set -eu
+                # この run が何か（Finally）と、追いかけている終端が何だったか。
+                echo "FLOW_PHASE=$FLOW_PHASE"
+                echo "FLOW_ENDING=${FLOW_ENDING:-}"
+                echo "FLOW_ENDING_PHASE=${FLOW_ENDING_PHASE:-}"
+                echo "FLOW_ENDING_OUTCOME=${FLOW_ENDING_OUTCOME:-}"
+                echo "FLOW_DIRECTORIES=$FLOW_DIRECTORIES"
+                # 終端の意味とフェーズ名は必ず来る。outcome だけは空があり得る
+                # （run が一度も決着せずに Failed に着いた場合。この flow では来ない）。
+                if [ -z "${FLOW_ENDING:-}" ] || [ -z "${FLOW_ENDING_PHASE:-}" ]; then
+                  echo "the cleanup run was not told which ending it follows"; exit 1
+                fi
+                ls -ld /workspace /workspace/*
+                # 語彙は spec.finally.done の 1 つだけ。ok は無い（この run の語彙ではない）。
+                if [ -d /workspace/ok ]; then echo "the cleanup run was given the phase vocabulary"; exit 1; fi
+                echo "cleaned $(date -u +%FT%TZ) after $FLOW_ENDING_PHASE ($FLOW_ENDING)" > /workspace/cleaned/report.md
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+            volumeMounts:
+              - name: workspace
+                mountPath: /workspace
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+---
 apiVersion: flow.tgy.io/v1alpha1
 kind: TaskFlow
 metadata:
@@ -95,4 +178,10 @@ spec:
         完了: ok
   terminals:
     完了: Success
+  # 終端の後に 1 回だけ走る（ADR-0009）。ディレクトリは 1 つ — 遷移が無いので選ぶものが無く、
+  # framework が知りたいのは「片付いたと言ったか」の 1 ビットだけ。名前をフェーズ側の ok と
+  # 変えてあるのは、片付けの語彙が spec.finally.done から来ていることを見えるようにするため。
+  finally:
+    handler: smoke-cleanup
+    done: cleaned
   reworkBudget: 0


### PR DESCRIPTION
taskflow #124（ADR-0009 の実装）を本番に載せ、smoke flow で一周させます。

## 変更

- **`kustomize/taskflow`**: remote base の `?ref=` をマージコミット `5ad396f` へ、controller と agent-sidecar の digest をその commit から焼かれた 2 つへ。この kustomization が要求する「ref と digest を人が揃えて上げる」をそのまま
- **`.github/schemas/flow.tgy.io/`**: 同じ commit の CRD から再生成（`scripts/crd2schema.py`）。`taskflows` に `finally` が生えたので、これを忘れると kubeconform の `-strict` が古いスキーマで manifests を通す
- **`manifests/claude-code/taskflow-smoke.yaml`**: cleanup handler（`smoke-cleanup`）を足し、flow に `finally: {handler: smoke-cleanup, done: cleaned}` を宣言

## smoke に足した理由と、確かめること

**片付ける物はありません。** これは「終端が確定した後にもう 1 回 run が立ち、終端はそれで動かない」という機構のスモークで、実際に外の物を消す flow（PR のコメント、ブランチ、投稿）のための配管を先に通すものです。LLM も Kata も通信も無く数秒で終わるので、機構だけを切り出して見られます。

期待する観測:
- Task は `完了`（Success）に着く。**その後** cleanup の run が 1 回だけ立つ
- `history` が 2 行になる（`確認/1/ok/Declared` と `Finally/2/cleaned/Declared`）。`status.phase` は `完了` のまま動かない
- `expiresAt` は終端到達では焼かれず、cleanup が決着した瞬間に焼かれる

**handler が受け取る 3 値も実証します。** cleanup の run にだけ `FLOW_ENDING` / `FLOW_ENDING_PHASE` / `FLOW_ENDING_OUTCOME` が付きます。空で来たら配管の穴なので、黙って片付いたことにせず非 0 で落とします。ディレクトリ名をフェーズ側の `ok` と変えて `cleaned` にしたのは、片付けの語彙が `spec.finally.done` から来ていることを見えるようにするためです。

## 安全側の確認

- 専用ラベル `taskflow-smoke` に CNP を書かない = `policyEnforcementMode: always` で全遮断（既存の smoke handler と同じ）
- restricted PSA 準拠（`runAsNonRoot` / `allowPrivilegeEscalation: false` / `seccompProfile` / `drop: [ALL]` / `readOnlyRootFilesystem`）、SA token は automount しない、cpu limit は付けない
- `kubeconform -strict` を再生成後のスキーマで通してあります（4 resources valid）

反映後に Task を 1 本投げて、上の観測を `/dev-watch` で見届けます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQY4XjZbEmyukk7k9Rnxn3
