### PR TITLE
taskflow: drop fsGroup from the pr-review handler, open the App key to other

### DIFF
--- a/manifests/claude-code/taskflow-pr-review.yaml
+++ b/manifests/claude-code/taskflow-pr-review.yaml
@@ -110,14 +110,11 @@ spec:
         # エージェントは宣言ディレクトリにだけ書ける。
         securityContext:
           runAsUser: 65533
-          # Secret volume のファイルは root 所有で、fsGroup が無いと 0440 でも uid 65533 から
-          # 読めない（初回 run で実測。init の parts が鍵ファイルを読めず exit 1、Task は
-          # Escalated）。runAsGroup + fsGroup を読む側の uid に揃えるのは uid 65532 系の
-          # Argo WFT（implement-wft.yaml 等）の慣行で、Secret を volume で読む taskflow handler
-          # はこれが最初。コントローラが注入するサイドカーも pod の runAsGroup を継承するが、
-          # run ディレクトリの閉じ方は owner uid 基準で gid に依らない（taskflow sidecar.go）。
-          runAsGroup: 65533
-          fsGroup: 65533
+          # fsGroup は付けない。#869 で runAsGroup + fsGroup 65533 を付けたところ、Kata では
+          # agent の workspace（subPath: work/<runID>）が prepare の敷いた宣言ディレクトリと別の
+          # 空ディレクトリ（root:65533、setgid、mtime が agent 起動時刻）になり、判定を書く先が
+          # 消えて NoAnswer → Escalated になった（2026-09-12 実測、fsGroup 無しの同構造は動く）。
+          # App 鍵は下の Secret volume を 0444 にして init だけに読ませる。
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
@@ -134,7 +131,9 @@ spec:
           - name: github-app
             secret:
               secretName: github-app-private-key
-              defaultMode: 0440
+              # Secret volume のファイルは root 所有。fsGroup を使えない（上）ので other-read で
+              # 読ませる。この volume をマウントするのは init の parts だけで、agent には無い。
+              defaultMode: 0444
               items:
                 - key: private-key
                   path: private-key


### PR DESCRIPTION
#869 の fsGroup を戻す。fsGroup 付きの Kata Pod では、agent の workspace（`subPath: work/<runID>`）が prepare の敷いた宣言ディレクトリとは別の空ディレクトリ（root:65533、setgid、mtime が agent 起動時刻）になり、レビュー自体は完了したのに判定を書く先が無く NoAnswer → Escalated になった（Pod `pr-review-parts-s8nxv-1-…` の prepare / publish / agent ログで実測）。

- securityContext は #867 の形（runAsUser 65533 のみ）に戻す
- App 鍵の Secret volume は `defaultMode: 0444`。マウントするのは init `parts` だけで agent には無い。前例: `manifests/argo/etcd-backup.yaml`, `manifests/argo/upgrade-k8s.yaml`
- Kata + fsGroup + subPath の組み合わせは home-cluster で初めてで、そこで壊れた。taskflow handler には fsGroup を付けない

マージ後に pr-review Task を流して、init の成功と `/workspace/{ok,findings,escalate}` への書き込みを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAwFVBFQGNFTxrmiFxY4X