### PR TITLE
Move the RSS images to the org namespace

### DIFF
--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.4@sha256:e75507093de10e122ad3650410282f2cbb0effb6c0f39235645104ebd83a280b
+  image: ghcr.io/tsuguya-hc/home-rss-cleaner:v0.1.5@sha256:d99f636c1946aa849d27104823c236dc6c6b74fed81c8198100c1b1988faa6a2
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.4@sha256:a57933dafaa7294c43cf6f0499d5276e2fb0d21e67a85a84111b657c3d7c2671
+  image: ghcr.io/tsuguya-hc/home-rss-fetcher:v0.1.5@sha256:ed6178ca36b6a2a1a53c3340777015dd35280256c02aeaf60e162947010ca8a0
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-server:v0.1.4@sha256:28b777429e835e562205c5cd217f41d87582a9a91a0ab8843c27a31694a3bf63
+  image: ghcr.io/tsuguya-hc/home-rss-server:v0.1.5@sha256:428195afbf2523778e39a4e9d8ba302222f525898c6735c5045b2fceace4e670
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-ui:v0.1.4@sha256:b795d6d66e16754a8e2cac0ff649cc00031c4e91252897f639a25b9dce95bd77
+  image: ghcr.io/tsuguya-hc/home-rss-ui:v0.1.5@sha256:243d13d77d3fa07738b892748e5f76821455ac3a7fcf45c082a3922709b11562
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:


### PR DESCRIPTION
home-rss now publishes to `ghcr.io/tsuguya-hc/*` (home-rss#128): the packages had stayed under the personal account after the org migration, where an org repository's `GITHUB_TOKEN` has no installation to push through. v0.1.5 is the first release cut into the new namespace, so this points the four SpinApps at it.

v0.1.5 is v0.1.4 plus the 20 commits that had accumulated on main — Renovate dependency bumps (spin-sdk v7, pnpm 12, quick-xml 0.42) and CI fixes. All four services and the test suite are green on it.

No package visibility change is needed here: the SpinApps already pull through the `ghcr-pull` secret in the `rss` namespace, and that credential reads the new private packages — verified by resolving `ghcr.io/tsuguya-hc/home-rss-server:v0.1.5` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAwFVBFQGNFTxrmiFxY4X