### PR TITLE
Read the admin talosconfig from a service-account-owned 1Password document

### DIFF
--- a/manifests/secrets/argo-talosconfig.yaml
+++ b/manifests/secrets/argo-talosconfig.yaml
@@ -12,10 +12,12 @@ spec:
     name: talosconfig
     creationPolicy: Owner
     deletionPolicy: Retain
-  dataFrom:
-    - extract:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: talosconfig
-        metadataPolicy: None
-        nullBytePolicy: Ignore
+  data:
+    # Admin talosconfig as a 1Password Document owned by the service account, so
+    # home-infra's rotate-ca.sh can replace it after a Talos CA rotation (the older
+    # `talosconfig` Secure Note was user-created and the service account cannot edit it).
+    # Workflows mount the Secret at /etc/talos and read /etc/talos/config.
+    - secretKey: config
+      remoteRef:
+        key: talos-admin-talosconfig
+        property: talosconfig


### PR DESCRIPTION
The Talos API CA was rotated today, which invalidates every talosconfig. home-infra's new `scripts/rotate-ca.sh` stores the rotated config in 1Password, but the service account gets 404 on every edit of the user-created `talosconfig` Secure Note, so the config now lives in the Document `talos-admin-talosconfig` (created and verified writable by the service account). This points the ExternalSecret at it. The Secret keeps its name and the `config` key that etcd-backup / upgrade-k8s / node-shutdown mount at `/etc/talos`.

Until this merges the in-cluster talosconfig is the pre-rotation one and those workflows cannot reach the Talos API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5WpFDkWCGGnUE4vJvKAX8