### PR TITLE
Move the remaining RSS services to v0.1.6

### DIFF
--- a/manifests/rss/spinapp-fetcher.yaml
+++ b/manifests/rss/spinapp-fetcher.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-fetcher:v0.1.4@sha256:a57933dafaa7294c43cf6f0499d5276e2fb0d21e67a85a84111b657c3d7c2671
+  image: ghcr.io/tsuguya-hc/home-rss-fetcher:v0.1.6@sha256:d6ff0e11482c219d6cf2f6cd5b276d545a7831ede6d2f2b292e1fc82554e6d4a
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-server.yaml
+++ b/manifests/rss/spinapp-server.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-server:v0.1.4@sha256:28b777429e835e562205c5cd217f41d87582a9a91a0ab8843c27a31694a3bf63
+  image: ghcr.io/tsuguya-hc/home-rss-server:v0.1.6@sha256:1a73299f39212afae57c512ac916b9db8145f74e658d2187b978026e81dfbb19
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:

--- a/manifests/rss/spinapp-ui.yaml
+++ b/manifests/rss/spinapp-ui.yaml
@@ -9,7 +9,7 @@ metadata:
     # `relation "feeds" does not exist`.
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  image: ghcr.io/tsuguya/home-rss-ui:v0.1.4@sha256:b795d6d66e16754a8e2cac0ff649cc00031c4e91252897f639a25b9dce95bd77
+  image: ghcr.io/tsuguya-hc/home-rss-ui:v0.1.6@sha256:b97c9f62f08b4ea8055a4e41649ce37834ac94c58e014abb5185d8ec20c7739c
   replicas: 1
   executor: containerd-shim-spin
   imagePullSecrets:


### PR DESCRIPTION
Follows #882. `rss-cleaner` has been up on v0.1.6 in the org namespace with no restarts, which is the evidence the other three were missing when v0.1.5 took all four down at once.

v0.1.6 is the first build with spin-sdk and the Spin CLI held under what `containerd-shim-spin` on the nodes actually links (home-rss#129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBAwFVBFQGNFTxrmiFxY4X