### PR TITLE
Point the talos-build image references at the org namespace

### DIFF
--- a/.github/workflows/digest-cooldown.yml
+++ b/.github/workflows/digest-cooldown.yml
@@ -44,7 +44,7 @@ jobs:
           # First-party registries: their digests are built and signed by our
           # own pipeline, so the "detect an upstream compromise" premise the
           # cooldown exists for does not apply.
-          skip-registries: registry.infra.tgy.io,ghcr.io/tsuguya
+          skip-registries: registry.infra.tgy.io,ghcr.io/tsuguya-hc
           # Gate tag bumps on our clock too, not just pure digest bumps.
           gate-version-bumps: true
           # The self-hosted Renovate runs as our own GitHub App, so its PRs are

--- a/docs/secureboot.md
+++ b/docs/secureboot.md
@@ -107,14 +107,14 @@ upstream `e4afe22` ("fix: iscsi-tools and multipath-tools", 2026-03-15) で `con
 
 ### 前提
 
-- `ghcr.io/tsuguya/installer:vX.Y.Z` に SecureBoot 署名済み installer が存在
+- `ghcr.io/tsuguya-hc/installer:vX.Y.Z` に SecureBoot 署名済み installer が存在
 - USB に .auth ファイル（PK.auth, KEK.auth, db.auth）をコピー済み
 
 ### 方法 A: UEFI Key Management（TRIGKEY G4 / NiPoGi AK2Plus）
 
 1. **installer アップグレード**
    ```bash
-   talosctl upgrade --image ghcr.io/tsuguya/installer:vX.Y.Z -n <NODE_IP>
+   talosctl upgrade --image ghcr.io/tsuguya-hc/installer:vX.Y.Z -n <NODE_IP>
    ```
 
 2. **UEFI キー登録**（物理アクセス必要）
@@ -137,7 +137,7 @@ UEFI Shell で .auth ファイルを ESP に配置し、systemd-boot の自動�
 
 1. **SecureBoot installer にアップグレード**
    ```bash
-   talosctl upgrade --image ghcr.io/tsuguya/installer:vX.Y.Z -n <NODE_IP>
+   talosctl upgrade --image ghcr.io/tsuguya-hc/installer:vX.Y.Z -n <NODE_IP>
    ```
 
 2. **UEFI 設定変更**（物理アクセス必要）

--- a/manifests/talos-build/scripts.yaml
+++ b/manifests/talos-build/scripts.yaml
@@ -51,7 +51,7 @@ data:
     # imager を使う initContainer だけを名前順に取る。同じファイルに載っている
     # argo-tools や alpine の digest は入らない——そこが「無関係な変更で焼き直さない」の要。
     SEL='[.status.storedWorkflowTemplateSpec.templates[]? | .initContainers[]?
-          | select(.image | test("ghcr\\.io/tsuguya/imager")) | {name, image, args}]
+          | select(.image | test("ghcr\\.io/tsuguya-hc/imager")) | {name, image, args}]
          | sort_by(.name)'
 
     # `--request-timeout` は付けない。**このフラグは kubectl の in-cluster 設定の解決を
@@ -119,7 +119,7 @@ data:
     INSTALLER_TAR=$(find /build -name '*.tar' | head -1)
     echo "=== Pushing SecureBoot installer: ${INSTALLER_TAR} ==="
     crane auth login ghcr.io -u tsuguya -p "${GHCR_TOKEN}"
-    crane push "${INSTALLER_TAR}" "ghcr.io/tsuguya/installer:${VERSION}"
+    crane push "${INSTALLER_TAR}" "ghcr.io/tsuguya-hc/installer:${VERSION}"
     echo "=== Done ==="
 
   push-iso.sh: |

--- a/manifests/talos-build/workflowtemplate.yaml
+++ b/manifests/talos-build/workflowtemplate.yaml
@@ -302,7 +302,7 @@ spec:
               mountPath: /github-token
               readOnly: true
         - name: build
-          image: "ghcr.io/tsuguya/imager:{{inputs.parameters.version}}"
+          image: "ghcr.io/tsuguya-hc/imager:{{inputs.parameters.version}}"
           command: [/bin/imager]
           args:
             - secureboot-installer
@@ -318,7 +318,7 @@ spec:
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
             - ghcr.io/siderolabs/kata-containers:3.32.0@sha256:287e3cee744f3258a98818a5a3370265255d104ecacb4efa0eed38c77de323fa
             - --base-installer-image
-            - "ghcr.io/tsuguya/installer-base:{{inputs.parameters.version}}"
+            - "ghcr.io/tsuguya-hc/installer-base:{{inputs.parameters.version}}"
             - --extra-kernel-arg
             - "-lockdown"
             - --extra-kernel-arg
@@ -440,7 +440,7 @@ spec:
               mountPath: /github-token
               readOnly: true
         - name: build-secureboot-iso
-          image: "ghcr.io/tsuguya/imager:{{inputs.parameters.version}}"
+          image: "ghcr.io/tsuguya-hc/imager:{{inputs.parameters.version}}"
           command: [/bin/imager]
           args:
             - secureboot-iso
@@ -456,7 +456,7 @@ spec:
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
             - ghcr.io/siderolabs/kata-containers:3.32.0@sha256:287e3cee744f3258a98818a5a3370265255d104ecacb4efa0eed38c77de323fa
             - --base-installer-image
-            - "ghcr.io/tsuguya/installer-base:{{inputs.parameters.version}}"
+            - "ghcr.io/tsuguya-hc/installer-base:{{inputs.parameters.version}}"
             - --extra-kernel-arg
             - "-lockdown"
             - --extra-kernel-arg
@@ -482,7 +482,7 @@ spec:
             - name: build-sb-iso
               mountPath: /build-sb-iso
         - name: build-iso
-          image: "ghcr.io/tsuguya/imager:{{inputs.parameters.version}}"
+          image: "ghcr.io/tsuguya-hc/imager:{{inputs.parameters.version}}"
           command: [/bin/imager]
           args:
             - iso
@@ -498,7 +498,7 @@ spec:
             # renovate: datasource=docker depName=ghcr.io/siderolabs/kata-containers
             - ghcr.io/siderolabs/kata-containers:3.32.0@sha256:287e3cee744f3258a98818a5a3370265255d104ecacb4efa0eed38c77de323fa
             - --base-installer-image
-            - "ghcr.io/tsuguya/installer-base:{{inputs.parameters.version}}"
+            - "ghcr.io/tsuguya-hc/installer-base:{{inputs.parameters.version}}"
             - --extra-kernel-arg
             - "-lockdown"
             - --extra-kernel-arg


### PR DESCRIPTION
The org migration moved every repository to `Tsuguya-HC` but left the GHCR packages in the personal namespace `ghcr.io/tsuguya/*`, none of them linked to a repository. An org repository's `GITHUB_TOKEN` has no installation there, so every push from Actions fails with

```
DENIED: permission_denied: The requested installation does not exist.
```

talos-custom-build's weekly check built the v1.14.0 kernel for 1h54m on 2026-09-07 and died on that push, which is why no Talos newer than v1.13.9 exists and why the Kubernetes 1.37 bump in home-infra cannot pass validation.

This is the home-cluster half of moving the packages to `ghcr.io/tsuguya-hc/*`: the imager and installer-base the Argo signing workflow pulls, the installer it pushes, the jq selector in `plan-build.sh` that identifies imager initContainers by image name, the first-party prefix `digest-cooldown` skips (it matches on segment boundaries, so `ghcr.io/tsuguya` does not cover `ghcr.io/tsuguya-hc`), and the upgrade commands in `docs/secureboot.md`.

## Do not merge before the images exist and are public

Verified while preparing this:

- New org packages are created **private**, and `talos-build-executor` carries only `dockerhub-pull-credentials` — no GHCR pull secret. The image pull is at kubelet level, so the in-container `DOCKER_CONFIG` does not help.
- Merging triggers a run: the `talos-extension-bump` sensor fires on the ArgoCD `deployed` event for the `talos-build` app. It resolves the version from talos-custom-build's latest release, so it needs that version's imager and installer-base present under the new namespace.
- The in-cluster PAT (`ghcr-pat`, 1Password `github-pat-talos-build`, scopes `repo, write:packages`) can push to `ghcr.io/tsuguya-hc/` — verified with a throwaway image.
- `plan-build.sh` compares against previous runs by imager image name. Existing Succeeded runs carry the old name, so the first run after this lands falls to "no usable previous run" and rebuilds once. That is the script's documented fail-safe direction.

Reviewed by the infra-review-cycle reviewers (security / reliability / rendering / architecture / consistency / general); `kubeconform -strict`, `kubectl apply --dry-run=server` and `scripts/unread-values.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAwFVBFQGNFTxrmiFxY4X