### PR TITLE
Move rss-cleaner to v0.1.6 in the org namespace

### DIFF
--- a/manifests/rss/spinapp-cleaner.yaml
+++ b/manifests/rss/spinapp-cleaner.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-cleaner:v0.1.4@sha256:e75507093de10e122ad3650410282f2cbb0effb6c0f39235645104ebd83a280b
+  image: ghcr.io/tsuguya-hc/home-rss-cleaner:v0.1.6@sha256:5a1358b8e4fa82b94965c9bde9aa9d7f411ae854b57ce0d600b1f87e84a1ad50
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:


### PR DESCRIPTION
One service first. v0.1.5 moved all four at once and three of them crashed on arrival — spin-sdk 7 built against a runtime newer than the shim on the nodes (home-rss#129 puts both spin-sdk and the Spin CLI back under that ceiling; v0.1.6 is the first build with them held).

`cleaner` is the service nothing else depends on, so it carries the risk for the other three. The remaining three follow once it has been up long enough to mean something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAwFVBFQGNFTxrmiFxY4X