### PR TITLE
fix(monitoring): scrape etcd on all three control planes

### DIFF
--- a/helm-values/kube-prometheus-stack/values.yaml
+++ b/helm-values/kube-prometheus-stack/values.yaml
@@ -12,6 +12,7 @@ kubeEtcd:
   endpoints:
     - 192.168.10.230
     - 192.168.10.231
+    - 192.168.10.232
 
 nodeExporter:
   operatingSystems:


### PR DESCRIPTION
## 何が起きていたか

`kubeEtcd.endpoints` が CP 2 台時代（.230 / .231）のまま。2026-08-15 の CP 置換以降は cp-13 (.230) / cp-11 (.231) / cp-12 (.232) の 3 台で etcd も 3 メンバーだが、cp-12 の etcd metrics は一度も scrape されていなかった。

## 変更

`helm-values/kube-prometheus-stack/values.yaml`: `kubeEtcd.endpoints` に 192.168.10.232 を追加（1 行）。

## 検証

- unread-values: no unread keys。`helm template` で Endpoints `kube-prometheus-stack-kube-etcd` に 3 IP、kubeconform `-strict` 117 resources Valid、`kubectl apply --dry-run=server` 通過
- 到達性: Prometheus の egress CNP は `toEntities: host, remote-node` + port 2381 で IP 非依存。cp-12 の etcd は `listen-metrics-urls: http://0.0.0.0:2381`、3 台とも etcd healthy
- etcd のアラート（etcdInsufficientMembers 等）は target 数の相対式なので 2→3 で誤発火しない
- 他の CP IP 列挙箇所（talconfig / node-shutdown-wft / pxe-sync / disaster-recovery）は 3 台済みで漏れなし
- /infra-review-cycle Round 1 で 6 名 CLEAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dr2MseNc2wEmoeRGkXqQEe
