### PR TITLE
Run cnp-check where the sandbox was not what protected it

### DIFF
--- a/manifests/claude-code/cnp-check-cwf.yaml
+++ b/manifests/claude-code/cnp-check-cwf.yaml
@@ -51,20 +51,13 @@ rules:
     resources: [workflowtaskresults]
     verbs: [create, patch]
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: agent-cnp-reader-executor
-  namespace: claude-code
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: agent-executor
-subjects:
-  - kind: ServiceAccount
-    name: agent-cnp-reader
-    namespace: claude-code
----
+# agent-cnp-reader へのこの Role の RoleBinding は無い。かつて Step 0 の cnp-check が
+# Argo Workflow として動いていた頃、agent-cnp-reader コンテナ自身が Argo executor として
+# workflowtaskresults を書く必要があって与えたものだが、taskflow の Job（cnp-planner /
+# cnp-reporter）にはその経路が無い。agent-cnp-reader を ClusterRole 同様の get/list だけの
+# 読み取り専用にするため撤去した（taskflow-cnp-check.yaml が「守っているのは SA の read-only」
+# と主張する前提）。executor 権限が要るのは今も起票側の task-submitter だけ（下）。
+#
 # 起票用。tasks の create しか持たない（handler の SA とは別に切る: 起票する側が
 # 点検する権限を持つ必要はない）。
 apiVersion: v1

--- a/manifests/claude-code/taskflow-cnp-check.yaml
+++ b/manifests/claude-code/taskflow-cnp-check.yaml
@@ -161,7 +161,26 @@ spec:
           taskflow-cnp-check: "true"
       spec:
         restartPolicy: Never
-        runtimeClassName: kata
+        # サンドボックス（RuntimeClass kata）は使わない。この flow が読むのはクラスタ自身の
+        # 状態と、自分が前のフェーズで書いた報告だけで、外から持ってきたコードは実行しない。
+        # ここを守っているのは SA の read-only と CNP であって VM ではない。外のコード
+        # （PR の ref）と外の文章（PR 本文）をプロンプトに取り込む pr-review 側は kata のまま
+        # （taskflow-pr-review.yaml）。read-only の裏付けは ClusterRole agent-cnp-reader の
+        # get/list だけ（cnp-check-cwf.yaml）。旧 Argo Workflow 版が持っていた
+        # workflowtaskresults の create/patch（Argo executor 用）は taskflow の Job では
+        # 経路が無いので撤去済み。
+        #
+        # 手放したもの: SA と CNP が絞るのは「注入が成功した後、エージェントが何に到達できるか」
+        # であって、「注入が成功した後、コンテナが host kernel に対して何ができるか」ではない。
+        # kata が提供していたのは後者（VM 境界）で、runc に落とした以上ここは手放している。
+        # 残る守りは cap drop ALL / non-root / seccomp RuntimeDefault / hostPath・hostNetwork・
+        # hostPID なし、それに上の SA read-only と CNP。
+        #
+        # 外部由来の文字列がこの flow に入る唯一の経路は、この 調査 フェーズが Loki から引く
+        # hubble の POLICY_DENIED（外から来た identity / DNS 名）。ここを突かれても、到達
+        # できるのは上の CNP が開けた範囲（apiserver・Loki・Anthropic API）と SA の read-only
+        # 権限までで、API 越しの被害は読み取りに閉じる。それを、kata + NFS の exit-sync 罠
+        # という実在の故障クラス（taskflow-smoke-workspace.yaml 冒頭）と引き換えに受け入れている。
         serviceAccountName: agent-cnp-reader
         # 既定の 30 秒だと、TERM 後の子プロセス停止待ちと NFS 越しの sync で猶予を食い潰しうる
         # （子の停止時間そのものは未実測。安全側のマージンとして確保）。
@@ -180,8 +199,7 @@ spec:
           - name: parts
             emptyDir: {}
           # parts リポは private。clone 用の installation token を作る App の鍵で、init だけが
-          # マウントする（root 所有なので 0444 で other-read。fsGroup は Kata の subPath と
-          # 相性が悪く使わない — taskflow-pr-review.yaml）。
+          # マウントする（root 所有なので 0444 で other-read なので fsGroup は要らない）。
           - name: github-app
             secret:
               secretName: github-app-private-key
@@ -222,7 +240,7 @@ spec:
                 cpu: 100m
                 memory: 64Mi
               limits:
-                cpu: "1"
+                # cpu limit は置かない（agent コンテナと同じ理由、下記参照）。
                 memory: 256Mi
         containers:
           - name: agent
@@ -256,12 +274,11 @@ spec:
                 wait $pid || true
                 # 判定はディレクトリで出る。ここから先は何もしない（回収は publish サイドカー）。
                 #
-                # sync は Kata + NFS の workspace PVC に要る。書き戻しが残ったままコンテナが
-                # exit すると Kata のゲストエージェントが応答を失い、shim が終了コードを
-                # 取れずに 255 を返す（report.md は落ちているのに Pod は Failed）。
-                # 2026-09-05 に wn-03 / kata-containers 3.30.0 で実測: 書いて即 exit は 5/5 で
-                # 255、sync か 1 秒の待ちを挟むと 0。同じ Pod のサイドカーも巻き添えで 255 に
-                # なるため publish サイドカー側では手当てできない — 書いた本人が flush する。
+                # sync は NFS 越しの workspace PVC への書き戻しを exit 前に確定させる保険。
+                # kata で回していたときは必須だった（書き戻しを残して exit すると Pod 内の
+                # 全コンテナが 255 で落ちる。2026-09-05 に wn-03 で 5/5 実測。この形は kata の
+                # ままの taskflow-pr-review.yaml には今も効く）。runc では publish サイドカーが
+                # 同じ mount を見るので close だけで足りるが、安いので残す。
                 sync
             env:
               - name: HOME
@@ -288,9 +305,10 @@ spec:
                 cpu: 500m
                 memory: 512Mi
               limits:
-                # Kata では limit がそのまま VM のサイズ。cpu limit を書かないと 1 vCPU に
-                # なる（[[image-build-kata-cpu-starvation]] の実測）ので必ず書く。
-                cpu: "2"
+                # cpu limit は置かない — CPU はコンプレッシブルリソースで、limit を設定すると
+                # CFS throttling が発生しレイテンシが悪化する（docs/resource-limits.md）。
+                # kata のときは limit が VM のサイズを決めていたので必須だったが、runc に
+                # 落ちた以上その例外は消える。
                 memory: 4Gi
 ---
 apiVersion: flow.tgy.io/v1alpha1
@@ -315,7 +333,16 @@ spec:
           taskflow-cnp-report: "true"
       spec:
         restartPolicy: Never
-        runtimeClassName: kata
+        # サンドボックス（RuntimeClass kata）は使わない。この flow が読むのはクラスタ自身の
+        # 状態と、自分が前のフェーズで書いた報告だけで、外から持ってきたコードは実行しない。
+        # ここを守っているのは SA の read-only と CNP であって VM ではない。外のコード
+        # （PR の ref）と外の文章（PR 本文）をプロンプトに取り込む pr-review 側は kata のまま
+        # （taskflow-pr-review.yaml）。agent-cnp-reporter は RBAC 自体を持たず
+        # automountServiceAccountToken: false（下）なので、read-only よりさらに絞れている。
+        #
+        # 手放したもの・受け入れた理由は 調査 フェーズと同じ（cnp-planner の同じ箇所）。
+        # この 報告 フェーズは apiserver も Loki も持たないので、外部由来の文字列が入る経路は
+        # 前フェーズが既に書いた報告を読むことだけ。
         serviceAccountName: agent-cnp-reporter
         automountServiceAccountToken: false
         # 既定の 30 秒だと、TERM 後の子プロセス停止待ちと NFS 越しの sync で猶予を食い潰しうる
@@ -333,8 +360,7 @@ spec:
           - name: parts
             emptyDir: {}
           # parts リポは private。clone 用の installation token を作る App の鍵で、init だけが
-          # マウントする（root 所有なので 0444 で other-read。fsGroup は Kata の subPath と
-          # 相性が悪く使わない — taskflow-pr-review.yaml）。
+          # マウントする（root 所有なので 0444 で other-read なので fsGroup は要らない）。
           - name: github-app
             secret:
               secretName: github-app-private-key
@@ -375,7 +401,7 @@ spec:
                 cpu: 100m
                 memory: 64Mi
               limits:
-                cpu: "1"
+                # cpu limit は置かない（agent コンテナと同じ理由、下記参照）。
                 memory: 256Mi
           # 人間への報告のうち 完了（Success）だけをここで扱う（設計 §7 / §9）。SIGTERM で
           # ok/ が非空かどうかを見る。escalate / ambiguous（ok と escalate 両方が非空）/
@@ -472,12 +498,11 @@ spec:
                       exit 143' TERM INT
                 wait $pid || true
                 #
-                # sync は Kata + NFS の workspace PVC に要る。書き戻しが残ったままコンテナが
-                # exit すると Kata のゲストエージェントが応答を失い、shim が終了コードを
-                # 取れずに 255 を返す（report.md は落ちているのに Pod は Failed）。
-                # 2026-09-05 に wn-03 / kata-containers 3.30.0 で実測: 書いて即 exit は 5/5 で
-                # 255、sync か 1 秒の待ちを挟むと 0。同じ Pod のサイドカーも巻き添えで 255 に
-                # なるため publish サイドカー側では手当てできない — 書いた本人が flush する。
+                # sync は NFS 越しの workspace PVC への書き戻しを exit 前に確定させる保険。
+                # kata で回していたときは必須だった（書き戻しを残して exit すると Pod 内の
+                # 全コンテナが 255 で落ちる。2026-09-05 に wn-03 で 5/5 実測。この形は kata の
+                # ままの taskflow-pr-review.yaml には今も効く）。runc では publish サイドカーが
+                # 同じ mount を見るので close だけで足りるが、安いので残す。
                 sync
             env:
               - name: HOME
@@ -511,9 +536,10 @@ spec:
                 cpu: 500m
                 memory: 512Mi
               limits:
-                # Kata では limit がそのまま VM のサイズ。cpu limit を書かないと 1 vCPU に
-                # なる（[[image-build-kata-cpu-starvation]] の実測）ので必ず書く。
-                cpu: "2"
+                # cpu limit は置かない — CPU はコンプレッシブルリソースで、limit を設定すると
+                # CFS throttling が発生しレイテンシが悪化する（docs/resource-limits.md）。
+                # kata のときは limit が VM のサイズを決めていたので必須だったが、runc に
+                # 落ちた以上その例外は消える。
                 memory: 4Gi
 ---
 apiVersion: flow.tgy.io/v1alpha1

--- a/manifests/claude-code/taskflow-pr-review.yaml
+++ b/manifests/claude-code/taskflow-pr-review.yaml
@@ -190,7 +190,9 @@ spec:
                 # 取り込みは決定論の側でやる。エージェントに clone させると「どの ref を
                 # 読んだか」が run ごとに変わり、指摘の再現ができなくなる。
                 ESCALATE=/workspace/escalate
-                # sync は Kata + NFS の workspace PVC に要る（taskflow-cnp-check.yaml の同じ箇所）。
+                # sync は Kata + NFS の workspace PVC に要る（下の agent コンテナと同じ理由）。
+                # cnp-check は runc に落としたのでこの罠を踏まない側になった
+                # （taskflow-cnp-check.yaml、sync は保険で残しているだけ）。
                 give_up() { printf '%s\n' "$1" > "$ESCALATE/report.md"; sync; exit 0; }
 
                 REPO=Tsuguya-HC/taskflow

--- a/manifests/claude-code/taskflow-smoke-workspace.yaml
+++ b/manifests/claude-code/taskflow-smoke-workspace.yaml
@@ -25,8 +25,14 @@
 #   - publish の rename が qnap-nfs 上で成立し、results/<runID> に現れる
 #   - 閉じた 0555 が rename を越えて棚の上でも保たれる（publish が rename のために一度開けて閉じ直す）
 #   - 後続フェーズが subPath: results で「棚」を読める（自分の run ではなく前の run が見える）
-#   - **Kata + NFS の組み合わせで一周する**（本番の handler は runtimeClassName: kata なので、
-#     runc で通っただけでは「本番でも通る」と言えない）
+#   - **Kata + NFS の組み合わせで一周する**（taskflow が支える runtime のうち壊れやすいのは
+#     kata 側なので、runc で通っただけでは通ると言えない）
+#
+# この smoke が守っているのは taskflow 側の配管の保証（PVC 生成・work/<runID> への pin・
+# 0555 封印・publish の rename・subPath: results での棚読み）であって、本番 handler の
+# 模写ではない。Kata を載せているのは、taskflow が支える runtime のうち壊れやすい側で
+# 配管を通すため（下の exit-sync の罠）— 本番のどの handler が kata かとは独立に決まる。
+# 現状の内訳は pr-review が kata、cnp-check が runc（taskflow-cnp-check.yaml）。
 #
 # Kata を載せているのは飾りではない。Kata のゲストは NFS を virtio-fs 越しに見ており、
 # **書き戻しが残ったままコンテナが exit すると、ゲストエージェントが応答を失って shim が
@@ -35,7 +41,8 @@
 # sync か 1 秒の待ちを挟むと 0）。同じ Pod のサイドカーも巻き添えで 255 になるので、
 # framework の publish サイドカーでは手当てできず、**書いた本人が sync する**しかない。
 # 下の 2 つの handler が末尾で sync しているのはそのため。この smoke が runc のままだと
-# この罠は本番の cnp-check で初めて出る。
+# この罠は本番の pr-review で初めて出る（cnp-check は runc に落としたので、この形を
+# 本番で踏むのは pr-review だけ — taskflow-cnp-check.yaml）。
 #
 # 棚のレイアウトは results/<runID>/<宣言ディレクトリ>/report.md。手元の run と同じ形
 # （/workspace/ok/report.md ↔ /shelf/<runID>/ok/report.md）。初版は間に out/ が挟まっていて
@@ -65,7 +72,8 @@ spec:
           taskflow-smoke: "true"
       spec:
         restartPolicy: Never
-        # 本番の handler と同じランタイム。runc で通っても Kata で通るとは限らない（冒頭参照）。
+        # taskflow が支える runtime のうち壊れやすいのは kata 側（下の exit-sync の罠、冒頭参照）。
+        # runc で通っても通るとは限らないので、ここは kata を外さない。
         runtimeClassName: kata
         # taskflow-smoke.yaml が定義する ServiceAccount を再利用（ここでは定義しない）。
         # 権限ゼロ・automountServiceAccountToken: false が一致しているので使い回して問題ない。
@@ -131,7 +139,8 @@ spec:
           taskflow-smoke: "true"
       spec:
         restartPolicy: Never
-        # 本番の handler と同じランタイム。runc で通っても Kata で通るとは限らない（冒頭参照）。
+        # taskflow が支える runtime のうち壊れやすいのは kata 側（下の exit-sync の罠、冒頭参照）。
+        # runc で通っても通るとは限らないので、ここは kata を外さない。
         runtimeClassName: kata
         # taskflow-smoke.yaml が定義する ServiceAccount を再利用（ここでは定義しない）。
         # 権限ゼロ・automountServiceAccountToken: false が一致しているので使い回して問題ない。


### PR DESCRIPTION
cnp-check の 2 フェーズ（cnp-planner / cnp-reporter）から `runtimeClassName: kata` を外す。**pr-review は kata のまま。**

## なぜ

このフェーズが読むのは**クラスタ自身の状態**（`agent-cnp-reader` は get・list のみ）と、**自分が前フェーズで書いた報告**だけで、外から持ってきたコードは実行しない。外部由来の文字列が入る唯一の経路は調査フェーズが Loki から引く hubble の `POLICY_DENIED`（外から来た identity / DNS 名）で、そこを踏まれても API 越しの被害は read-only に閉じる。**ここを守っているのは SA と CNP であって VM 境界ではない。**

一方で kata は実在する故障クラスを持ち込んでいる — 書き戻しを残して exit すると Pod 内の全コンテナが 255 で落ちる（report.md は落ちているのに Failed。2026-09-05 に wn-03 で 5/5 実測）。VM 起動そのものは 2 秒で、払っているのは時間ではなくこの制約。

pr-review は `git fetch refs/pull/N/head` で PR のコードを取り込み、PR 本文をプロンプトに入れる。**そちらが kata の本来の用途**なので触らない。

## レビューで出た、判断の土台の穴

`/infra-review-cycle` 3 ラウンド、採用 6 件。うち 1 件は**この PR の主張そのものが成立していなかった**という指摘:

`agent-cnp-reader` には旧 Argo Workflow 版 cnp-check の名残の RoleBinding が残っていて、`workflowtaskresults` の **create/patch** を持っていた。そのトークンは `--dangerously-skip-permissions` で走る agent コンテナに automount されている。「SA は read-only」が事実ではなかった。

**コメントを実態に合わせるのではなく、RoleBinding を撤去して実態を主張に合わせた。** taskflow の Job は Argo executor として走らないのでこの権限を使う経路は無く、起票側の CronWorkflow は `task-submitter` SA（自前の RoleBinding を持つ）で走る。`Role agent-executor` と `ClusterRole agent-cnp-reader`（get/list）は残置。

## その他の変更

- **`limits.cpu` の削除**（agent / init 両方）。kata では limit が VM のサイズだから必須だったが、runc に落ちた以上 `docs/resource-limits.md:8`「limits.cpu は設定しない（CFS throttling）」の既定に戻る。`limits.memory` は維持
- pr-review / smoke-workspace の**コメントのみ**更新（kata 前提の相互参照が嘘になっていた 3 箇所）

## 検証

- kubeconform: `manifests/` 517 resources, Valid 505, Invalid 0
- `kubectl apply --server-side --dry-run=server --field-manager=argocd-controller` で apiserver のマージ結果を実証: `runtimeClassName` 消失 / `limits.cpu` 4 箇所消失・`limits.memory` 全保持 / **prune 対象は RoleBinding 1 件だけ**
- `agent-cnp-reader` を subject に持つ他の RoleBinding が無いこと、現役の Argo フロー（horenso-verify 等）の executor RBAC を巻き込んでいないことを横断確認

**方法論の注意**: 素の `kubectl apply --dry-run=server` は live object に last-applied annotation が無いため JSON Merge Patch に落ち、**削除したフィールドが残って見える**。ArgoCD は ServerSideApply なので `--server-side --field-manager=argocd-controller` で確認すること。

## マージ後

prune で `agent-cnp-reader-executor` が消えるので、`/dev-watch` で NotFound になることと次の cnp-check が一周することを見届ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQY4XjZbEmyukk7k9Rnxn3