### PR TITLE
taskflow: let the parts init container read the App key

### DIFF
--- a/manifests/claude-code/taskflow-pr-review.yaml
+++ b/manifests/claude-code/taskflow-pr-review.yaml
@@ -110,6 +110,14 @@ spec:
         # エージェントは宣言ディレクトリにだけ書ける。
         securityContext:
           runAsUser: 65533
+          # Secret volume のファイルは root 所有で、fsGroup が無いと 0440 でも uid 65533 から
+          # 読めない（初回 run で実測。init の parts が鍵ファイルを読めず exit 1、Task は
+          # Escalated）。runAsGroup + fsGroup を読む側の uid に揃えるのは uid 65532 系の
+          # Argo WFT（implement-wft.yaml 等）の慣行で、Secret を volume で読む taskflow handler
+          # はこれが最初。コントローラが注入するサイドカーも pod の runAsGroup を継承するが、
+          # run ディレクトリの閉じ方は owner uid 基準で gid に依らない（taskflow sidecar.go）。
+          runAsGroup: 65533
+          fsGroup: 65533
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -126,7 +134,7 @@ spec:
           - name: github-app
             secret:
               secretName: github-app-private-key
-              defaultMode: 0400
+              defaultMode: 0440
               items:
                 - key: private-key
                   path: private-key


### PR DESCRIPTION
#867 の初回 run で init `parts` が `parts: no GITHUB_TOKEN and no readable /github-app/private-key` で失敗（Secret volume のファイルは root 所有、fsGroup 無しでは uid 65533 から読めない）。taskflow 側は想定どおり Escalated / Ready=False で声を出した。

- Pod securityContext に `runAsGroup: 65533` / `fsGroup: 65533`、Secret の defaultMode を 0440 に
- uid 65532 系の Argo WFT が既に使う慣行で、Secret を volume で読む taskflow handler ではこれが最初。Kata + fsGroup もこのリポ初適用なので、マージ後に pr-review Task を流して init の成功を最終確認する
- run ディレクトリの閉じ方（ADR-0005）は owner uid 基準で gid に依らないことを taskflow sidecar.go で確認（レビューで実測）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAwFVBFQGNFTxrmiFxY4X