### PR TITLE
Take the runner that reads state, and smoke it (taskflow ADR-0011)

### DIFF
--- a/.github/schemas/flow.tgy.io/task_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/task_v1alpha1.json
@@ -105,7 +105,7 @@
        "type": "integer"
       },
       "jobName": {
-       "description": "JobName is derived deterministically from the task, phase, runID and\nthe count of infrastructure retries, so a controller restart re-creates\nthe same object instead of a second one.",
+       "description": "JobName is derived deterministically from the task, phase, runID and\nthe count of infrastructure retries, so a controller restart re-creates\nthe same object instead of a second one.\n\nEmpty for a run the framework does not start; verdictBox below is what\nsuch a run has instead, and exactly one of the two is set once an\nattempt is under way. Which one says how this run is being driven, and\nthe controller reads it from here rather than from the handler: an\nattempt already in flight is not re-decided by a definition edited\nunderneath it (ADR-0007).\n\n\"Once an attempt\" rather than \"once a run\" on purpose: an infrastructure\nretry (taskstate.RetryInfra) rebuilds this ref with neither field set,\nso the run it carries goes back to having both empty until the next\nreconcile reads the handler again — the same moment ensureJob would\nbuild a fresh Job for it anyway. The invariant is real, but it resets\nat every attempt boundary rather than holding across all of a run's.\n\nThe reset only ever happens to a run with a Job, though: retryInfra is\nreached from driveJobRun's own reading of a Job's pods, and a run with\na verdictBox instead never goes through it — nothing started, so\nnothing can have failed to start. A run being driven by state is fixed\nfor the run's whole life the moment its box is opened; the \"one\nattempt\" this invariant resets at is a distinction that only exists on\nthe Job side.",
        "type": "string"
       },
       "phase": {
@@ -115,6 +115,14 @@
       "runID": {
        "format": "int32",
        "type": "integer"
+      },
+      "verdictBox": {
+       "description": "VerdictBox names the ConfigMap this run's answer appears in, for a run\nthe framework does not start (ADR-0011). Empty for every run that has\na Job.\n\nIt is written down before the object is created, not after. That\nordering is what lets the controller tell its own box from one somebody\nput there first: on the reconcile that first opens a box this field is\nempty, so the create is unconditional and an AlreadyExists means the\nplace was taken before the run began. It is also how whoever is meant\nto answer finds where to write, without being told a naming rule.\n\nThat does not hold on the repair path, where this field is already set\nbut the box it names is not there and this run has never been dated\n(ensureVerdictBox): the create there cannot tell a squatter from its own\nearlier create having landed late, so it is not treated as fencing\nthere — an AlreadyExists is retried, and the next reconcile's Get is\nwhat actually decides whether the box is this run's.\n\nThis is not a pointer to where a run's output went (ADR-0008): the\nframework decided this name, created the object and reads it back. What\nit must not become is a second place to say where results live.",
+       "type": "string"
+      },
+      "verdictBoxUID": {
+       "description": "VerdictBoxUID is the apiserver's own UID for the object VerdictBox\nnames, stamped the moment this run's Create succeeds (ensureVerdictBox)\nand empty until then. The name alone is not enough to say a later Get\nfound the same object: a name can be deleted and recreated, and nothing\nabout the new object need be the same one except its name — least of\nall its ownerReferences, which are free-form metadata their author\nwrote and which IsControlledBy alone cannot tell forged from genuine.\nThis UID is different: the apiserver assigns it, once, to the object\nthis run's own Create actually made, and no later Create under the same\nname can produce it again. Once it is stamped, a Get returning an\nobject with a different UID is refused (ensureVerdictBox) whatever its\nownerReferences claim — IsControlledBy still runs, and is still what\ndecides the one window before this is stamped: the moment right after a\nCreate whose response this process never saw.",
+       "type": "string"
       }
      },
      "required": [
@@ -131,7 +139,6 @@
     },
     "history": {
      "items": {
-      "description": "HistoryEntry records a completed run. This is the audit trail, and it is\nthe whole of what the framework knows: what the run decided and why. Where\nthe run's output ended up is not here, because the controller never learns\nit — it does not touch the workspace or any store (ADR-0008).",
       "properties": {
        "directory": {
         "description": "Directory the handler wrote into, empty when the run produced no single\nanswer.",
@@ -150,13 +157,21 @@
         "type": "string"
        },
        "reason": {
-        "description": "Reason is the one line a human reads next to Outcome: which edge was\nfollowed, or why no answer counted, or what the handler said after\nnaming its directory. The transition never reads it.",
+        "description": "Reason is the one line a human reads next to Outcome: which edge was\nfollowed, or why no answer counted, or what the handler said after\nnaming its directory. The transition never reads it.\nKept in sync with HistoryReasonMaxLength above.",
         "maxLength": 2048,
         "type": "string"
        },
        "runID": {
         "format": "int32",
         "type": "integer"
+       },
+       "runner": {
+        "description": "Runner is how the run was driven. It is here, and not only on the\nhandler, because a run the framework did not start seals nothing: the\nnext run that has a pod lays its directory on the shelf instead\n(ADR-0011 決定7), and by then the handler may say something else or be\ngone. It is also the honest answer to what a human reads this line\nfor — whether anything ran at all.\n\nEmpty reads as Job — but not because Job was ever the only kind a run\ncould have had before this field existed: ADR-0011 決定2〜6 already let\na build drive and settle a State run before 決定7 added this field, so\na task that reached settle in that window has a history line that is\nempty for a run that never had a pod, and reading it as Job is wrong\nfor exactly that line. There is no fixing it after the fact — the\nhandler bound to that phase may have changed since, or be gone — so\nshelfHoles simply does not shelve that run's answer: its number is a\ngap 決定7 cannot close.",
+        "enum": [
+         "Job",
+         "State"
+        ],
+        "type": "string"
        }
       },
       "required": [

--- a/.github/schemas/flow.tgy.io/taskhandler_v1alpha1.json
+++ b/.github/schemas/flow.tgy.io/taskhandler_v1alpha1.json
@@ -13,10 +13,10 @@
    "type": "object"
   },
   "spec": {
-   "description": "TaskHandlerSpec is the box that fills one phase.\n\nThere is no field here for a prompt, a model, an API key, a store or a\nnotification target, and that absence is the design: the controller's\nvocabulary is phases, Jobs and verdicts, and everything an LLM needs lives\nin the pod spec its author writes. The same shape therefore accepts a\nlinter, a test suite or a shell script — from the controller's side there is\nno difference between those and an agent.",
+   "description": "TaskHandlerSpec is the box that fills one phase.\n\nThere is no field here for a prompt, a model, an API key, a store or a\nnotification target, and that absence is the design: the controller's\nvocabulary is phases, Jobs and verdicts, and everything an LLM needs lives\nin the pod spec its author writes. The same shape therefore accepts a\nlinter, a test suite or a shell script — from the controller's side there is\nno difference between those and an agent.\n\nThe two CEL rules are what runner.type means for the rest of the spec, said\nwhere it is written rather than discovered when a run starts: a State run\nneeds a deadline it cannot get from anywhere else, and it has no pod, so the\nthree fields that only describe one are refused rather than accepted and\nnever read (ADR-0011 決定6).",
    "properties": {
     "jobTemplate": {
-     "description": "JobTemplate is handed to the runner as written. The controller does not\nadd labels, service accounts or images to it: what a pod must carry to\nbe selected by a network policy is a property of the cluster it runs in,\nnot something a framework may decide. What the framework provides is one\nplace to say it — a pod template as CronJob users know it, but with only\ntemplate and no job-level spec (no backoffLimit, no completions, no\nparallelism) — rather than the two locations with differing semantics\nthat a workflow engine's own template would ask for.\n\nRequired when runner.type is Job; ignored when it is External.",
+     "description": "JobTemplate is handed to the runner as written. The controller does not\nadd labels, service accounts or images to it: what a pod must carry to\nbe selected by a network policy is a property of the cluster it runs in,\nnot something a framework may decide. What the framework provides is one\nplace to say it — a pod template as CronJob users know it, but with only\ntemplate and no job-level spec (no backoffLimit, no completions, no\nparallelism) — rather than the two locations with differing semantics\nthat a workflow engine's own template would ask for.\n\nRequired when runner.type is Job, and refused when it is State: a run\nnothing starts has no pod for this to describe.",
      "properties": {
       "template": {
        "description": "PodTemplate is the pod a run consists of.",
@@ -7136,7 +7136,7 @@
      "additionalProperties": false
     },
     "maxInfraRetries": {
-     "description": "MaxInfraRetries bounds retries for failures that are not the handler's\njudgement — an image that would not pull, an evicted pod. A handler that\nran and reached no conclusion is not retried here; it is indeterminate,\nand indeterminate goes to a human.",
+     "description": "MaxInfraRetries bounds retries for failures that are not the handler's\njudgement — an image that would not pull, an evicted pod. A handler that\nran and reached no conclusion is not retried here; it is indeterminate,\nand indeterminate goes to a human.\n\nRefused for a State runner rather than ignored there: nothing is\nstarted, so there is no infrastructure to fail and nothing an\nallowance could ever be spent on. A field that is read by nothing but\naccepted anyway is the shape of every setting that turns out not to\nhave been in effect.",
      "format": "int32",
      "minimum": 0,
      "type": "integer"
@@ -7156,7 +7156,7 @@
        "description": "RunnerType selects how a phase is executed.\n\nA workflow engine is deliberately absent. Multi-step work fits in one pod\nwith shared volumes, so an engine-backed runner would buy only the reuse of\ndefinitions already written for it — not worth the dependency, and a single\npod structurally avoids the class of trap where a volume the steps are meant\nto share turns out to be scoped to one pod.",
        "enum": [
         "Job",
-        "External"
+        "State"
        ],
        "type": "string"
       }
@@ -7168,11 +7168,11 @@
      "additionalProperties": false
     },
     "timeout": {
-     "description": "Timeout is the single source of truth for how long a run may take. The\ncontroller writes it into the Job as well, so the kubelet enforces it\ntoo; setting activeDeadlineSeconds yourself is rejected.",
+     "description": "Timeout is the single source of truth for how long a run may take. The\ncontroller writes it into the Job as well, so the kubelet enforces it\ntoo; setting activeDeadlineSeconds yourself is rejected.\n\nA State runner must declare one (the CEL rule on this spec). Nothing\nis started, so there is no Job to carry the deadline and nothing else\nthat ends the wait: without a timeout, a run nobody ever answers is\nindistinguishable from one still being considered, and a task that\nnever stops reaches neither its TTL nor the metric that counts how\nflows end.",
      "type": "string"
     },
     "workspace": {
-     "description": "Workspace is where the controller's own containers find the run's\ndirectories. The template does not name those containers — they are\nadded when the Job is built, with the framework's image, and a\ntemplate that carries a container under one of their names is\nrefused rather than merged.\n\nRequired when runner.type is Job; ignored when it is External.",
+     "description": "Workspace is where the controller's own containers find the run's\ndirectories. The template does not name those containers — they are\nadded when the Job is built, with the framework's image, and a\ntemplate that carries a container under one of their names is\nrefused rather than merged.\n\nRequired when runner.type is Job, and refused when it is State: there\nare no containers of the controller's to fit into a run that starts\nnone.",
      "properties": {
       "mountPath": {
        "description": "MountPath is where the injected containers mount that volume. The\nhandler's own containers are free to mount the same volume at any\npath — it is the same underlying volume either way — as long as at\nleast one of them mounts it writably. Every such mount that names no\nsubPath of its own shows this run's directory at its root: the\ndeclared directories, directly under the mount point, and nothing\nelse. Their names are what the contract shares, not the path they are\nreached through.",

--- a/kustomize/taskflow/kustomization.yaml
+++ b/kustomize/taskflow/kustomization.yaml
@@ -39,7 +39,7 @@ kind: Kustomization
 # 実測していない。この不確実性に賭けず、renovate.jsonc の packageRules で明示的に
 # enabled: false にして止めている。
 resources:
-  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=ef9854a85710b047f4f5263be0d0185ce6c0dc45
+  - https://github.com/Tsuguya-HC/taskflow//config/default?ref=5ad7ad47dd79ae15af4e6f712ee2228d60df45f3
 
 # newTag と digest を分けて併記すると、Renovate の kustomize manager が
 # invalid-dependency-specification で抽出を捨て、digest が自動更新されなくなる
@@ -49,7 +49,7 @@ resources:
 images:
   - name: controller
     newName: registry.infra.tgy.io/tools/taskflow
-    newTag: latest@sha256:2d7148f1ad6f4e388cb10d7c2379ccb46e68d52a7fb0305789712e12ce2c6852
+    newTag: latest@sha256:8447f65cf44b2791058cfbd5bff8e0dd91c356a3953ed8dd16c1b9ffa40f5a7b
 
 patches:
   # 全 namespace restricted 運用に合わせる（config/default の Namespace にはラベルが無い）
@@ -88,7 +88,7 @@ patches:
               - name: manager
                 env:
                   - name: SIDECAR_IMAGE
-                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:b8d1ddf5b3ed7a963f53383bf6a23272ded484d9e7d46f66c3bac3b897a9a5fb
+                    value: registry.infra.tgy.io/tools/agent-sidecar:latest@sha256:516735061dc2d7077e10613ba53967e7e75b3841c5d9d6e62e549803d617f686
 
   # TaskFlow の構造検査 webhook（taskflow #17 / ADR-0006）。taskflow 側は caBundle を
   # 持たない ValidatingWebhookConfiguration を配るだけなので、埋めるのはこちら —

--- a/manifests/claude-code/taskflow-smoke-state.yaml
+++ b/manifests/claude-code/taskflow-smoke-state.yaml
@@ -1,0 +1,158 @@
+# framework が起こさない run（runner: State、taskflow ADR-0011）の配管を通すスモーク flow。
+# Pod も LLM も要らないフェーズが 1 つと、その棚を読む Job フェーズが 1 つ。
+#
+# 確かめていること:
+#   - State のフェーズで **Job が作られない**。代わりにコントローラが答えの置き場（ConfigMap）を
+#     1 つ作り、`status.currentRun.verdictBox` にその名前と `deadline` が載る
+#   - 置き場が空で作られ、注釈に語彙（`flow.tgy.io/choices`）とフェーズ名が乗る。
+#     ラベルは framework 産の 3 つ（managed-by / task-uid / run-id）
+#   - `data.verdict` に宣言ディレクトリ名を書くと遷移する。`data.reason` は history の reason に出る
+#   - **Pod を持たなかった run の棚が、次の run の prepare に空で敷かれる**（ADR-0011 決定7）。
+#     `results/1/ok/` が存在し、中身が空で、run ディレクトリは封印済み（*555）で、
+#     `.prepared-by` が無い（用意した Pod が無いのだから無いのが正しい）
+#   - history に `runner: State` / `runner: Job` が記録される
+#
+# 投げ方（cron は付けない。手動のスモーク）:
+#   kubectl -n claude-code create -f - <<EOF
+#   apiVersion: flow.tgy.io/v1alpha1
+#   kind: Task
+#   metadata: {generateName: smoke-state-, namespace: claude-code}
+#   spec: {flow: smoke-state}
+#   EOF
+#
+# 答え方（誰が書いたかは framework から見えない。書ける権限＝素の RBAC が決める）:
+#   box=$(kubectl -n claude-code get task <name> -o jsonpath='{.status.currentRun.verdictBox}')
+#   kubectl -n claude-code patch configmap "$box" --type merge -p '{"data":{"verdict":"ok","reason":"手で承認"}}'
+#
+# 期待: Task が 完了 (Success)。history は 2 行で、1 行目が `承認/1/ok/Declared` かつ runner: State、
+# 2 行目が `確認/2/ok/Declared` かつ runner: Job。
+---
+# 何も起動しないフェーズ。jobTemplate も workspace も **書けない**（CEL が拒否する） —
+# 起動するものが無いフェーズに Pod の話を書かせない。timeout だけは必須で、
+# 期限の無い待ちは沈黙と区別が付かないから（ADR-0011 決定6）。
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskHandler
+metadata:
+  name: smoke-state-gate
+  namespace: claude-code
+spec:
+  phase: 承認
+  runner:
+    type: State
+  # スモークなので人が答えるのを待てる長さ。超えれば NoAnswer → Escalated。
+  timeout: 30m
+---
+# 直前の State run の棚を読む。手元の run（work/<runID>）とは別に、results/ を読み取り専用で見る。
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskHandler
+metadata:
+  name: smoke-state-checker
+  namespace: claude-code
+spec:
+  phase: 確認
+  runner:
+    type: Job
+  timeout: 3m
+  maxInfraRetries: 1
+  workspace:
+    volume: flow-workspace
+    mountPath: /workspace
+  jobTemplate:
+    template:
+      metadata:
+        labels:
+          # この名前の CNP は無い = 全遮断（policyEnforcementMode: always）。通信は要らない。
+          taskflow-smoke: "true"
+      spec:
+        restartPolicy: Never
+        # 本番の handler と同じランタイム。runc で通っても Kata で通るとは限らない。
+        runtimeClassName: kata
+        # taskflow-smoke.yaml が定義する ServiceAccount を再利用（権限ゼロ）。
+        serviceAccountName: taskflow-smoke
+        automountServiceAccountToken: false
+        securityContext:
+          runAsUser: 65533
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        containers:
+          - name: handler
+            image: registry.infra.tgy.io/tools/argo-tools:latest@sha256:0b658d03cee98b3118622d47d07950b5dc5dd8ef73689bab68ff28c00299f296
+            command: [sh, -c]
+            args:
+              - |
+                set -eu
+                echo "FLOW_DIRECTORIES=$FLOW_DIRECTORIES phase=$FLOW_PHASE"
+                echo "shelf: $(ls /shelf | tr '\n' ' ')"
+                # run 1 は Pod を持たなかった run。その棚を敷いたのは、この run の prepare。
+                test -d /shelf/1 || { echo "run 1 left a hole in the shelf"; exit 1; }
+                # 答えた語だけが並ぶ。中身は空 — Pod が無いのだから書いたものが無い。
+                test -d /shelf/1/ok || { echo "the word run 1 answered is not on the shelf"; exit 1; }
+                if [ -n "$(ls -A /shelf/1/ok)" ]; then
+                  echo "ok/ is not empty: $(ls -A /shelf/1/ok)"
+                  exit 1
+                fi
+                # 封印済みの形は Pod を持った run と同じ（末尾 3 桁だけ見る理由は
+                # taskflow-smoke-workspace.yaml の同じ検査を参照）。
+                mode=$(stat -c %a /shelf/1)
+                case "$mode" in
+                  *555) ;;
+                  *) echo "shelved run 1 is not sealed: mode=$mode (want *555)"; exit 1 ;;
+                esac
+                # 用意した Pod が無いので、Pod の印も無い。
+                if [ -e /shelf/1/.prepared-by ]; then
+                  echo "a run nothing prepared carries a pod's mark"
+                  exit 1
+                fi
+                echo "run 1 is on the shelf, empty and sealed"
+                echo "$FLOW_TASK_UID" > /workspace/ok/report.md
+                # Kata + NFS では書き戻しを残したまま exit するとゲストが落ちる
+                # （taskflow-smoke-workspace.yaml の冒頭を参照）。
+                sync
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+            volumeMounts:
+              # 自分の run（subPath 無し → work/<runID> が焼かれる）
+              - name: flow-workspace
+                mountPath: /workspace
+              # 棚（subPath を明示したので pin されない）
+              - name: flow-workspace
+                mountPath: /shelf
+                subPath: results
+                readOnly: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                # Kata では memory limit が VM のサイズ。16Mi 級だとゲストが起動しない
+                memory: 512Mi
+---
+apiVersion: flow.tgy.io/v1alpha1
+kind: TaskFlow
+metadata:
+  name: smoke-state
+  namespace: claude-code
+spec:
+  profile: investigate
+  # 棚がある = flow workspace がある、なので既定のまま宣言する（{RWX, 1Gi}, default SC）。
+  workspace: {}
+  start: 承認
+  bindings:
+    承認:
+      handler: smoke-state-gate
+      next:
+        確認: ok
+        # 語彙を 2 つにしておく: 置き場の注釈 choices が宣言から生成されることが
+        # 1 つだけだと確かめられない。こちらを書けば人手に渡って止まる。
+        Escalated: hold
+    確認:
+      handler: smoke-state-checker
+      next:
+        完了: ok
+  terminals:
+    完了: Success
+  reworkBudget: 0


### PR DESCRIPTION
taskflow の ADR-0011（`runner: State`）が全決定そろったので、クラスタへ入れる。

## 何を上げたか

- `kustomize/taskflow` の `?ref=` を **5ad7ad4**（taskflow main、決定7 まで入った commit）へ
- controller / agent-sidecar の digest を**同じ commit のビルド**へ（`taskflow-build-gltxw` / `taskflow-sidecar-build-slz9g`、どちらも `commit-sha=5ad7ad4`）
- `.github/schemas/flow.tgy.io/*.json` を同じ commit の CRD から再生成（`task` と `taskhandler` に差分。kustomization の冒頭コメントが要求している手順）

RBAC は remote base から来る。レンダリングで確認済み — manager の ClusterRole に `configmaps: [create, get]` だけが増える（`list` / `watch` は増えない。何も watch しないため）。

## スモーク flow を 1 本足す

`manifests/claude-code/taskflow-smoke-state.yaml`。**Pod を持たないフェーズは、それ自体では何も観測できない**ので、後ろに Pod を持つフェーズを置いて棚を読ませる形にした:

```
承認 (State, timeout 30m)  --ok-->  確認 (Job, workspace)  --ok-->  完了 (Success)
  \--hold--> Escalated
```

`承認` は `runner: {type: State}` と `timeout` だけ。`jobTemplate` も `workspace` も**書けない**（CEL が拒否する）。`確認` は `/shelf/1` を見て、**空・封印済み（*555）・`.prepared-by` 無し**を確かめる — 用意した Pod が無いのだから印も無いのが正しい。

`Escalated: hold` を足してあるのは、置き場の注釈 `flow.tgy.io/choices` が**宣言から生成される**ことを確かめるため（語彙が 1 つだけだと確かめられない）。

## 確認手順

```
kubectl -n claude-code create -f - <<'EOT'
apiVersion: flow.tgy.io/v1alpha1
kind: Task
metadata: {generateName: smoke-state-, namespace: claude-code}
spec: {flow: smoke-state}
EOT

box=$(kubectl -n claude-code get task <name> -o jsonpath='{.status.currentRun.verdictBox}')
kubectl -n claude-code patch configmap "$box" --type merge -p '{"data":{"verdict":"ok","reason":"手で承認"}}'
```

期待: history 2 行（`承認/1/ok/Declared` runner=State、`確認/2/ok/Declared` runner=Job）、`完了 (Success)`。

## 検査

- `kubectl kustomize kustomize/taskflow` でレンダリング通過、イメージと RBAC を実物で確認
- `kubeconform -strict`（CI と同じ schema-location）で新規マニフェスト 3 resource すべて valid
- `/lint` 11 ルール: Critical / Important ともに指摘なし（PSA 準拠・SA token 無効・memory limit あり・CPU limit 無し・機密値なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQY4XjZbEmyukk7k9Rnxn3