### PR TITLE
fix(monitoring): stop KubeContainerWaiting firing on terminal pods

### DIFF
--- a/helm-values/kube-prometheus-stack/values.yaml
+++ b/helm-values/kube-prometheus-stack/values.yaml
@@ -1,3 +1,10 @@
+# KubeContainerWaiting は Failed / Succeeded で決着した Pod の中の「起動されなかった
+# コンテナ」も waiting として数えるので、chart 同梱版を止めて
+# manifests/monitoring/prometheusrule-container-waiting.yaml で置き換えている。
+defaultRules:
+  disabled:
+    KubeContainerWaiting: true
+
 kubeProxy:
   enabled: false
 

--- a/manifests/monitoring/prometheusrule-container-waiting.yaml
+++ b/manifests/monitoring/prometheusrule-container-waiting.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: container-waiting
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: container-waiting
+      rules:
+        # chart 同梱の KubeContainerWaiting の置き換え（values で disabled にしている）。
+        #
+        # init container が失敗した Pod では、メインコンテナは一度も起動されず
+        # waiting / PodInitializing のまま固定される。Pod 自体は Failed で決着して
+        # いるのに、kube_pod_container_status_waiting_reason は 1 を出し続けるので、
+        # 同梱版（CrashLoopBackOff だけ除外）は Pod が GC されるまで鳴り続ける。
+        #
+        # 2026-09-12 に claude-code の taskflow Task 2 件がこの形で発火した。
+        # Task は当日中に NoAnswer で決着していて、Job は設計上 Task の TTL
+        # （7 日）まで残る（taskflow ADR-0004）。同じ 14 日間に trading の
+        # CronJob Pod 3 件も同じ形で 21 時間ずつ発火していた。
+        #
+        # 決着した Pod（Failed / Succeeded）の中のコンテナは「待っている」わけでは
+        # ないので除外する。Task の失敗そのものは taskflow 側の alert が知らせる。
+        - alert: KubeContainerWaiting
+          expr: |
+            kube_pod_container_status_waiting_reason{job="kube-state-metrics", reason!="CrashLoopBackOff"} > 0
+            unless on (namespace, pod)
+            kube_pod_status_phase{job="kube-state-metrics", phase=~"Failed|Succeeded"} == 1
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod container waiting longer than 1 hour"
+            description: "pod/{{ $labels.pod }} in namespace {{ $labels.namespace }} on container {{ $labels.container }} has been in waiting state for longer than 1 hour. (reason: \"{{ $labels.reason }}\")"
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontainerwaiting

--- a/manifests/monitoring/prometheusrule-container-waiting.yaml
+++ b/manifests/monitoring/prometheusrule-container-waiting.yaml
@@ -18,7 +18,7 @@ spec:
         #
         # 2026-09-12 に claude-code の taskflow Task 2 件がこの形で発火した。
         # Task は当日中に NoAnswer で決着していて、Job は設計上 Task の TTL
-        # （7 日）まで残る（taskflow ADR-0004）。同じ 14 日間に trading の
+        # （7 日）まで残る（taskflow design.md §10「掃除」）。同じ 14 日間に trading の
         # CronJob Pod 3 件も同じ形で 21 時間ずつ発火していた。
         #
         # 決着した Pod（Failed / Succeeded）の中のコンテナは「待っている」わけでは


### PR DESCRIPTION
## 何が起きていたか

`KubeContainerWaiting` が claude-code namespace の taskflow Task 2 件に対して 1 時間以上鳴り続けた（2026-09-12 の GitHub App 鍵ローテーション作業中に `parts` init container が失敗したもの）。

- init container が失敗すると main container は一度も起動されず、`waiting / PodInitializing` のまま固定される
- Pod 自体は Failed で決着しているが、`kube_pod_container_status_waiting_reason` は Pod が GC されるまで 1 を出し続ける
- taskflow は設計上 Job を消さず Task の TTL（failed 168h）まで残すので、アラートも 7 日間鳴り続ける
- chart 同梱ルールは `CrashLoopBackOff` しか除外していない。直近 14 日で trading の CronJob Pod 3 件も同じ形で誤発火していた

## 変更

- `helm-values/kube-prometheus-stack/values.yaml`: `defaultRules.disabled.KubeContainerWaiting: true`
- `manifests/monitoring/prometheusrule-container-waiting.yaml`: 同じ `for` / `severity` / annotations で、`phase=~"Failed|Succeeded"` の Pod を `unless` で除外した置き換えルール

Task の失敗そのものは `prometheusrule-taskflow.yaml`、Job の失敗は同梱の `KubeJobFailed` が別途知らせるので、検知経路は減らない。

## 検証

- unread-values: 31 files, no unread keys（`defaultRules.disabled` は chart の `kubernetes-apps.yaml` の分岐と階層一致、control render で復元も確認）
- kubeconform `-strict` Valid、`kubectl apply --dry-run=server` 通過、`release: kube-prometheus-stack` が Prometheus の ruleSelector と一致
- 本番 Prometheus で新式を評価: 決着済み 2 Pod（phase=Failed）が除外され 0 件、Pending のまま止まる Pod（ImagePullBackOff 等）は対象のまま
- /infra-review-cycle 2 ラウンド、Round 2 は 6 名 CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dr2MseNc2wEmoeRGkXqQEe
