### PR TITLE
Let the controller say its endings before they happen

### DIFF
--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -39,7 +39,7 @@ kind: Kustomization
 # 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
 # enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=5ad396f0d090dae80fd6801fa9ffeb7e94c9ce79
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=ef9854a85710b047f4f5263be0d0185ce6c0dc45
 
 # newTag と digest を分けて併記すると、Renovate の kustomize manager が
 # invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
@@ -49,7 +49,7 @@ resources:
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest@sha256:a6739157a66acee607ed0f03437d39f32c42fb050e8c0519df789934197d7ae0
+    newTag: latest@sha256:2d7148f1ad6f4e388cb10d7c2379ccb46e68d52a7fb0305789712e12ce2c6852
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
@@ -88,7 +88,7 @@ patches:
               - name: manager
                 env:
                   - name: SIDECAR_IMAGE
-                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:0bd0cf148bf4e7253d5e7e8e75abed841562e80889815642e616742ab6b1323e
+                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:b8d1ddf5b3ed7a963f53383bf6a23272ded484d9e7d46f66c3bac3b897a9a5fb
 
   # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。taskflow 側は caBundle を
   # 持たない ValidatingWebhookConfiguration を配るだけなので、埋めるのはこちら —


### PR DESCRIPTION
taskflow `ef9854a`（Tsuguya-HC/taskflow#126）を本番へ。**このクラスタで実際に鳴らなかった alert を鳴るようにする**変更。

## なぜ

`manifests/monitoring/prometheusrule-taskflow.yaml` の 2 本は、`taskflow_task_outcomes_total` の counter が「最初の `Inc()` で値 1 として生まれる」ため、**実際に該当する終端が起きた 2 回とも鳴っていなかった**（本番 Prometheus で実測。14 日間 ALERTS 発火ゼロ）:

| 実際に起きたこと | counter | `increase(...[5m])` | ALERTS |
|---|---|---|---|
| `pr-review` が `要修正`（Failure）に着いた（8/30 08:52） | 値 **1** で出現、pod の寿命まで 1 のまま | **結果系列すら返らない** | 発火ゼロ |
| `smoke-workspace` が `Escalated` に着いた | 同じく値 **1** で出現 | 同上 | 発火ゼロ |

`up{namespace="taskflow-system"}` は両 replica とも 1 で、ServiceMonitor / CNP / ClusterRoleBinding / Alertmanager ルートはすべて正しかった。**配線は全部合っていて、声だけが出ていなかった。**

`cnp-check` の Success だけは日次 cron で 1→2→3 と増えるので `increase()` が効く。効かないのは「その pod 世代で初めて起きた終端」だけ — つまり **珍しい異常ほど鳴らない**。design.md §9 が「人間が見るべき瞬間」と定義した `Failure` と `Escalated` は、その定義上いつもこの条件に当たる。

## この PR で何が変わるか

**alert 式は 1 文字も変えない。** 直したのは提供側（コントローラ）で、宣言された終端を起きる前から 0 で報告するようにした。counter は「すでに scrape されている系列の上で上がる」ようになる。

`promtool test rules` に現行の PrometheusRule をそのまま与えて検証済み:

| 入力系列 | 結果 |
|---|---|
| `_x20 1+0x40`（修正前の姿） | **鳴らない** |
| `0+0x20 1+0x40`（修正後） | **発火**し、5 分窓を抜けて resolve |
| rollout で旧 pod の 1 が消え新 pod が 0 で出現 | 誤発火しない |
| 交代後の新 pod で初めて `0 → 1` | 鳴る |

3 行目が重要で、「0 初期化すると rollout のたびに鳴るのでは」という懸念は起きない。

## 3 つの成果物を揃えた

このファイル冒頭の規約どおり、remote base の `?ref=`・controller image・agent-sidecar image を**同じ commit `ef9854a` に揃えて**上げている（#687 の検証対象）。

**CRD と RBAC はこの commit で不変**（`config/` と `api/` は `5ad396f` に対して差分ゼロ。`*_types.go` を触っていない）。したがって `.github/schemas/flow.tgy.io/*.json` のミラーは現行のままで正しく、**意図的に再生成していない**。

## 検証

- `kubectl kustomize kustomize/taskflow` が通り、24 docs をレンダリング
- レンダリング結果に新 digest 2 つ（`2d7148f1ad6f` = controller、`b8d1ddf5b3ed` = agent-sidecar）が乗っていることを確認
- `kubeconform -strict`: 22 valid / 0 invalid / 3 skipped

## 反映後に見ること

`Failure` / `Escalated` が次に起きたときに Discord へ実際に声が出るか。今回の主題が「鳴っていなかった」ことなので、**リソースが作られたことではなく、声が出ることが完了条件**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQY4XjZbEmyukk7k9Rnxn3
